### PR TITLE
Support custom API address

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:icon="@mipmap/ic_gpt_mobile"
         android:label="@string/app_name"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         tools:targetApi="upside_down_cake">
         <activity
             android:name=".presentation.ui.main.MainActivity"

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/ModelConstants.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/ModelConstants.kt
@@ -5,6 +5,9 @@ object ModelConstants {
     val openaiModels = linkedSetOf("gpt-4o", "gpt-4-turbo", "gpt-4", "gpt-3.5-turbo")
     val anthropicModels = linkedSetOf("claude-3-5-sonnet-20240620", "claude-3-opus-20240229", "claude-3-sonnet-20240229", "claude-3-haiku-20240307")
     val googleModels = linkedSetOf("gemini-1.5-pro-latest", "gemini-1.5-flash-latest", "gemini-1.0-pro")
+    const val OPENAI_API_URL = "https://api.openai.com"
+    const val ANTHROPIC_API_URL = "https://api.anthropic.com"
+    const val GOOGLE_API_URL = "https://generativelanguage.googleapis.com"
 
     const val ANTHROPIC_MAXIMUM_TOKEN = 4096
 
@@ -13,7 +16,5 @@ object ModelConstants {
             "You are familiar with various languages in the world. " +
             "You are to answer my questions precisely. "
 
-    const val ANTHROPIC_PROMPT = "Your task is to answer my questions precisely."
-
-    const val GOOGLE_PROMPT = "Your task is to answer my questions precisely."
+    const val DEFAULT_PROMPT = "Your task is to answer my questions precisely."
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/ModelConstants.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/ModelConstants.kt
@@ -1,5 +1,7 @@
 package dev.chungjungsoo.gptmobile.data
 
+import dev.chungjungsoo.gptmobile.data.model.ApiType
+
 object ModelConstants {
     // LinkedHashSet should be used to guarantee item order
     val openaiModels = linkedSetOf("gpt-4o", "gpt-4-turbo", "gpt-4", "gpt-3.5-turbo")
@@ -8,6 +10,12 @@ object ModelConstants {
     const val OPENAI_API_URL = "https://api.openai.com"
     const val ANTHROPIC_API_URL = "https://api.anthropic.com"
     const val GOOGLE_API_URL = "https://generativelanguage.googleapis.com"
+
+    fun getDefaultAPIUrl(apiType: ApiType) = when (apiType) {
+        ApiType.OPENAI -> OPENAI_API_URL
+        ApiType.ANTHROPIC -> ANTHROPIC_API_URL
+        ApiType.GOOGLE -> GOOGLE_API_URL
+    }
 
     const val ANTHROPIC_MAXIMUM_TOKEN = 4096
 

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/datastore/SettingDataSource.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/datastore/SettingDataSource.kt
@@ -8,6 +8,7 @@ interface SettingDataSource {
     suspend fun updateDynamicTheme(theme: DynamicTheme)
     suspend fun updateThemeMode(themeMode: ThemeMode)
     suspend fun updateStatus(apiType: ApiType, status: Boolean)
+    suspend fun updateAPIUrl(apiType: ApiType, url: String)
     suspend fun updateToken(apiType: ApiType, token: String)
     suspend fun updateModel(apiType: ApiType, model: String)
     suspend fun updateTemperature(apiType: ApiType, temperature: Float)
@@ -16,6 +17,7 @@ interface SettingDataSource {
     suspend fun getDynamicTheme(): DynamicTheme?
     suspend fun getThemeMode(): ThemeMode?
     suspend fun getStatus(apiType: ApiType): Boolean?
+    suspend fun getAPIUrl(apiType: ApiType): String?
     suspend fun getToken(apiType: ApiType): String?
     suspend fun getModel(apiType: ApiType): String?
     suspend fun getTemperature(apiType: ApiType): Float?

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/datastore/SettingDataSourceImpl.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/datastore/SettingDataSourceImpl.kt
@@ -22,6 +22,11 @@ class SettingDataSourceImpl @Inject constructor(
         ApiType.ANTHROPIC to booleanPreferencesKey("anthropic_status"),
         ApiType.GOOGLE to booleanPreferencesKey("google_status")
     )
+    private val apiUrlMap = mapOf(
+        ApiType.OPENAI to stringPreferencesKey("openai_url"),
+        ApiType.ANTHROPIC to stringPreferencesKey("anthropic_url"),
+        ApiType.GOOGLE to stringPreferencesKey("google_url")
+    )
     private val apiTokenMap = mapOf(
         ApiType.OPENAI to stringPreferencesKey("openai_token"),
         ApiType.ANTHROPIC to stringPreferencesKey("anthropic_token"),
@@ -65,6 +70,12 @@ class SettingDataSourceImpl @Inject constructor(
     override suspend fun updateStatus(apiType: ApiType, status: Boolean) {
         dataStore.edit { pref ->
             pref[apiStatusMap[apiType]!!] = status
+        }
+    }
+
+    override suspend fun updateAPIUrl(apiType: ApiType, url: String) {
+        dataStore.edit { pref ->
+            pref[apiUrlMap[apiType]!!] = url
         }
     }
 
@@ -116,6 +127,10 @@ class SettingDataSourceImpl @Inject constructor(
 
     override suspend fun getStatus(apiType: ApiType): Boolean? = dataStore.data.map { pref ->
         pref[apiStatusMap[apiType]!!]
+    }.first()
+
+    override suspend fun getAPIUrl(apiType: ApiType): String? = dataStore.data.map { pref ->
+        pref[apiUrlMap[apiType]!!]
     }.first()
 
     override suspend fun getToken(apiType: ApiType): String? = dataStore.data.map { pref ->

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/dto/Platform.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/dto/Platform.kt
@@ -6,6 +6,7 @@ data class Platform(
     val name: ApiType,
     val selected: Boolean = false,
     val enabled: Boolean = false,
+    val apiUrl: String = "",
     val token: String? = null,
     val model: String? = null,
     val temperature: Float? = null,

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/dto/Platform.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/dto/Platform.kt
@@ -1,12 +1,13 @@
 package dev.chungjungsoo.gptmobile.data.dto
 
+import dev.chungjungsoo.gptmobile.data.ModelConstants.getDefaultAPIUrl
 import dev.chungjungsoo.gptmobile.data.model.ApiType
 
 data class Platform(
     val name: ApiType,
     val selected: Boolean = false,
     val enabled: Boolean = false,
-    val apiUrl: String = "",
+    val apiUrl: String = getDefaultAPIUrl(name),
     val token: String? = null,
     val model: String? = null,
     val temperature: Float? = null,

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/network/AnthropicAPI.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/network/AnthropicAPI.kt
@@ -6,5 +6,6 @@ import kotlinx.coroutines.flow.Flow
 
 interface AnthropicAPI {
     fun setToken(token: String?)
+    fun setAPIUrl(url: String)
     fun streamChatMessage(messageRequest: MessageRequest): Flow<MessageResponseChunk>
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/network/AnthropicAPIImpl.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/network/AnthropicAPIImpl.kt
@@ -1,5 +1,6 @@
 package dev.chungjungsoo.gptmobile.data.network
 
+import dev.chungjungsoo.gptmobile.data.ModelConstants
 import dev.chungjungsoo.gptmobile.data.dto.anthropic.request.MessageRequest
 import dev.chungjungsoo.gptmobile.data.dto.anthropic.response.ErrorDetail
 import dev.chungjungsoo.gptmobile.data.dto.anthropic.response.ErrorResponseChunk
@@ -32,9 +33,14 @@ class AnthropicAPIImpl @Inject constructor(
 ) : AnthropicAPI {
 
     private var token: String? = null
+    private var apiUrl: String = ModelConstants.ANTHROPIC_API_URL
 
     override fun setToken(token: String?) {
         this.token = token
+    }
+
+    override fun setAPIUrl(url: String) {
+        this.apiUrl = url
     }
 
     override fun streamChatMessage(messageRequest: MessageRequest): Flow<MessageResponseChunk> {
@@ -42,7 +48,7 @@ class AnthropicAPIImpl @Inject constructor(
 
         val builder = HttpRequestBuilder().apply {
             method = HttpMethod.Post
-            url("${ANTHROPIC_CHAT_API}/v1/messages")
+            url("$apiUrl/v1/messages")
             contentType(ContentType.Application.Json)
             setBody(body)
             accept(ContentType.Text.EventStream)
@@ -81,7 +87,6 @@ class AnthropicAPIImpl @Inject constructor(
     }
 
     companion object {
-        private const val ANTHROPIC_CHAT_API = "https://api.anthropic.com"
         private const val STREAM_PREFIX = "data:"
         private const val STREAM_END_TOKEN = "event: message_stop"
         private const val API_KEY_HEADER = "x-api-key"

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
@@ -160,7 +160,7 @@ fun ChatScreen(
                                 .horizontalScroll(chatBubbleScrollStates[(key - 1) / 2])
                         ) {
                             Spacer(modifier = Modifier.width(8.dp))
-                            groupedMessages[key]!!.sortedByDescending { it.platformType }.forEach { m ->
+                            groupedMessages[key]!!.sortedBy { it.platformType }.forEach { m ->
                                 m.platformType?.let { apiType ->
                                     OpponentChatBubble(
                                         modifier = Modifier
@@ -200,7 +200,7 @@ fun ChatScreen(
                             .horizontalScroll(chatBubbleScrollStates[(latestMessageIndex + 1) / 2])
                     ) {
                         Spacer(modifier = Modifier.width(8.dp))
-                        chatViewModel.enabledPlatformsInChat.sortedDescending().forEach { apiType ->
+                        chatViewModel.enabledPlatformsInChat.sorted().forEach { apiType ->
                             val message = when (apiType) {
                                 ApiType.OPENAI -> openAIMessage
                                 ApiType.ANTHROPIC -> anthropicMessage

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingDialogs.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingDialogs.kt
@@ -1,6 +1,7 @@
 package dev.chungjungsoo.gptmobile.presentation.ui.setting
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
@@ -27,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import dev.chungjungsoo.gptmobile.R
 import dev.chungjungsoo.gptmobile.data.ModelConstants.anthropicModels
+import dev.chungjungsoo.gptmobile.data.ModelConstants.getDefaultAPIUrl
 import dev.chungjungsoo.gptmobile.data.ModelConstants.googleModels
 import dev.chungjungsoo.gptmobile.data.ModelConstants.openaiModels
 import dev.chungjungsoo.gptmobile.data.model.ApiType
@@ -44,17 +46,25 @@ import kotlin.math.roundToInt
 fun APIUrlDialog(
     dialogState: SettingViewModel.DialogState,
     apiType: ApiType,
+    initialValue: String,
     settingViewModel: SettingViewModel
 ) {
     if (dialogState.isApiUrlDialogOpen) {
         APIUrlDialog(
             apiType = apiType,
-            onDismissRequest = settingViewModel::closeApiUrlDialog
-        ) { apiUrl ->
-            settingViewModel.updateURL(apiType, apiUrl)
-            settingViewModel.savePlatformSettings()
-            settingViewModel.closeApiUrlDialog()
-        }
+            initialValue = initialValue,
+            onDismissRequest = settingViewModel::closeApiUrlDialog,
+            onResetRequest = {
+                settingViewModel.updateURL(apiType, getDefaultAPIUrl(apiType))
+                settingViewModel.savePlatformSettings()
+                settingViewModel.closeApiUrlDialog()
+            },
+            onConfirmRequest = { apiUrl ->
+                settingViewModel.updateURL(apiType, apiUrl)
+                settingViewModel.savePlatformSettings()
+                settingViewModel.closeApiUrlDialog()
+            }
+        )
     }
 }
 
@@ -158,10 +168,12 @@ fun SystemPromptDialog(
 @Composable
 private fun APIUrlDialog(
     apiType: ApiType,
+    initialValue: String,
     onDismissRequest: () -> Unit,
+    onResetRequest: () -> Unit,
     onConfirmRequest: (url: String) -> Unit
 ) {
-    var apiUrl by remember { mutableStateOf("") }
+    var apiUrl by remember { mutableStateOf(initialValue) }
     val configuration = LocalConfiguration.current
 
     AlertDialog(
@@ -174,7 +186,7 @@ private fun APIUrlDialog(
                     .fillMaxWidth()
                     .padding(horizontal = 20.dp, vertical = 16.dp),
                 value = apiUrl,
-                isError = apiUrl.isValidUrl(),
+                isError = apiUrl.isValidUrl().not(),
                 onValueChange = { apiUrl = it },
                 label = {
                     Text(stringResource(R.string.api_url))
@@ -196,10 +208,16 @@ private fun APIUrlDialog(
             }
         },
         dismissButton = {
-            TextButton(
-                onClick = onDismissRequest
-            ) {
-                Text(stringResource(R.string.cancel))
+            Row {
+                TextButton(
+                    modifier = Modifier.padding(end = 8.dp),
+                    onClick = onResetRequest
+                ) {
+                    Text(stringResource(R.string.reset))
+                }
+                TextButton(onClick = onDismissRequest) {
+                    Text(stringResource(R.string.cancel))
+                }
             }
         }
     )

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingDialogs.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingDialogs.kt
@@ -37,7 +37,26 @@ import dev.chungjungsoo.gptmobile.util.generateGoogleModelList
 import dev.chungjungsoo.gptmobile.util.generateOpenAIModelList
 import dev.chungjungsoo.gptmobile.util.getPlatformAPILabelResources
 import dev.chungjungsoo.gptmobile.util.getPlatformHelpLinkResources
+import dev.chungjungsoo.gptmobile.util.isValidUrl
 import kotlin.math.roundToInt
+
+@Composable
+fun APIUrlDialog(
+    dialogState: SettingViewModel.DialogState,
+    apiType: ApiType,
+    settingViewModel: SettingViewModel
+) {
+    if (dialogState.isApiUrlDialogOpen) {
+        APIUrlDialog(
+            apiType = apiType,
+            onDismissRequest = settingViewModel::closeApiUrlDialog
+        ) { apiUrl ->
+            settingViewModel.updateURL(apiType, apiUrl)
+            settingViewModel.savePlatformSettings()
+            settingViewModel.closeApiUrlDialog()
+        }
+    }
+}
 
 @Composable
 fun APIKeyDialog(
@@ -134,6 +153,56 @@ fun SystemPromptDialog(
             settingViewModel.closeSystemPromptDialog()
         }
     }
+}
+
+@Composable
+private fun APIUrlDialog(
+    apiType: ApiType,
+    onDismissRequest: () -> Unit,
+    onConfirmRequest: (url: String) -> Unit
+) {
+    var apiUrl by remember { mutableStateOf("") }
+    val configuration = LocalConfiguration.current
+
+    AlertDialog(
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+        modifier = Modifier.widthIn(max = configuration.screenWidthDp.dp - 40.dp),
+        title = { Text(text = stringResource(R.string.api_url)) },
+        text = {
+            OutlinedTextField(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 16.dp),
+                value = apiUrl,
+                isError = apiUrl.isValidUrl(),
+                onValueChange = { apiUrl = it },
+                label = {
+                    Text(stringResource(R.string.api_url))
+                },
+                supportingText = {
+                    if (apiUrl.isValidUrl().not()) {
+                        Text(text = stringResource(R.string.invalid_api_url))
+                    }
+                }
+            )
+        },
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            TextButton(
+                enabled = apiUrl.isNotBlank() && apiUrl.isValidUrl(),
+                onClick = { onConfirmRequest(apiUrl) }
+            ) {
+                Text(stringResource(R.string.confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismissRequest
+            ) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingScreen.kt
@@ -87,14 +87,29 @@ fun PlatformSettingScreen(
             val topP = platform?.topP
             val systemPrompt = platform?.systemPrompt ?: when (apiType) {
                 ApiType.OPENAI -> ModelConstants.OPENAI_PROMPT
-                ApiType.ANTHROPIC -> ModelConstants.ANTHROPIC_PROMPT
-                ApiType.GOOGLE -> ModelConstants.GOOGLE_PROMPT
+                ApiType.ANTHROPIC -> ModelConstants.DEFAULT_PROMPT
+                ApiType.GOOGLE -> ModelConstants.DEFAULT_PROMPT
             }
 
             PreferenceSwitchWithContainer(
                 title = stringResource(R.string.enable_api),
                 isChecked = enabled
             ) { settingViewModel.toggleAPI(apiType) }
+            SettingItem(
+                modifier = Modifier.height(64.dp),
+                title = stringResource(R.string.api_url),
+                description = "",
+                enabled = enabled,
+                onItemClick = settingViewModel::openApiUrlDialog,
+                showTrailingIcon = false,
+                showLeadingIcon = true,
+                leadingIcon = {
+                    Icon(
+                        ImageVector.vectorResource(id = R.drawable.ic_link),
+                        contentDescription = stringResource(R.string.url_icon)
+                    )
+                }
+            )
             SettingItem(
                 modifier = Modifier.height(64.dp),
                 title = stringResource(R.string.api_key),

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingScreen.kt
@@ -99,7 +99,7 @@ fun PlatformSettingScreen(
                 modifier = Modifier.height(64.dp),
                 title = stringResource(R.string.api_url),
                 description = "",
-                enabled = enabled,
+                enabled = enabled && platform?.name != ApiType.GOOGLE,
                 onItemClick = settingViewModel::openApiUrlDialog,
                 showTrailingIcon = false,
                 showLeadingIcon = true,

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingScreen.kt
@@ -80,6 +80,7 @@ fun PlatformSettingScreen(
                 .verticalScroll(scrollState)
         ) {
             val platform = platformState.firstOrNull { it.name == apiType }
+            val url = platform?.apiUrl ?: ModelConstants.getDefaultAPIUrl(apiType)
             val enabled = platform?.enabled ?: false
             val model = platform?.model
             val token = platform?.token
@@ -98,7 +99,7 @@ fun PlatformSettingScreen(
             SettingItem(
                 modifier = Modifier.height(64.dp),
                 title = stringResource(R.string.api_url),
-                description = "",
+                description = url,
                 enabled = enabled && platform?.name != ApiType.GOOGLE,
                 onItemClick = settingViewModel::openApiUrlDialog,
                 showTrailingIcon = false,
@@ -186,6 +187,7 @@ fun PlatformSettingScreen(
                 }
             )
 
+            APIUrlDialog(dialogState, apiType, url, settingViewModel)
             APIKeyDialog(dialogState, apiType, settingViewModel)
             ModelDialog(dialogState, apiType, model, settingViewModel)
             TemperatureDialog(dialogState, apiType, temperature, settingViewModel)

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/SettingViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/SettingViewModel.kt
@@ -54,6 +54,22 @@ class SettingViewModel @Inject constructor(
         }
     }
 
+    fun updateURL(apiType: ApiType, url: String) {
+        val index = _platformState.value.indexOfFirst { it.name == apiType }
+
+        if (index >= 0) {
+            _platformState.update {
+                it.mapIndexed { i, p ->
+                    if (index == i && url.isNotBlank()) {
+                        p.copy(apiUrl = url)
+                    } else {
+                        p
+                    }
+                }
+            }
+        }
+    }
+
     fun updateToken(apiType: ApiType, token: String) {
         val index = _platformState.value.indexOfFirst { it.name == apiType }
 
@@ -146,6 +162,8 @@ class SettingViewModel @Inject constructor(
 
     fun openThemeDialog() = _dialogState.update { it.copy(isThemeDialogOpen = true) }
 
+    fun openApiUrlDialog() = _dialogState.update { it.copy(isApiUrlDialogOpen = true) }
+
     fun openApiTokenDialog() = _dialogState.update { it.copy(isApiTokenDialogOpen = true) }
 
     fun openApiModelDialog() = _dialogState.update { it.copy(isApiModelDialogOpen = true) }
@@ -157,6 +175,8 @@ class SettingViewModel @Inject constructor(
     fun openSystemPromptDialog() = _dialogState.update { it.copy(isSystemPromptDialogOpen = true) }
 
     fun closeThemeDialog() = _dialogState.update { it.copy(isThemeDialogOpen = false) }
+
+    fun closeApiUrlDialog() = _dialogState.update { it.copy(isApiUrlDialogOpen = false) }
 
     fun closeApiTokenDialog() = _dialogState.update { it.copy(isApiTokenDialogOpen = false) }
 
@@ -177,6 +197,7 @@ class SettingViewModel @Inject constructor(
 
     data class DialogState(
         val isThemeDialogOpen: Boolean = false,
+        val isApiUrlDialogOpen: Boolean = false,
         val isApiTokenDialogOpen: Boolean = false,
         val isApiModelDialogOpen: Boolean = false,
         val isTemperatureDialogOpen: Boolean = false,

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/Strings.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/Strings.kt
@@ -1,0 +1,6 @@
+package dev.chungjungsoo.gptmobile.util
+
+import android.util.Patterns
+import android.webkit.URLUtil
+
+fun String.isValidUrl(): Boolean = URLUtil.isValidUrl(this) && Patterns.WEB_URL.matcher(this).matches()

--- a/app/src/main/res/drawable/ic_link.xml
+++ b/app/src/main/res/drawable/ic_link.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M17,7h-3c-0.55,0 -1,0.45 -1,1s0.45,1 1,1h3c1.65,0 3,1.35 3,3s-1.35,3 -3,3h-3c-0.55,0 -1,0.45 -1,1c0,0.55 0.45,1 1,1h3c2.76,0 5,-2.24 5,-5S19.76,7 17,7zM8,12c0,0.55 0.45,1 1,1h6c0.55,0 1,-0.45 1,-1s-0.45,-1 -1,-1H9C8.45,11 8,11.45 8,12zM10,15H7c-1.65,0 -3,-1.35 -3,-3s1.35,-3 3,-3h3c0.55,0 1,-0.45 1,-1s-0.45,-1 -1,-1H7c-2.76,0 -5,2.24 -5,5s2.24,5 5,5h3c0.55,0 1,-0.45 1,-1C11,15.45 10.55,15 10,15z"/>
+    
+</vector>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -107,4 +107,7 @@
     <string name="github_icon">GitHub 아이콘</string>
     <string name="f_droid_icon">F-Droid 아이콘</string>
     <string name="play_store_icon">Play Store 아이콘</string>
+    <string name="api_url">API 주소</string>
+    <string name="url_icon">주소 아이콘</string>
+    <string name="invalid_api_url">유효한 주소를 입력해 주세요.</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -110,4 +110,5 @@
     <string name="api_url">API 주소</string>
     <string name="url_icon">주소 아이콘</string>
     <string name="invalid_api_url">유효한 주소를 입력해 주세요.</string>
+    <string name="reset">초기화</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,4 +133,7 @@
     <string name="f_droid_link" translatable="false">https://f-droid.org/packages/dev.chungjungsoo.gptmobile/</string>
     <string name="play_store_link" translatable="false">https://play.google.com/store/apps/details?id=dev.chungjungsoo.gptmobile</string>
     <string name="feedback_link" translatable="false">https://github.com/Taewan-P/gpt_mobile/issues/new</string>
+    <string name="api_url">API URL</string>
+    <string name="url_icon">URL Icon</string>
+    <string name="invalid_api_url">Please enter a valid URL.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,4 +136,5 @@
     <string name="api_url">API URL</string>
     <string name="url_icon">URL Icon</string>
     <string name="invalid_api_url">Please enter a valid URL.</string>
+    <string name="reset">Reset</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.0"
+agp = "8.5.2"
 autoLicense = "11.2.2"
 kotlin = "1.9.23"
 coreKtx = "1.13.1"


### PR DESCRIPTION
Resolves #19 

However, Custom URL for Gemini will not be supported at the moment because the URL option for Generative AI library can't be imported ([See Here](https://github.com/google-gemini/generative-ai-android/blob/main/common/src/main/kotlin/com/google/ai/client/generativeai/common/RequestOptions.kt) & [Here](https://github.com/google-gemini/generative-ai-android/blob/main/generativeai/src/main/java/com/google/ai/client/generativeai/type/RequestOptions.kt))

<img width="499" alt="image" src="https://github.com/user-attachments/assets/4180270c-5bfb-4c90-b5d6-e84ac095fc81">
