### PR TITLE
Add GPT-4o mini support

### DIFF
--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/ModelConstants.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/ModelConstants.kt
@@ -4,7 +4,7 @@ import dev.chungjungsoo.gptmobile.data.model.ApiType
 
 object ModelConstants {
     // LinkedHashSet should be used to guarantee item order
-    val openaiModels = linkedSetOf("gpt-4o", "gpt-4-turbo", "gpt-4", "gpt-3.5-turbo")
+    val openaiModels = linkedSetOf("gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-4")
     val anthropicModels = linkedSetOf("claude-3-5-sonnet-20240620", "claude-3-opus-20240229", "claude-3-sonnet-20240229", "claude-3-haiku-20240307")
     val googleModels = linkedSetOf("gemini-1.5-pro-latest", "gemini-1.5-flash-latest", "gemini-1.0-pro")
     val ollamaModels = linkedSetOf<String>()

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/MapStringResources.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/MapStringResources.kt
@@ -44,9 +44,9 @@ fun getPlatformHelpLinkResources(): Map<ApiType, String> = mapOf(
 fun generateOpenAIModelList(models: LinkedHashSet<String>) = models.mapIndexed { index, model ->
     val (name, description) = when (index) {
         0 -> stringResource(R.string.gpt_4o) to stringResource(R.string.gpt_4o_description)
-        1 -> stringResource(R.string.gpt_4_turbo) to stringResource(R.string.gpt_4_turbo_description)
-        2 -> stringResource(R.string.gpt_4) to stringResource(R.string.gpt_4_description)
-        3 -> stringResource(R.string.gpt_3_5_turbo) to stringResource(R.string.gpt_3_5_description)
+        1 -> stringResource(R.string.gpt_4o_mini) to stringResource(R.string.gpt_4o_mini_description)
+        2 -> stringResource(R.string.gpt_4_turbo) to stringResource(R.string.gpt_4_turbo_description)
+        3 -> stringResource(R.string.gpt_4) to stringResource(R.string.gpt_4_description)
         else -> "" to ""
     }
     APIModel(name, description, model)

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -22,6 +22,7 @@
     <string name="select_openai_model">OpenAI 모델 선택</string>
     <string name="select_openai_model_description">OpenAI 채팅 모델을 선택해 주세요. 멀티모달 모델을 선택하더라도, 현재 텍스트 입력만 지원합니다.</string>
     <string name="gpt_4o_description">가장 빠르고 합리적인 가격의 플래그십 모델입니다.</string>
+    <string name="gpt_4o_mini_description">빠르고 가벼운 작업을 위한 경제적이고 지능적인 소형 모델</string>
     <string name="gpt_4_turbo_description">"GPT-4보다 3배 저렴하고 안정성이 뛰어납니다. "</string>
     <string name="gpt_4_description">추상적인 문제 해결에 가장 뛰어납니다.</string>
     <string name="gpt_3_5_description">"간단한 작업을 위한 빠르고 저렴한 모델입니다. "</string>
@@ -115,4 +116,14 @@
     <string name="ollama_setting">Ollama 설정</string>
     <string name="select_ollama_model_description">Ollama 모델을 선택해 주세요. 현재 Ollama에서 지원하는 모델과 태그가 너무 많으므로, 직접 모델 값을 설정할 수도 있습니다. 입력한 Endpoint에서 해당 모델이 실행되고 있는지 꼭 확인해주세요. 실행되고 있지 않은 모델을 입력시, 답변 생성 시에 오류가 발생할 수 있습니다.</string>
     <string name="reset">초기화</string>
+    <string name="custom">사용자 지정</string>
+    <string name="custom_description">직접 모델 값을 설정하세요.</string>
+    <string name="model_name">모델 이름</string>
+    <string name="model_custom_example">예시) llama3.2, llava, llama3:latest, …</string>
+    <string name="custom_model_warning">API가 지원하는 이름을 입력해야 정상 작동합니다.</string>
+    <string name="enter_api_address">API 주소 입력</string>
+    <string name="api_address_description">포트번호를 포함하여 API 주소를 입력하세요. 이 앱은 v1/chat/completions 엔드포인트를 사용하기에, 주소의 앞부분만 입력하세요. 주소는 끝에 \'/\'로 끝나야 합니다. 예시) http://192.168.1.100:11434/</string>
+    <string name="ollama_api_address">Ollama API 주소</string>
+    <string name="ollama_api_key">Ollama API 키</string>
+    <string name="api_url_cautions">URL이 \'/\'로 끝나야 합니다.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,9 +148,9 @@
     <string name="model_custom_example">e.g. llama3.2, llava, llama3:latest, …</string>
     <string name="custom_model_warning">Note that the model name should be supported by the api.</string>
     <string name="enter_api_address">Enter API Address</string>
-    <string name="api_address_description">Please enter the address of your Ollama API including the port number. The app will be using /api/chat endpoint, so please enter only the front part of the full address. The address must end with a \'/\'.</string>
+    <string name="api_address_description">Please enter the address of your Ollama API including the port number. The app will be using v1/chat/completions endpoint, so please enter only the front part of the full address. The address must end with a \'/\'. e.g) http://192.168.1.100:11434/</string>
     <string name="ollama_api_address">Ollama API Address</string>
-    <string name="ollama_api_help">https://github.com/ollama/ollama/blob/main/docs/api.md</string>
+    <string name="ollama_api_help" translatable="false">https://ollama.com/blog/openai-compatibility</string>
     <string name="reset">Reset</string>
     <string name="ollama_api_key">Ollama API Key</string>
     <string name="api_url_cautions">The url must end with a \'/\'.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,13 +27,13 @@
     <string name="select_openai_model">Select OpenAI Chat Model</string>
     <string name="select_openai_model_description">Please select the OpenAI chat model. Even if the selected model is multimodal, the app currently supports text inputs only. May be supported later in the future.</string>
     <string name="gpt_4o" translatable="false">GPT-4o</string>
+    <string name="gpt_4o_mini" translatable="false">GPT-4o mini</string>
     <string name="gpt_4_turbo" translatable="false">GPT-4 Turbo</string>
     <string name="gpt_4" translatable="false">GPT-4</string>
-    <string name="gpt_3_5_turbo" translatable="false">GPT-3.5 Turbo</string>
     <string name="gpt_4o_description">The fastest and most affordable flagship model.</string>
+    <string name="gpt_4o_mini_description">Affordable and intelligent small model for fast, lightweight tasks</string>
     <string name="gpt_4_turbo_description">Decent reliability, 3x cheaper than GPT-4.</string>
     <string name="gpt_4_description">Performs the best at solving abstract problems.</string>
-    <string name="gpt_3_5_description">A fast, inexpensive model for simple tasks.</string>
     <string name="select_anthropic_model">Select Anthropic Chat Model</string>
     <string name="select_anthropic_model_description">Please select the Anthropic chat model. We currently support the Claude 3 family of models with only text inputs.</string>
     <string name="claude_3_5_sonnet" translatable="false">Claude 3.5 Sonnet</string>


### PR DESCRIPTION
- Resolves #42 

Also deprecates GPT-3.5 Turbo. This model still can be used by using custom models, but should be replaced with 4o mini as it is cheaper, more capable, multimodal, and just as fast.

<img src="https://github.com/user-attachments/assets/1a57a664-166b-4aa9-b35d-3d4e961b7cb2" width="300"/>
