### PR TITLE
Fix latestMessageIndex out of bounds error

### DIFF
--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
@@ -64,6 +64,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import dev.chungjungsoo.gptmobile.R
 import dev.chungjungsoo.gptmobile.data.database.entity.Message
 import dev.chungjungsoo.gptmobile.data.model.ApiType
+import dev.chungjungsoo.gptmobile.util.DefaultHashMap
 import dev.chungjungsoo.gptmobile.util.collectManagedState
 import dev.chungjungsoo.gptmobile.util.multiScrollStateSaver
 import kotlinx.coroutines.delay
@@ -104,20 +105,9 @@ fun ChatScreen(
     val canUseChat = (chatViewModel.enabledPlatformsInChat.toSet() - appEnabledPlatforms.toSet()).isEmpty()
     val groupedMessages = remember(messages) { groupMessages(messages) }
     val latestMessageIndex = groupedMessages.keys.maxOrNull() ?: 0
-    val chatBubbleScrollStates = rememberSaveable(saver = multiScrollStateSaver) { MutableList(latestMessageIndex + 2) { ScrollState(0) } }
+    val chatBubbleScrollStates = rememberSaveable(saver = multiScrollStateSaver) { DefaultHashMap<Int, ScrollState>({ ScrollState(0) }) }
 
     val scope = rememberCoroutineScope()
-
-    LaunchedEffect(latestMessageIndex) {
-        val opponentBubbles = ((latestMessageIndex + 1) / 2) + 1
-        val scrollStatesToAdd = opponentBubbles - chatBubbleScrollStates.size
-
-        if (scrollStatesToAdd > 0) {
-            repeat(scrollStatesToAdd) {
-                chatBubbleScrollStates.add(ScrollState(0))
-            }
-        }
-    }
 
     LaunchedEffect(isIdle) {
         listState.animateScrollToItem(groupedMessages.keys.size)

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/DefaultHashMap.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/DefaultHashMap.kt
@@ -1,0 +1,18 @@
+package dev.chungjungsoo.gptmobile.util
+
+/**
+ Small implementation of HashMap, but with default values.
+ This way the get operator will not throw an error or null.
+ Inspired by Python collections DefaultDict.
+ */
+open class DefaultHashMap<K, V>(protected val defaultValueProvider: () -> V) : HashMap<K, V>() {
+    override operator fun get(key: K): V {
+        if (key in this) {
+            return super.get(key)!!
+        }
+
+        val defaultValue = defaultValueProvider()
+        this[key] = defaultValue
+        return super.get(key)!!
+    }
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/ScrollStateSaver.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/ScrollStateSaver.kt
@@ -3,7 +3,15 @@ package dev.chungjungsoo.gptmobile.util
 import androidx.compose.foundation.ScrollState
 import androidx.compose.runtime.saveable.Saver
 
-val multiScrollStateSaver: Saver<MutableList<ScrollState>, *> = Saver(
-    save = { it.map { scrollState -> scrollState.value } },
-    restore = { it.map { i -> ScrollState(i) }.toMutableList() }
+val multiScrollStateSaver: Saver<DefaultHashMap<Int, ScrollState>, *> = Saver(
+    save = {
+        val saver = hashMapOf<Int, Int>()
+        it.forEach { i, scrollState -> saver[i] = scrollState.value }
+        saver
+    },
+    restore = {
+        val restored = DefaultHashMap<Int, ScrollState>({ ScrollState(0) })
+        it.forEach { i, v -> restored[i] = ScrollState(v) }
+        restored
+    }
 )


### PR DESCRIPTION
- Resolves #72 
- Now, the multi-scroll ScrollStates are saved in custom implemented DefaultHashMap instead of MutableList.
  The DefaultHashMap has default values, so it will not be null and will not throw out of bounds error like Lists.