### PR TITLE
Add new required types for Anthropic API

### DIFF
--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/dto/anthropic/response/Usage.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/dto/anthropic/response/Usage.kt
@@ -9,6 +9,12 @@ data class Usage(
     @SerialName("input_tokens")
     val inputTokens: Int,
 
+    @SerialName("cache_creation_input_tokens")
+    val cacheCreationInputTokens: Int? = null,
+
+    @SerialName("cache_read_input_tokens")
+    val cacheReadInputTokens: Int? = null,
+
     @SerialName("output_tokens")
     val outputTokens: Int
 )

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/network/AnthropicAPIImpl.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/network/AnthropicAPIImpl.kt
@@ -71,12 +71,14 @@ class AnthropicAPIImpl @Inject constructor(
 
     private suspend inline fun <reified T> FlowCollector<T>.streamEventsFrom(response: HttpResponse) {
         val channel: ByteReadChannel = response.body()
+        val jsonInstance = Json { ignoreUnknownKeys = true }
+
         try {
             while (currentCoroutineContext().isActive && !channel.isClosedForRead) {
                 val line = channel.readUTF8Line() ?: continue
                 val value: T = when {
                     line.startsWith(STREAM_END_TOKEN) -> break
-                    line.startsWith(STREAM_PREFIX) -> Json.decodeFromString(line.removePrefix(STREAM_PREFIX))
+                    line.startsWith(STREAM_PREFIX) -> jsonInstance.decodeFromString(line.removePrefix(STREAM_PREFIX))
                     else -> continue
                 }
                 emit(value)


### PR DESCRIPTION
Fix missing types for updated [Anthropic API v0.42.0](https://github.com/anthropics/anthropic-sdk-python/releases/tag/v0.42.0)
```
Encountered an unknown key 'cache_creation_input_tokens' at path: $.message.usage.input_tokens
```