### PR TITLE
Fix retry-after-failure regenerate crash

### DIFF
--- a/app/schemas/dev.chungjungsoo.gptmobile.data.database.ChatDatabaseV2/4.json
+++ b/app/schemas/dev.chungjungsoo.gptmobile.data.database.ChatDatabaseV2/4.json
@@ -1,0 +1,292 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "c096fead26510d5ae0539929a23d6325",
+    "entities": [
+      {
+        "tableName": "chats_v2",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chat_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `enabled_platform` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "chat_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabledPlatform",
+            "columnName": "enabled_platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "chat_id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages_v2",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`message_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `chat_id` INTEGER NOT NULL, `thoughts` TEXT NOT NULL, `content` TEXT NOT NULL, `attachments` TEXT NOT NULL, `revisions` TEXT NOT NULL, `active_revision_index` INTEGER NOT NULL, `linked_message_id` INTEGER NOT NULL, `platform_type` TEXT, `created_at` INTEGER NOT NULL, FOREIGN KEY(`chat_id`) REFERENCES `chats_v2`(`chat_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "message_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chat_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thoughts",
+            "columnName": "thoughts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attachments",
+            "columnName": "attachments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revisions",
+            "columnName": "revisions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeRevisionIndex",
+            "columnName": "active_revision_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkedMessageId",
+            "columnName": "linked_message_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platformType",
+            "columnName": "platform_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "message_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_v2_chat_id",
+            "unique": false,
+            "columnNames": [
+              "chat_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_v2_chat_id` ON `${TABLE_NAME}` (`chat_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chats_v2",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chat_id"
+            ],
+            "referencedColumns": [
+              "chat_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "platform_v2",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`platform_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `uid` TEXT NOT NULL, `name` TEXT NOT NULL, `compatible_type` TEXT NOT NULL, `enabled` INTEGER NOT NULL, `api_url` TEXT NOT NULL, `token` TEXT, `model` TEXT NOT NULL, `temperature` REAL, `top_p` REAL, `system_prompt` TEXT, `stream` INTEGER NOT NULL, `reasoning` INTEGER NOT NULL, `timeout` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "platform_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "compatibleType",
+            "columnName": "compatible_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiUrl",
+            "columnName": "api_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "token",
+            "columnName": "token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "top_p",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "systemPrompt",
+            "columnName": "system_prompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stream",
+            "columnName": "stream",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reasoning",
+            "columnName": "reasoning",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeout",
+            "columnName": "timeout",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "platform_id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_platform_model_v2",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chat_id` INTEGER NOT NULL, `platform_uid` TEXT NOT NULL, `model` TEXT NOT NULL, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`chat_id`, `platform_uid`), FOREIGN KEY(`chat_id`) REFERENCES `chats_v2`(`chat_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "chatId",
+            "columnName": "chat_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platformUid",
+            "columnName": "platform_uid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chat_id",
+            "platform_uid"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "chats_v2",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chat_id"
+            ],
+            "referencedColumns": [
+              "chat_id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c096fead26510d5ae0539929a23d6325')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2.kt
@@ -7,6 +7,7 @@ import dev.chungjungsoo.gptmobile.data.database.dao.ChatPlatformModelV2Dao
 import dev.chungjungsoo.gptmobile.data.database.dao.ChatRoomV2Dao
 import dev.chungjungsoo.gptmobile.data.database.dao.MessageV2Dao
 import dev.chungjungsoo.gptmobile.data.database.dao.PlatformV2Dao
+import dev.chungjungsoo.gptmobile.data.database.entity.AssistantRevisionListConverter
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatAttachmentListConverter
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatPlatformModelV2
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoomV2
@@ -16,10 +17,14 @@ import dev.chungjungsoo.gptmobile.data.database.entity.StringListConverter
 
 @Database(
     entities = [ChatRoomV2::class, MessageV2::class, PlatformV2::class, ChatPlatformModelV2::class],
-    version = 3,
+    version = 4,
     exportSchema = true
 )
-@TypeConverters(StringListConverter::class, ChatAttachmentListConverter::class)
+@TypeConverters(
+    StringListConverter::class,
+    ChatAttachmentListConverter::class,
+    AssistantRevisionListConverter::class
+)
 abstract class ChatDatabaseV2 : RoomDatabase() {
 
     abstract fun platformDao(): PlatformV2Dao

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2Migrations.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2Migrations.kt
@@ -2,6 +2,9 @@ package dev.chungjungsoo.gptmobile.data.database
 
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import dev.chungjungsoo.gptmobile.data.database.entity.ACTIVE_REVISION_LATEST
+import dev.chungjungsoo.gptmobile.data.database.entity.AssistantRevision
+import dev.chungjungsoo.gptmobile.data.database.entity.AssistantRevisionListConverter
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatAttachmentListConverter
 import dev.chungjungsoo.gptmobile.data.model.ChatAttachment
 import java.io.File
@@ -124,6 +127,92 @@ object ChatDatabaseV2Migrations {
         }
     }
 
+    val MIGRATION_3_4 = object : Migration(3, 4) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `messages_v2_new` (
+                    `message_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    `chat_id` INTEGER NOT NULL,
+                    `thoughts` TEXT NOT NULL,
+                    `content` TEXT NOT NULL,
+                    `attachments` TEXT NOT NULL,
+                    `revisions` TEXT NOT NULL,
+                    `active_revision_index` INTEGER NOT NULL,
+                    `linked_message_id` INTEGER NOT NULL,
+                    `platform_type` TEXT,
+                    `created_at` INTEGER NOT NULL,
+                    FOREIGN KEY(`chat_id`) REFERENCES `chats_v2`(`chat_id`) ON UPDATE NO ACTION ON DELETE CASCADE
+                )
+                """.trimIndent()
+            )
+
+            db.query(
+                """
+                SELECT
+                    `message_id`,
+                    `chat_id`,
+                    `thoughts`,
+                    `content`,
+                    `attachments`,
+                    `revisions`,
+                    `linked_message_id`,
+                    `platform_type`,
+                    `created_at`
+                FROM `messages_v2`
+                """.trimIndent()
+            ).use { cursor ->
+                val idIndex = cursor.getColumnIndexOrThrow("message_id")
+                val chatIdIndex = cursor.getColumnIndexOrThrow("chat_id")
+                val thoughtsIndex = cursor.getColumnIndexOrThrow("thoughts")
+                val contentIndex = cursor.getColumnIndexOrThrow("content")
+                val attachmentsIndex = cursor.getColumnIndexOrThrow("attachments")
+                val revisionsIndex = cursor.getColumnIndexOrThrow("revisions")
+                val linkedMessageIdIndex = cursor.getColumnIndexOrThrow("linked_message_id")
+                val platformTypeIndex = cursor.getColumnIndexOrThrow("platform_type")
+                val createdAtIndex = cursor.getColumnIndexOrThrow("created_at")
+
+                while (cursor.moveToNext()) {
+                    db.execSQL(
+                        """
+                        INSERT INTO `messages_v2_new` (
+                            `message_id`,
+                            `chat_id`,
+                            `thoughts`,
+                            `content`,
+                            `attachments`,
+                            `revisions`,
+                            `active_revision_index`,
+                            `linked_message_id`,
+                            `platform_type`,
+                            `created_at`
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """.trimIndent(),
+                        arrayOf(
+                            cursor.getInt(idIndex),
+                            cursor.getInt(chatIdIndex),
+                            cursor.getString(thoughtsIndex) ?: "",
+                            cursor.getString(contentIndex) ?: "",
+                            cursor.getString(attachmentsIndex) ?: "",
+                            legacyRevisionsToStructuredJson(
+                                revisionsValue = cursor.getString(revisionsIndex).orEmpty(),
+                                createdAt = cursor.getLong(createdAtIndex)
+                            ),
+                            ACTIVE_REVISION_LATEST,
+                            cursor.getInt(linkedMessageIdIndex),
+                            cursor.getString(platformTypeIndex),
+                            cursor.getLong(createdAtIndex)
+                        )
+                    )
+                }
+            }
+
+            db.execSQL("DROP TABLE `messages_v2`")
+            db.execSQL("ALTER TABLE `messages_v2_new` RENAME TO `messages_v2`")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_messages_v2_chat_id` ON `messages_v2` (`chat_id`)")
+        }
+    }
+
     internal fun legacyFilesToAttachmentsJson(filesValue: String): String {
         val attachments = filesValue
             .split(",")
@@ -140,5 +229,18 @@ object ChatDatabaseV2Migrations {
             }
 
         return ChatAttachmentListConverter().fromList(attachments)
+    }
+
+    internal fun legacyRevisionsToStructuredJson(
+        revisionsValue: String,
+        createdAt: Long
+    ): String {
+        val revisions = revisionsValue
+            .split(",")
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .map { AssistantRevision(content = it, thoughts = "", createdAt = createdAt) }
+
+        return AssistantRevisionListConverter().fromList(revisions)
     }
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/AssistantRevisionListConverter.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/AssistantRevisionListConverter.kt
@@ -1,0 +1,21 @@
+package dev.chungjungsoo.gptmobile.data.database.entity
+
+import androidx.room.TypeConverter
+import kotlinx.serialization.json.Json
+
+class AssistantRevisionListConverter {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    @TypeConverter
+    fun fromString(value: String): List<AssistantRevision> = if (value.isBlank()) {
+        emptyList()
+    } else {
+        json.decodeFromString(value)
+    }
+
+    @TypeConverter
+    fun fromList(value: List<AssistantRevision>): String = json.encodeToString(value)
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/MessageV2.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/MessageV2.kt
@@ -6,6 +6,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import dev.chungjungsoo.gptmobile.data.model.ChatAttachment
+import kotlinx.serialization.Serializable
 
 @Entity(
     tableName = "messages_v2",
@@ -37,7 +38,10 @@ data class MessageV2(
     val attachments: List<ChatAttachment> = listOf(),
 
     @ColumnInfo(name = "revisions")
-    val revisions: List<String> = listOf(),
+    val revisions: List<AssistantRevision> = listOf(),
+
+    @ColumnInfo(name = "active_revision_index")
+    val activeRevisionIndex: Int = ACTIVE_REVISION_LATEST,
 
     @ColumnInfo(name = "linked_message_id")
     val linkedMessageId: Int = 0,
@@ -48,3 +52,43 @@ data class MessageV2(
     @ColumnInfo(name = "created_at")
     val createdAt: Long = System.currentTimeMillis() / 1000
 )
+
+@Serializable
+data class AssistantRevision(
+    val content: String,
+    val thoughts: String = "",
+    val createdAt: Long
+)
+
+const val ACTIVE_REVISION_LATEST = -1
+
+fun MessageV2.hasHistoricalRevisionSelected(): Boolean = activeRevisionIndex in revisions.indices
+
+fun MessageV2.effectiveContent(): String = revisions
+    .getOrNull(activeRevisionIndex)
+    ?.content
+    ?: content
+
+fun MessageV2.effectiveThoughts(): String = revisions
+    .getOrNull(activeRevisionIndex)
+    ?.thoughts
+    ?: thoughts
+
+fun MessageV2.isEffectivelyBlank(): Boolean = effectiveContent().isBlank() && attachments.isEmpty()
+
+fun MessageV2.resetActiveRevision(): MessageV2 = copy(activeRevisionIndex = ACTIVE_REVISION_LATEST)
+
+fun MessageV2.selectRevision(index: Int): MessageV2 = copy(
+    activeRevisionIndex = if (index in revisions.indices) index else ACTIVE_REVISION_LATEST
+)
+
+fun MessageV2.snapshotLatestAssistantRevision(timestamp: Long = System.currentTimeMillis() / 1000): AssistantRevision? {
+    if (platformType == null) return null
+    if (content.isBlank() && thoughts.isBlank()) return null
+
+    return AssistantRevision(
+        content = content,
+        thoughts = thoughts,
+        createdAt = timestamp
+    )
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImpl.kt
@@ -14,7 +14,6 @@ import dev.chungjungsoo.gptmobile.data.database.entity.Message
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
 import dev.chungjungsoo.gptmobile.data.database.entity.effectiveContent
-import dev.chungjungsoo.gptmobile.data.database.entity.isEffectivelyBlank
 import dev.chungjungsoo.gptmobile.data.dto.ApiState
 import dev.chungjungsoo.gptmobile.data.dto.anthropic.common.ImageContent as AnthropicImageContent
 import dev.chungjungsoo.gptmobile.data.dto.anthropic.common.ImageSource
@@ -162,7 +161,7 @@ class ChatRepositoryImpl @Inject constructor(
 
                     if (index < assistantMessages.size) {
                         assistantMessages[index]
-                            .firstOrNull { !it.isEffectivelyBlank() && it.platformType == platform.uid }
+                            .firstOrNull { it.platformType == platform.uid && it.hasSendableAssistantPayload() }
                             ?.let { assistantMsg ->
                                 inputMessages.add(transformMessageV2ToResponsesInput(assistantMsg, isUser = false, platformUid = platform.uid))
                             }
@@ -239,7 +238,7 @@ class ChatRepositoryImpl @Inject constructor(
 
                     if (index < assistantMessages.size) {
                         assistantMessages[index]
-                            .firstOrNull { !it.isEffectivelyBlank() && it.platformType == platform.uid }
+                            .firstOrNull { it.platformType == platform.uid && it.hasSendableAssistantPayload() }
                             ?.let { assistantMsg ->
                                 messages.add(transformMessageV2ToChatMessage(assistantMsg, isUser = false))
                             }
@@ -309,7 +308,7 @@ class ChatRepositoryImpl @Inject constructor(
 
                     if (index < assistantMessages.size) {
                         assistantMessages[index]
-                            .firstOrNull { !it.isEffectivelyBlank() && it.platformType == platform.uid }
+                            .firstOrNull { it.platformType == platform.uid && it.hasSendableAssistantPayload() }
                             ?.let { assistantMsg ->
                                 messages.add(transformMessageV2ToChatMessage(assistantMsg, isUser = false))
                             }
@@ -348,7 +347,7 @@ class ChatRepositoryImpl @Inject constructor(
 
     private suspend fun transformMessageV2ToChatMessage(message: MessageV2, isUser: Boolean): ChatMessage {
         val content = mutableListOf<OpenAIMessageContent>()
-        val messageContent = if (isUser) message.content else stripAssistantErrorNote(message.effectiveContent())
+        val messageContent = if (isUser) message.content else message.sendableAssistantContent()
 
         // Add text content
         if (messageContent.isNotBlank()) {
@@ -377,7 +376,7 @@ class ChatRepositoryImpl @Inject constructor(
 
     private suspend fun transformMessageV2ToResponsesInput(message: MessageV2, isUser: Boolean, platformUid: String): ResponseInputMessage {
         val role = if (isUser) "user" else "assistant"
-        val messageContent = if (isUser) message.content else stripAssistantErrorNote(message.effectiveContent())
+        val messageContent = if (isUser) message.content else message.sendableAssistantContent()
 
         // Check if there are any image files
         val imageAttachments = message.attachments.filter { attachment ->
@@ -447,7 +446,7 @@ class ChatRepositoryImpl @Inject constructor(
 
                     if (index < assistantMessages.size) {
                         assistantMessages[index]
-                            .firstOrNull { !it.isEffectivelyBlank() && it.platformType == platform.uid }
+                            .firstOrNull { it.platformType == platform.uid && it.hasSendableAssistantPayload() }
                             ?.let { assistantMsg ->
                                 messages.add(transformMessageV2ToAnthropic(assistantMsg, MessageRole.ASSISTANT, platform.uid))
                             }
@@ -510,7 +509,7 @@ class ChatRepositoryImpl @Inject constructor(
 
     private suspend fun transformMessageV2ToAnthropic(message: MessageV2, role: MessageRole, platformUid: String): InputMessage {
         val content = mutableListOf<AnthropicMessageContent>()
-        val messageContent = if (role == MessageRole.USER) message.content else stripAssistantErrorNote(message.effectiveContent())
+        val messageContent = if (role == MessageRole.USER) message.content else message.sendableAssistantContent()
 
         // Add text content
         if (messageContent.isNotBlank()) {
@@ -565,7 +564,7 @@ class ChatRepositoryImpl @Inject constructor(
 
                     if (index < assistantMessages.size) {
                         assistantMessages[index]
-                            .firstOrNull { !it.isEffectivelyBlank() && it.platformType == platform.uid }
+                            .firstOrNull { it.platformType == platform.uid && it.hasSendableAssistantPayload() }
                             ?.let { assistantMsg ->
                                 contents.add(transformMessageV2ToGoogle(assistantMsg, GoogleRole.MODEL, platform.uid))
                             }
@@ -625,7 +624,7 @@ class ChatRepositoryImpl @Inject constructor(
 
     private suspend fun transformMessageV2ToGoogle(message: MessageV2, role: GoogleRole, platformUid: String): Content {
         val parts = mutableListOf<Part>()
-        val messageContent = if (role == GoogleRole.USER) message.content else stripAssistantErrorNote(message.effectiveContent())
+        val messageContent = if (role == GoogleRole.USER) message.content else message.sendableAssistantContent()
 
         // Add text content
         if (messageContent.isNotBlank()) {
@@ -903,6 +902,13 @@ internal fun createGroqChatCompletionRequest(
 }
 
 internal fun isGroqGptOssModel(model: String): Boolean = model.contains("gpt-oss", ignoreCase = true)
+
+internal fun MessageV2.sendableAssistantContent(): String {
+    val strippedContent = stripAssistantErrorNote(effectiveContent()).trim()
+    return if (strippedContent.startsWith("Error: ")) "" else strippedContent
+}
+
+internal fun MessageV2.hasSendableAssistantPayload(): Boolean = sendableAssistantContent().isNotBlank() || attachments.isNotEmpty()
 
 internal fun validateResponseInputPartsOrThrow(messageContent: String, partCount: Int, messageId: Int) {
     if (messageContent.isBlank() && partCount == 0) {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImpl.kt
@@ -13,6 +13,8 @@ import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoomV2
 import dev.chungjungsoo.gptmobile.data.database.entity.Message
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
+import dev.chungjungsoo.gptmobile.data.database.entity.effectiveContent
+import dev.chungjungsoo.gptmobile.data.database.entity.isEffectivelyBlank
 import dev.chungjungsoo.gptmobile.data.dto.ApiState
 import dev.chungjungsoo.gptmobile.data.dto.anthropic.common.ImageContent as AnthropicImageContent
 import dev.chungjungsoo.gptmobile.data.dto.anthropic.common.ImageSource
@@ -160,7 +162,7 @@ class ChatRepositoryImpl @Inject constructor(
 
                     if (index < assistantMessages.size) {
                         assistantMessages[index]
-                            .firstOrNull { it.content.isNotBlank() && it.platformType == platform.uid }
+                            .firstOrNull { !it.isEffectivelyBlank() && it.platformType == platform.uid }
                             ?.let { assistantMsg ->
                                 inputMessages.add(transformMessageV2ToResponsesInput(assistantMsg, isUser = false, platformUid = platform.uid))
                             }
@@ -237,7 +239,7 @@ class ChatRepositoryImpl @Inject constructor(
 
                     if (index < assistantMessages.size) {
                         assistantMessages[index]
-                            .firstOrNull { it.content.isNotBlank() && it.platformType == platform.uid }
+                            .firstOrNull { !it.isEffectivelyBlank() && it.platformType == platform.uid }
                             ?.let { assistantMsg ->
                                 messages.add(transformMessageV2ToChatMessage(assistantMsg, isUser = false))
                             }
@@ -307,7 +309,7 @@ class ChatRepositoryImpl @Inject constructor(
 
                     if (index < assistantMessages.size) {
                         assistantMessages[index]
-                            .firstOrNull { it.content.isNotBlank() && it.platformType == platform.uid }
+                            .firstOrNull { !it.isEffectivelyBlank() && it.platformType == platform.uid }
                             ?.let { assistantMsg ->
                                 messages.add(transformMessageV2ToChatMessage(assistantMsg, isUser = false))
                             }
@@ -346,7 +348,7 @@ class ChatRepositoryImpl @Inject constructor(
 
     private suspend fun transformMessageV2ToChatMessage(message: MessageV2, isUser: Boolean): ChatMessage {
         val content = mutableListOf<OpenAIMessageContent>()
-        val messageContent = if (isUser) message.content else stripAssistantErrorNote(message.content)
+        val messageContent = if (isUser) message.content else stripAssistantErrorNote(message.effectiveContent())
 
         // Add text content
         if (messageContent.isNotBlank()) {
@@ -375,7 +377,7 @@ class ChatRepositoryImpl @Inject constructor(
 
     private suspend fun transformMessageV2ToResponsesInput(message: MessageV2, isUser: Boolean, platformUid: String): ResponseInputMessage {
         val role = if (isUser) "user" else "assistant"
-        val messageContent = if (isUser) message.content else stripAssistantErrorNote(message.content)
+        val messageContent = if (isUser) message.content else stripAssistantErrorNote(message.effectiveContent())
 
         // Check if there are any image files
         val imageAttachments = message.attachments.filter { attachment ->
@@ -445,7 +447,7 @@ class ChatRepositoryImpl @Inject constructor(
 
                     if (index < assistantMessages.size) {
                         assistantMessages[index]
-                            .firstOrNull { it.content.isNotBlank() && it.platformType == platform.uid }
+                            .firstOrNull { !it.isEffectivelyBlank() && it.platformType == platform.uid }
                             ?.let { assistantMsg ->
                                 messages.add(transformMessageV2ToAnthropic(assistantMsg, MessageRole.ASSISTANT, platform.uid))
                             }
@@ -508,7 +510,7 @@ class ChatRepositoryImpl @Inject constructor(
 
     private suspend fun transformMessageV2ToAnthropic(message: MessageV2, role: MessageRole, platformUid: String): InputMessage {
         val content = mutableListOf<AnthropicMessageContent>()
-        val messageContent = if (role == MessageRole.USER) message.content else stripAssistantErrorNote(message.content)
+        val messageContent = if (role == MessageRole.USER) message.content else stripAssistantErrorNote(message.effectiveContent())
 
         // Add text content
         if (messageContent.isNotBlank()) {
@@ -563,7 +565,7 @@ class ChatRepositoryImpl @Inject constructor(
 
                     if (index < assistantMessages.size) {
                         assistantMessages[index]
-                            .firstOrNull { it.content.isNotBlank() && it.platformType == platform.uid }
+                            .firstOrNull { !it.isEffectivelyBlank() && it.platformType == platform.uid }
                             ?.let { assistantMsg ->
                                 contents.add(transformMessageV2ToGoogle(assistantMsg, GoogleRole.MODEL, platform.uid))
                             }
@@ -623,7 +625,7 @@ class ChatRepositoryImpl @Inject constructor(
 
     private suspend fun transformMessageV2ToGoogle(message: MessageV2, role: GoogleRole, platformUid: String): Content {
         val parts = mutableListOf<Part>()
-        val messageContent = if (role == GoogleRole.USER) message.content else stripAssistantErrorNote(message.content)
+        val messageContent = if (role == GoogleRole.USER) message.content else stripAssistantErrorNote(message.effectiveContent())
 
         // Add text content
         if (messageContent.isNotBlank()) {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/di/DatabaseModule.kt
@@ -58,6 +58,7 @@ object DatabaseModule {
         DB_NAME_V2
     ).addMigrations(
         ChatDatabaseV2Migrations.MIGRATION_1_2,
-        ChatDatabaseV2Migrations.MIGRATION_2_3
+        ChatDatabaseV2Migrations.MIGRATION_2_3,
+        ChatDatabaseV2Migrations.MIGRATION_3_4
     ).build()
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatAttachmentDraft.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatAttachmentDraft.kt
@@ -9,6 +9,7 @@ data class ChatAttachmentDraft(
     val attachment: ChatAttachment? = null,
     val mimeType: String = "",
     val status: Status = Status.Preparing,
+    val cleanupOnDiscard: Boolean = true,
     val notice: String? = null,
     val errorMessage: String? = null
 ) {
@@ -19,5 +20,16 @@ data class ChatAttachmentDraft(
         Preparing,
         Ready,
         Failed
+    }
+
+    companion object {
+        fun fromAttachment(attachment: ChatAttachment): ChatAttachmentDraft = ChatAttachmentDraft(
+            sourceFilePath = attachment.localFilePath,
+            preparedFilePath = attachment.preparedFilePath,
+            attachment = attachment,
+            mimeType = attachment.mimeType,
+            status = Status.Ready,
+            cleanupOnDiscard = false
+        )
     }
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material3.ButtonDefaults
@@ -90,6 +92,8 @@ fun OpponentChatBubble(
     contentIdentity: Any = text,
     canEdit: Boolean = false,
     revisionIndexLabel: String? = null,
+    canShowPreviousRevision: Boolean = false,
+    canShowNextRevision: Boolean = false,
     onCopyClick: () -> Unit = {},
     onSelectClick: () -> Unit = {},
     onRetryClick: () -> Unit = {},
@@ -165,15 +169,27 @@ fun OpponentChatBubble(
                         modifier = Modifier.padding(start = 16.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        TextButton(onClick = onShowPreviousRevision) {
-                            Text("<")
+                        IconButton(
+                            enabled = canShowPreviousRevision,
+                            onClick = onShowPreviousRevision
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                                contentDescription = stringResource(R.string.previous_revision)
+                            )
                         }
                         Text(
                             text = label,
                             style = MaterialTheme.typography.labelMedium
                         )
-                        TextButton(onClick = onShowNextRevision) {
-                            Text(">")
+                        IconButton(
+                            enabled = canShowNextRevision,
+                            onClick = onShowNextRevision
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                                contentDescription = stringResource(R.string.next_revision)
+                            )
                         }
                     }
                 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -73,7 +74,7 @@ fun UserChatBubble(
                 modifier = Modifier.padding(16.dp)
             )
         }
-        UserFileThumbnailRow(files = files)
+        MessageFileThumbnailRow(files = files)
     }
 }
 
@@ -85,10 +86,16 @@ fun OpponentChatBubble(
     isError: Boolean = false,
     text: String,
     thoughts: String = "",
+    attachments: List<String> = emptyList(),
     contentIdentity: Any = text,
+    canEdit: Boolean = false,
+    revisionIndexLabel: String? = null,
     onCopyClick: () -> Unit = {},
     onSelectClick: () -> Unit = {},
-    onRetryClick: () -> Unit = {}
+    onRetryClick: () -> Unit = {},
+    onEditClick: () -> Unit = {},
+    onShowPreviousRevision: () -> Unit = {},
+    onShowNextRevision: () -> Unit = {}
 ) {
     val cardColor = CardColors(
         containerColor = MaterialTheme.colorScheme.background,
@@ -116,14 +123,22 @@ fun OpponentChatBubble(
                 shape = RoundedCornerShape(0.dp),
                 colors = cardColor
             ) {
-                val displayText = if (isLoading) text + "●" else text
+                Column {
+                    val displayText = if (isLoading) text + "●" else text
 
-                ChatMarkdown(
-                    content = displayText,
-                    contentIdentity = contentIdentity,
-                    modifier = Modifier
-                        .padding(16.dp)
-                )
+                    ChatMarkdown(
+                        content = displayText,
+                        contentIdentity = contentIdentity,
+                        modifier = Modifier
+                            .padding(16.dp)
+                    )
+
+                    MessageFileThumbnailRow(
+                        files = attachments,
+                        usePrimaryColors = false,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                }
             }
 
             if (!isLoading) {
@@ -134,10 +149,32 @@ fun OpponentChatBubble(
                         CopyTextIcon(onCopyClick)
                         Spacer(modifier = Modifier.width(8.dp))
                         SelectTextIcon(onSelectClick)
+                        if (canEdit) {
+                            Spacer(modifier = Modifier.width(8.dp))
+                            EditTextIcon(onEditClick)
+                        }
                     }
                     if (canRetry) {
                         Spacer(modifier = Modifier.width(8.dp))
                         RetryIcon(onRetryClick)
+                    }
+                }
+
+                revisionIndexLabel?.let { label ->
+                    Row(
+                        modifier = Modifier.padding(start = 16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        TextButton(onClick = onShowPreviousRevision) {
+                            Text("<")
+                        }
+                        Text(
+                            text = label,
+                            style = MaterialTheme.typography.labelMedium
+                        )
+                        TextButton(onClick = onShowNextRevision) {
+                            Text(">")
+                        }
                     }
                 }
             }
@@ -231,6 +268,16 @@ private fun RetryIcon(onRetryClick: () -> Unit) {
     }
 }
 
+@Composable
+private fun EditTextIcon(onEditClick: () -> Unit) {
+    IconButton(onClick = onEditClick) {
+        Icon(
+            imageVector = Icons.Outlined.Edit,
+            contentDescription = stringResource(R.string.edit)
+        )
+    }
+}
+
 @Preview
 @Composable
 fun UserChatBubblePreview() {
@@ -273,7 +320,11 @@ fun OpponentChatBubblePreview() {
 }
 
 @Composable
-private fun UserFileThumbnailRow(files: List<String>) {
+fun MessageFileThumbnailRow(
+    files: List<String>,
+    usePrimaryColors: Boolean = true,
+    modifier: Modifier = Modifier
+) {
     // Filter out empty strings and check if we have valid files
     val validFiles = files.filter { it.isNotEmpty() && it.isNotBlank() }
 
@@ -282,22 +333,38 @@ private fun UserFileThumbnailRow(files: List<String>) {
     }
 
     Row(
-        modifier = Modifier
+        modifier = modifier
             .padding(top = 8.dp)
             .wrapContentHeight()
             .horizontalScroll(rememberScrollState()),
         horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp)
     ) {
         validFiles.forEach { filePath ->
-            UserFileThumbnail(filePath = filePath)
+            MessageFileThumbnail(
+                filePath = filePath,
+                usePrimaryColors = usePrimaryColors
+            )
         }
     }
 }
 
 @Composable
-private fun UserFileThumbnail(filePath: String) {
+private fun MessageFileThumbnail(
+    filePath: String,
+    usePrimaryColors: Boolean
+) {
     val file = File(filePath)
     val isImage = isImageFile(file.extension)
+    val containerColor = if (usePrimaryColors) {
+        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.7f)
+    } else {
+        MaterialTheme.colorScheme.surfaceVariant
+    }
+    val contentColor = if (usePrimaryColors) {
+        MaterialTheme.colorScheme.onPrimaryContainer
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
 
     Column(
         modifier = Modifier.width(56.dp),
@@ -307,7 +374,7 @@ private fun UserFileThumbnail(filePath: String) {
             modifier = Modifier
                 .size(48.dp)
                 .clip(RoundedCornerShape(8.dp))
-                .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.7f))
+                .background(containerColor)
         ) {
             if (isImage) {
                 Icon(
@@ -316,7 +383,7 @@ private fun UserFileThumbnail(filePath: String) {
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(8.dp),
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer
+                    tint = contentColor
                 )
             } else {
                 Icon(
@@ -325,7 +392,7 @@ private fun UserFileThumbnail(filePath: String) {
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(8.dp),
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer
+                    tint = contentColor
                 )
             }
         }
@@ -333,7 +400,7 @@ private fun UserFileThumbnail(filePath: String) {
         Text(
             text = file.name,
             style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onPrimaryContainer,
+            color = contentColor,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
             textAlign = androidx.compose.ui.text.style.TextAlign.Center,

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatDialogs.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatDialogs.kt
@@ -1,5 +1,7 @@
 package dev.chungjungsoo.gptmobile.presentation.ui.chat
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -18,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
@@ -25,6 +28,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import dev.chungjungsoo.gptmobile.R
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
+import dev.chungjungsoo.gptmobile.data.database.entity.effectiveContent
+import dev.chungjungsoo.gptmobile.data.database.entity.effectiveThoughts
 
 @Composable
 fun ChatModelDialog(
@@ -160,16 +165,27 @@ fun ChatTitleDialog(
 }
 
 @Composable
-fun ChatQuestionEditDialog(
+fun UserMessageEditDialog(
     initialQuestion: MessageV2,
+    attachments: List<ChatAttachmentDraft>,
+    onFileSelected: (String) -> Unit,
+    onFileRemoved: (String) -> Unit,
     onDismissRequest: () -> Unit,
     onConfirmRequest: (MessageV2) -> Unit
 ) {
     val configuration = LocalWindowInfo.current
     val screenWidth = with(LocalDensity.current) { configuration.containerSize.width.toDp() }
     val screenHeight = with(LocalDensity.current) { configuration.containerSize.height.toDp() }
+    val context = LocalContext.current
     var question by remember { mutableStateOf(initialQuestion.content) }
     val questionFieldMaxLines = 8
+    val filePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri ->
+        uri?.let {
+            copyFileToAppDirectory(context, it)?.let(onFileSelected)
+        }
+    }
 
     AlertDialog(
         properties = DialogProperties(usePlatformDefaultWidth = false),
@@ -178,7 +194,7 @@ fun ChatQuestionEditDialog(
             .heightIn(max = screenHeight - 80.dp),
         title = { Text(text = stringResource(R.string.edit_question)) },
         text = {
-            Column {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                 OutlinedTextField(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -190,12 +206,18 @@ fun ChatQuestionEditDialog(
                     maxLines = questionFieldMaxLines,
                     label = { Text(stringResource(R.string.user_message)) }
                 )
+                AttachmentEditorSection(
+                    attachments = attachments,
+                    onAttachFileClick = { filePickerLauncher.launch("*/*") },
+                    onFileRemoved = onFileRemoved
+                )
             }
         },
         onDismissRequest = onDismissRequest,
         confirmButton = {
             TextButton(
-                enabled = question.isNotBlank() && question != initialQuestion.content,
+                enabled = question.isNotBlank() &&
+                    (question != initialQuestion.content || attachments.mapNotNull { it.attachment } != initialQuestion.attachments),
                 onClick = { onConfirmRequest(initialQuestion.copy(content = question)) }
             ) {
                 Text(stringResource(R.string.confirm))
@@ -209,4 +231,111 @@ fun ChatQuestionEditDialog(
             }
         }
     )
+}
+
+@Composable
+fun AssistantMessageEditDialog(
+    initialMessage: MessageV2,
+    attachments: List<ChatAttachmentDraft>,
+    onFileSelected: (String) -> Unit,
+    onFileRemoved: (String) -> Unit,
+    onDismissRequest: () -> Unit,
+    onConfirmRequest: (MessageV2, String) -> Unit
+) {
+    val configuration = LocalWindowInfo.current
+    val screenWidth = with(LocalDensity.current) { configuration.containerSize.width.toDp() }
+    val screenHeight = with(LocalDensity.current) { configuration.containerSize.height.toDp() }
+    val context = LocalContext.current
+    var responseText by remember { mutableStateOf(initialMessage.effectiveContent()) }
+    var thoughtsText by remember { mutableStateOf(initialMessage.effectiveThoughts()) }
+    val filePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri ->
+        uri?.let {
+            copyFileToAppDirectory(context, it)?.let(onFileSelected)
+        }
+    }
+
+    AlertDialog(
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+        modifier = Modifier
+            .widthIn(max = screenWidth - 40.dp)
+            .heightIn(max = screenHeight - 80.dp),
+        title = { Text(text = stringResource(R.string.edit_assistant_message)) },
+        text = {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                OutlinedTextField(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 80.dp)
+                        .padding(horizontal = 20.dp, vertical = 16.dp),
+                    value = responseText,
+                    onValueChange = { responseText = it },
+                    minLines = 3,
+                    maxLines = 8,
+                    label = { Text(stringResource(R.string.assistant_message)) }
+                )
+                OutlinedTextField(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 80.dp)
+                        .padding(horizontal = 20.dp, vertical = 8.dp),
+                    value = thoughtsText,
+                    onValueChange = { thoughtsText = it },
+                    minLines = 2,
+                    maxLines = 8,
+                    label = { Text(stringResource(R.string.assistant_thoughts)) }
+                )
+                AttachmentEditorSection(
+                    attachments = attachments,
+                    onAttachFileClick = { filePickerLauncher.launch("*/*") },
+                    onFileRemoved = onFileRemoved
+                )
+            }
+        },
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            TextButton(
+                enabled = responseText.isNotBlank() &&
+                    (
+                        responseText != initialMessage.effectiveContent() ||
+                            thoughtsText != initialMessage.effectiveThoughts() ||
+                            attachments.mapNotNull { it.attachment } != initialMessage.attachments
+                        ),
+                onClick = {
+                    onConfirmRequest(
+                        initialMessage.copy(content = responseText),
+                        thoughtsText
+                    )
+                }
+            ) {
+                Text(stringResource(R.string.confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
+}
+
+@Composable
+private fun AttachmentEditorSection(
+    attachments: List<ChatAttachmentDraft>,
+    onAttachFileClick: () -> Unit,
+    onFileRemoved: (String) -> Unit
+) {
+    if (attachments.isNotEmpty()) {
+        FileThumbnailRow(
+            selectedAttachments = attachments,
+            onFileRemoved = onFileRemoved
+        )
+    }
+    TextButton(
+        modifier = Modifier.padding(horizontal = 12.dp),
+        onClick = onAttachFileClick
+    ) {
+        Text(text = stringResource(R.string.attach_file))
+    }
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatDialogs.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatDialogs.kt
@@ -169,6 +169,7 @@ fun UserMessageEditDialog(
     initialQuestion: MessageV2,
     attachments: List<ChatAttachmentDraft>,
     onFileSelected: (String) -> Unit,
+    onCopyFailed: () -> Unit,
     onFileRemoved: (String) -> Unit,
     onDismissRequest: () -> Unit,
     onConfirmRequest: (MessageV2) -> Unit
@@ -183,7 +184,12 @@ fun UserMessageEditDialog(
         contract = ActivityResultContracts.GetContent()
     ) { uri ->
         uri?.let {
-            copyFileToAppDirectory(context, it)?.let(onFileSelected)
+            val filePath = copyFileToAppDirectory(context, it)
+            if (filePath != null) {
+                onFileSelected(filePath)
+            } else {
+                onCopyFailed()
+            }
         }
     }
 
@@ -215,8 +221,10 @@ fun UserMessageEditDialog(
         },
         onDismissRequest = onDismissRequest,
         confirmButton = {
+            val hasPendingOrFailedAttachments = attachments.any { it.status != ChatAttachmentDraft.Status.Ready }
             TextButton(
-                enabled = question.isNotBlank() &&
+                enabled = !hasPendingOrFailedAttachments &&
+                    question.isNotBlank() &&
                     (question != initialQuestion.content || attachments.mapNotNull { it.attachment } != initialQuestion.attachments),
                 onClick = { onConfirmRequest(initialQuestion.copy(content = question)) }
             ) {
@@ -238,6 +246,7 @@ fun AssistantMessageEditDialog(
     initialMessage: MessageV2,
     attachments: List<ChatAttachmentDraft>,
     onFileSelected: (String) -> Unit,
+    onCopyFailed: () -> Unit,
     onFileRemoved: (String) -> Unit,
     onDismissRequest: () -> Unit,
     onConfirmRequest: (MessageV2, String) -> Unit
@@ -252,7 +261,12 @@ fun AssistantMessageEditDialog(
         contract = ActivityResultContracts.GetContent()
     ) { uri ->
         uri?.let {
-            copyFileToAppDirectory(context, it)?.let(onFileSelected)
+            val filePath = copyFileToAppDirectory(context, it)
+            if (filePath != null) {
+                onFileSelected(filePath)
+            } else {
+                onCopyFailed()
+            }
         }
     }
 
@@ -295,8 +309,10 @@ fun AssistantMessageEditDialog(
         },
         onDismissRequest = onDismissRequest,
         confirmButton = {
+            val hasPendingOrFailedAttachments = attachments.any { it.status != ChatAttachmentDraft.Status.Ready }
             TextButton(
-                enabled = responseText.isNotBlank() &&
+                enabled = !hasPendingOrFailedAttachments &&
+                    responseText.isNotBlank() &&
                     (
                         responseText != initialMessage.effectiveContent() ||
                             thoughtsText != initialMessage.effectiveThoughts() ||

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
@@ -330,11 +330,13 @@ fun ChatScreen(
                         initialQuestion = session.message,
                         attachments = session.attachments,
                         onFileSelected = chatViewModel::addMessageEditFile,
+                        onCopyFailed = chatViewModel::notifyAttachmentCopyFailed,
                         onFileRemoved = chatViewModel::removeMessageEditFile,
                         onDismissRequest = chatViewModel::discardMessageEditDialog,
                         onConfirmRequest = { question ->
-                            chatViewModel.saveUserMessageEdit(question, session.attachments)
-                            chatViewModel.finishMessageEditDialog()
+                            if (chatViewModel.saveUserMessageEdit(question, session.attachments)) {
+                                chatViewModel.finishMessageEditDialog()
+                            }
                         }
                     )
                 }
@@ -344,11 +346,13 @@ fun ChatScreen(
                         initialMessage = session.message,
                         attachments = session.attachments,
                         onFileSelected = chatViewModel::addMessageEditFile,
+                        onCopyFailed = chatViewModel::notifyAttachmentCopyFailed,
                         onFileRemoved = chatViewModel::removeMessageEditFile,
                         onDismissRequest = chatViewModel::discardMessageEditDialog,
                         onConfirmRequest = { message, thoughts ->
-                            chatViewModel.saveAssistantMessageEdit(message, thoughts, session.attachments)
-                            chatViewModel.finishMessageEditDialog()
+                            if (chatViewModel.saveAssistantMessageEdit(message, thoughts, session.attachments)) {
+                                chatViewModel.finishMessageEditDialog()
+                            }
                         }
                     )
                 }
@@ -397,6 +401,14 @@ private fun ChatMessagePair(
     val selectedAssistantMessage = assistantMessages.getOrNull(platformIndexState)
     val assistantContent = selectedAssistantMessage?.effectiveContent() ?: ""
     val assistantThoughts = selectedAssistantMessage?.effectiveThoughts() ?: ""
+    val canShowPreviousRevision = selectedAssistantMessage?.let { assistantMessage ->
+        assistantMessage.revisions.isNotEmpty() &&
+            assistantMessage.activeRevisionIndex < assistantMessage.revisions.lastIndex
+    } ?: false
+    val canShowNextRevision = selectedAssistantMessage?.let { assistantMessage ->
+        assistantMessage.revisions.isNotEmpty() &&
+            assistantMessage.activeRevisionIndex != ACTIVE_REVISION_LATEST
+    } ?: false
     val selectedPlatformUid = enabledPlatformsInChat.getOrElse(platformIndexState) { "" }
     val isCurrentPlatformLoading =
         loadingStates.getOrElse(platformIndexState) { ChatViewModel.LoadingState.Idle } == ChatViewModel.LoadingState.Loading
@@ -482,6 +494,8 @@ private fun ChatMessagePair(
                         )
                     }
                 },
+                canShowPreviousRevision = canShowPreviousRevision,
+                canShowNextRevision = canShowNextRevision,
                 onCopyClick = { onCopyText(assistantContent) },
                 onSelectClick = { onSelectText(assistantContent) },
                 onRetryClick = { onRetry(messageIndex, platformIndexState) },

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
@@ -90,8 +90,11 @@ import androidx.core.content.FileProvider.getUriForFile
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.chungjungsoo.gptmobile.R
+import dev.chungjungsoo.gptmobile.data.database.entity.ACTIVE_REVISION_LATEST
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
+import dev.chungjungsoo.gptmobile.data.database.entity.effectiveContent
+import dev.chungjungsoo.gptmobile.data.database.entity.effectiveThoughts
 import java.io.File
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -118,7 +121,7 @@ fun ChatScreen(
     val loadingStates by chatViewModel.loadingStates.collectAsStateWithLifecycle()
     val isChatTitleDialogOpen by chatViewModel.isChatTitleDialogOpen.collectAsStateWithLifecycle()
     val isChatModelDialogOpen by chatViewModel.isChatModelDialogOpen.collectAsStateWithLifecycle()
-    val isEditQuestionDialogOpen by chatViewModel.isEditQuestionDialogOpen.collectAsStateWithLifecycle()
+    val messageEditSession by chatViewModel.messageEditSession.collectAsStateWithLifecycle()
     val isSelectTextSheetOpen by chatViewModel.isSelectTextSheetOpen.collectAsStateWithLifecycle()
     val isLoaded by chatViewModel.isLoaded.collectAsStateWithLifecycle()
     val selectedAttachments by chatViewModel.selectedAttachments.collectAsStateWithLifecycle()
@@ -219,7 +222,8 @@ fun ChatScreen(
                             isActiveMessage = false,
                             maximumUserChatBubbleWidth = maximumUserChatBubbleWidth,
                             maximumOpponentChatBubbleWidth = maximumOpponentChatBubbleWidth,
-                            onEditQuestion = chatViewModel::openEditQuestionDialog,
+                            onEditQuestion = chatViewModel::openUserMessageEditDialog,
+                            onEditAssistant = chatViewModel::openAssistantMessageEditDialog,
                             onCopyText = { copiedText ->
                                 scope.launch {
                                     clipboardManager.setClipEntry(ClipEntry(ClipData.newPlainText(copiedText, copiedText)))
@@ -227,7 +231,9 @@ fun ChatScreen(
                             },
                             onPlatformClick = chatViewModel::updateChatPlatformIndex,
                             onSelectText = chatViewModel::openSelectTextSheet,
-                            onRetry = chatViewModel::retryChat
+                            onRetry = chatViewModel::retryChat,
+                            onShowPreviousRevision = chatViewModel::showPreviousAssistantRevision,
+                            onShowNextRevision = chatViewModel::showNextAssistantRevision
                         )
                     }
 
@@ -246,7 +252,8 @@ fun ChatScreen(
                                 isActiveMessage = true,
                                 maximumUserChatBubbleWidth = maximumUserChatBubbleWidth,
                                 maximumOpponentChatBubbleWidth = maximumOpponentChatBubbleWidth,
-                                onEditQuestion = chatViewModel::openEditQuestionDialog,
+                                onEditQuestion = chatViewModel::openUserMessageEditDialog,
+                                onEditAssistant = chatViewModel::openAssistantMessageEditDialog,
                                 onCopyText = { copiedText ->
                                     scope.launch {
                                         clipboardManager.setClipEntry(ClipEntry(ClipData.newPlainText(copiedText, copiedText)))
@@ -254,7 +261,9 @@ fun ChatScreen(
                                 },
                                 onPlatformClick = chatViewModel::updateChatPlatformIndex,
                                 onSelectText = chatViewModel::openSelectTextSheet,
-                                onRetry = chatViewModel::retryChat
+                                onRetry = chatViewModel::retryChat,
+                                onShowPreviousRevision = chatViewModel::showPreviousAssistantRevision,
+                                onShowNextRevision = chatViewModel::showNextAssistantRevision
                             )
                         }
                     }
@@ -314,16 +323,36 @@ fun ChatScreen(
             )
         }
 
-        if (isEditQuestionDialogOpen) {
-            val editedQuestion by chatViewModel.editedQuestion.collectAsStateWithLifecycle()
-            ChatQuestionEditDialog(
-                initialQuestion = editedQuestion,
-                onDismissRequest = chatViewModel::closeEditQuestionDialog,
-                onConfirmRequest = { question ->
-                    chatViewModel.editQuestion(question)
-                    chatViewModel.closeEditQuestionDialog()
+        messageEditSession?.let { session ->
+            when (session.role) {
+                ChatViewModel.MessageEditRole.USER -> {
+                    UserMessageEditDialog(
+                        initialQuestion = session.message,
+                        attachments = session.attachments,
+                        onFileSelected = chatViewModel::addMessageEditFile,
+                        onFileRemoved = chatViewModel::removeMessageEditFile,
+                        onDismissRequest = chatViewModel::discardMessageEditDialog,
+                        onConfirmRequest = { question ->
+                            chatViewModel.saveUserMessageEdit(question, session.attachments)
+                            chatViewModel.finishMessageEditDialog()
+                        }
+                    )
                 }
-            )
+
+                ChatViewModel.MessageEditRole.ASSISTANT -> {
+                    AssistantMessageEditDialog(
+                        initialMessage = session.message,
+                        attachments = session.attachments,
+                        onFileSelected = chatViewModel::addMessageEditFile,
+                        onFileRemoved = chatViewModel::removeMessageEditFile,
+                        onDismissRequest = chatViewModel::discardMessageEditDialog,
+                        onConfirmRequest = { message, thoughts ->
+                            chatViewModel.saveAssistantMessageEdit(message, thoughts, session.attachments)
+                            chatViewModel.finishMessageEditDialog()
+                        }
+                    )
+                }
+            }
         }
 
         if (isSelectTextSheetOpen) {
@@ -357,13 +386,17 @@ private fun ChatMessagePair(
     maximumUserChatBubbleWidth: Dp,
     maximumOpponentChatBubbleWidth: Dp,
     onEditQuestion: (MessageV2) -> Unit,
+    onEditAssistant: (Int, Int) -> Unit,
     onCopyText: (String) -> Unit,
     onPlatformClick: (Int, Int) -> Unit,
     onSelectText: (String) -> Unit,
-    onRetry: (Int, Int) -> Unit
+    onRetry: (Int, Int) -> Unit,
+    onShowPreviousRevision: (Int, Int) -> Unit,
+    onShowNextRevision: (Int, Int) -> Unit
 ) {
-    val assistantContent = assistantMessages.getOrNull(platformIndexState)?.content ?: ""
-    val assistantThoughts = assistantMessages.getOrNull(platformIndexState)?.thoughts ?: ""
+    val selectedAssistantMessage = assistantMessages.getOrNull(platformIndexState)
+    val assistantContent = selectedAssistantMessage?.effectiveContent() ?: ""
+    val assistantThoughts = selectedAssistantMessage?.effectiveThoughts() ?: ""
     val selectedPlatformUid = enabledPlatformsInChat.getOrElse(platformIndexState) { "" }
     val isCurrentPlatformLoading =
         loadingStates.getOrElse(platformIndexState) { ChatViewModel.LoadingState.Idle } == ChatViewModel.LoadingState.Loading
@@ -429,14 +462,32 @@ private fun ChatMessagePair(
                     .fillMaxWidth()
                     .padding(horizontal = 8.dp)
                     .widthIn(max = maximumOpponentChatBubbleWidth),
+                canEdit = canUseChat && isIdle,
                 canRetry = canUseChat && isActiveMessage && !isCurrentPlatformLoading,
                 isLoading = isActiveMessage && isCurrentPlatformLoading,
                 text = assistantContent,
                 thoughts = assistantThoughts,
+                attachments = selectedAssistantMessage?.attachments.orEmpty().map { it.filePathForDisplay },
                 contentIdentity = "$messageIndex:$selectedPlatformUid",
+                revisionIndexLabel = selectedAssistantMessage?.let { assistantMessage ->
+                    if (assistantMessage.revisions.isEmpty()) {
+                        null
+                    } else if (assistantMessage.activeRevisionIndex == ACTIVE_REVISION_LATEST) {
+                        stringResource(R.string.latest_revision)
+                    } else {
+                        stringResource(
+                            R.string.revision_counter,
+                            assistantMessage.activeRevisionIndex + 1,
+                            assistantMessage.revisions.size
+                        )
+                    }
+                },
                 onCopyClick = { onCopyText(assistantContent) },
                 onSelectClick = { onSelectText(assistantContent) },
-                onRetryClick = { onRetry(messageIndex, platformIndexState) }
+                onRetryClick = { onRetry(messageIndex, platformIndexState) },
+                onEditClick = { onEditAssistant(messageIndex, platformIndexState) },
+                onShowPreviousRevision = { onShowPreviousRevision(messageIndex, platformIndexState) },
+                onShowNextRevision = { onShowNextRevision(messageIndex, platformIndexState) }
             )
         }
     }
@@ -690,7 +741,7 @@ fun ChatInputBox(
 }
 
 @Composable
-private fun FileThumbnailRow(
+fun FileThumbnailRow(
     selectedAttachments: List<ChatAttachmentDraft>,
     onFileRemoved: (String) -> Unit
 ) {
@@ -711,7 +762,7 @@ private fun FileThumbnailRow(
 }
 
 @Composable
-private fun FileThumbnail(
+fun FileThumbnail(
     attachment: ChatAttachmentDraft,
     onRemove: () -> Unit
 ) {
@@ -814,7 +865,7 @@ private fun FileThumbnail(
     }
 }
 
-private fun copyFileToAppDirectory(context: Context, uri: android.net.Uri): String? {
+fun copyFileToAppDirectory(context: Context, uri: android.net.Uri): String? {
     return try {
         val inputStream = context.contentResolver.openInputStream(uri)
         val rawFileName = getFileName(context, uri)

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
@@ -360,7 +360,7 @@ private fun ChatMessagePair(
     onCopyText: (String) -> Unit,
     onPlatformClick: (Int, Int) -> Unit,
     onSelectText: (String) -> Unit,
-    onRetry: (Int) -> Unit
+    onRetry: (Int, Int) -> Unit
 ) {
     val assistantContent = assistantMessages.getOrNull(platformIndexState)?.content ?: ""
     val assistantThoughts = assistantMessages.getOrNull(platformIndexState)?.thoughts ?: ""
@@ -436,7 +436,7 @@ private fun ChatMessagePair(
                 contentIdentity = "$messageIndex:$selectedPlatformUid",
                 onCopyClick = { onCopyText(assistantContent) },
                 onSelectClick = { onSelectText(assistantContent) },
-                onRetryClick = { onRetry(platformIndexState) }
+                onRetryClick = { onRetry(messageIndex, platformIndexState) }
             )
         }
     }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModel.kt
@@ -203,17 +203,20 @@ class ChatViewModel @Inject constructor(
         }
     }
 
-    fun retryChat(platformIndex: Int) {
+    fun retryChat(turnIndex: Int, platformIndex: Int) {
+        if (turnIndex !in _groupedMessages.value.assistantMessages.indices) return
         if (platformIndex >= enabledPlatformsInChat.size || platformIndex < 0) return
         val platform = _enabledPlatformsInApp.value.firstOrNull { it.uid == enabledPlatformsInChat[platformIndex] } ?: return
         val platformWithChatModel = resolvePlatformModel(platform)
         _loadingStates.update { it.toMutableList().apply { this[platformIndex] = LoadingState.Loading } }
         _groupedMessages.update {
-            val updatedAssistantMessages = it.assistantMessages.toMutableList()
-            updatedAssistantMessages[it.assistantMessages.lastIndex] = updatedAssistantMessages[it.assistantMessages.lastIndex].toMutableList().apply {
-                this[platformIndex] = MessageV2(chatId = chatRoomId, content = "", platformType = platformWithChatModel.uid)
+            updateAssistantSlot(
+                groupedMessages = it,
+                turnIndex = turnIndex,
+                platformIndex = platformIndex
+            ) {
+                createEmptyAssistantMessage(chatRoomId, platformWithChatModel.uid)
             }
-            it.copy(assistantMessages = updatedAssistantMessages)
         }
 
         viewModelScope.launch {
@@ -223,6 +226,7 @@ class ChatViewModel @Inject constructor(
                 platformWithChatModel
             ).handleStates(
                 messageFlow = _groupedMessages,
+                turnIndex = turnIndex,
                 platformIdx = platformIndex,
                 onLoadingComplete = {
                     _loadingStates.update { it.toMutableList().apply { this[platformIndex] = LoadingState.Idle } }
@@ -365,6 +369,7 @@ class ChatViewModel @Inject constructor(
     private fun completeChat() {
         // Update all the platform loading states to Loading
         _loadingStates.update { List(enabledPlatformsInChat.size) { LoadingState.Loading } }
+        val turnIndex = _groupedMessages.value.assistantMessages.lastIndex
 
         // Send chat completion requests
         enabledPlatformsInChat.forEachIndexed { idx, platformUid ->
@@ -377,6 +382,7 @@ class ChatViewModel @Inject constructor(
                     platformWithChatModel
                 ).handleStates(
                     messageFlow = _groupedMessages,
+                    turnIndex = turnIndex,
                     platformIdx = idx,
                     onLoadingComplete = {
                         _loadingStates.update { it.toMutableList().apply { this[idx] = LoadingState.Idle } }
@@ -554,7 +560,6 @@ class ChatViewModel @Inject constructor(
 
     private suspend fun fetchGroupedMessages(chatId: Int): GroupedMessages {
         val messages = chatRepository.fetchMessagesV2(chatId).sortedBy { it.createdAt }
-        val platformOrderMap = enabledPlatformsInChat.withIndex().associate { (idx, uuid) -> uuid to idx }
 
         val userMessages = mutableListOf<MessageV2>()
         val assistantMessages = mutableListOf<MutableList<MessageV2>>()
@@ -568,16 +573,15 @@ class ChatViewModel @Inject constructor(
             }
         }
 
-        val sortedAssistantMessages = assistantMessages.map { assistantMessage ->
-            assistantMessage.sortedWith(
-                compareBy(
-                    { platformOrderMap[it.platformType] ?: Int.MAX_VALUE },
-                    { it.platformType }
-                )
+        val normalizedAssistantMessages = assistantMessages.map { assistantMessage ->
+            normalizeAssistantRow(
+                assistantMessages = assistantMessage,
+                enabledPlatformsInChat = enabledPlatformsInChat,
+                chatId = chatId
             )
         }
 
-        return GroupedMessages(userMessages, sortedAssistantMessages)
+        return GroupedMessages(userMessages, normalizedAssistantMessages)
     }
 
     private fun fetchChatRoom() {
@@ -658,4 +662,57 @@ class ChatViewModel @Inject constructor(
         val merged = _groupedMessages.value.userMessages + _groupedMessages.value.assistantMessages.flatten()
         return merged.filter { it.content.isNotBlank() }.sortedBy { it.createdAt }
     }
+}
+
+internal fun createEmptyAssistantMessage(chatId: Int, platformUid: String): MessageV2 = MessageV2(
+    chatId = chatId,
+    content = "",
+    platformType = platformUid
+)
+
+internal fun normalizeAssistantRow(
+    assistantMessages: List<MessageV2>,
+    enabledPlatformsInChat: List<String>,
+    chatId: Int
+): List<MessageV2> {
+    if (enabledPlatformsInChat.isEmpty()) return assistantMessages
+
+    val consumedIndexes = mutableSetOf<Int>()
+    val normalizedMessages = enabledPlatformsInChat.map { platformUid ->
+        val matchedIndex = assistantMessages.indices.firstOrNull { index ->
+            index !in consumedIndexes && assistantMessages[index].platformType == platformUid
+        }
+
+        if (matchedIndex == null) {
+            createEmptyAssistantMessage(chatId, platformUid)
+        } else {
+            consumedIndexes += matchedIndex
+            assistantMessages[matchedIndex]
+        }
+    }
+    val overflowMessages = assistantMessages.filterIndexed { index, _ -> index !in consumedIndexes }
+
+    return normalizedMessages + overflowMessages
+}
+
+internal fun updateAssistantSlot(
+    groupedMessages: ChatViewModel.GroupedMessages,
+    turnIndex: Int,
+    platformIndex: Int,
+    transform: (MessageV2) -> MessageV2
+): ChatViewModel.GroupedMessages {
+    if (turnIndex !in groupedMessages.assistantMessages.indices) return groupedMessages
+
+    val currentTurnMessages = groupedMessages.assistantMessages[turnIndex]
+    if (platformIndex !in currentTurnMessages.indices) return groupedMessages
+
+    val updatedTurnMessages = currentTurnMessages.toMutableList()
+    val updatedMessage = transform(updatedTurnMessages[platformIndex])
+    if (updatedMessage == updatedTurnMessages[platformIndex]) return groupedMessages
+
+    updatedTurnMessages[platformIndex] = updatedMessage
+    val assistantMessages = groupedMessages.assistantMessages.toMutableList()
+    assistantMessages[turnIndex] = updatedTurnMessages
+
+    return groupedMessages.copy(assistantMessages = assistantMessages)
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModel.kt
@@ -14,7 +14,6 @@ import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoomV2
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
 import dev.chungjungsoo.gptmobile.data.database.entity.effectiveContent
-import dev.chungjungsoo.gptmobile.data.database.entity.effectiveThoughts
 import dev.chungjungsoo.gptmobile.data.database.entity.resetActiveRevision
 import dev.chungjungsoo.gptmobile.data.database.entity.selectRevision
 import dev.chungjungsoo.gptmobile.data.database.entity.snapshotLatestAssistantRevision
@@ -324,7 +323,8 @@ class ChatViewModel @Inject constructor(
         addDraftFile(
             currentAttachments = { _messageEditSession.value?.attachments.orEmpty() },
             updateAttachments = ::updateMessageEditAttachments,
-            filePath = filePath
+            filePath = filePath,
+            onNotice = { notice -> _attachmentNotice.update { notice } }
         )
     }
 
@@ -347,16 +347,25 @@ class ChatViewModel @Inject constructor(
         _attachmentNotice.update { null }
     }
 
+    fun notifyAttachmentCopyFailed() {
+        _attachmentNotice.update { "Failed to copy attachment." }
+    }
+
     fun saveUserMessageEdit(
         editedMessage: MessageV2,
         attachments: List<ChatAttachmentDraft>
-    ) {
+    ): Boolean {
+        if (attachments.any { it.status != ChatAttachmentDraft.Status.Ready }) {
+            _attachmentNotice.update { "Wait for attachments to finish processing before saving." }
+            return false
+        }
+
         val userMessages = _groupedMessages.value.userMessages
         val assistantMessages = _groupedMessages.value.assistantMessages
 
         // Find the index of the message being edited
         val messageIndex = userMessages.indexOfFirst { it.id == editedMessage.id }
-        if (messageIndex == -1) return
+        if (messageIndex == -1) return false
 
         // Update the message content
         val updatedUserMessages = userMessages.toMutableList()
@@ -396,20 +405,26 @@ class ChatViewModel @Inject constructor(
 
         // Start new conversation from the edited question
         completeChat()
+        return true
     }
 
     fun saveAssistantMessageEdit(
         editedMessage: MessageV2,
         thoughts: String,
         attachments: List<ChatAttachmentDraft>
-    ) {
-        val session = _messageEditSession.value ?: return
-        val turnIndex = session.turnIndex ?: return
-        val platformIndex = session.platformIndex ?: return
+    ): Boolean {
+        if (attachments.any { it.status != ChatAttachmentDraft.Status.Ready }) {
+            _attachmentNotice.update { "Wait for attachments to finish processing before saving." }
+            return false
+        }
+
+        val session = _messageEditSession.value ?: return false
+        val turnIndex = session.turnIndex ?: return false
+        val platformIndex = session.platformIndex ?: return false
         val currentMessage = _groupedMessages.value.assistantMessages
             .getOrNull(turnIndex)
             ?.getOrNull(platformIndex)
-            ?: return
+            ?: return false
 
         val updatedContent = editedMessage.content
         val updatedThoughts = thoughts
@@ -439,6 +454,7 @@ class ChatViewModel @Inject constructor(
                 ).resetActiveRevision()
             }
         }
+        return true
     }
 
     fun showPreviousAssistantRevision(turnIndex: Int, platformIndex: Int) {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModel.kt
@@ -9,9 +9,15 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.chungjungsoo.gptmobile.data.database.entity.ACTIVE_REVISION_LATEST
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoomV2
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
+import dev.chungjungsoo.gptmobile.data.database.entity.effectiveContent
+import dev.chungjungsoo.gptmobile.data.database.entity.effectiveThoughts
+import dev.chungjungsoo.gptmobile.data.database.entity.resetActiveRevision
+import dev.chungjungsoo.gptmobile.data.database.entity.selectRevision
+import dev.chungjungsoo.gptmobile.data.database.entity.snapshotLatestAssistantRevision
 import dev.chungjungsoo.gptmobile.data.repository.AttachmentUploadCoordinator
 import dev.chungjungsoo.gptmobile.data.repository.ChatRepository
 import dev.chungjungsoo.gptmobile.data.repository.SettingRepository
@@ -45,6 +51,19 @@ class ChatViewModel @Inject constructor(
         val assistantMessages: List<List<MessageV2>> = listOf()
     )
 
+    enum class MessageEditRole {
+        USER,
+        ASSISTANT
+    }
+
+    data class MessageEditSession(
+        val message: MessageV2,
+        val role: MessageEditRole,
+        val turnIndex: Int? = null,
+        val platformIndex: Int? = null,
+        val attachments: List<ChatAttachmentDraft> = emptyList()
+    )
+
     private val chatRoomId: Int = checkNotNull(savedStateHandle["chatRoomId"])
     private val enabledPlatformString: String = checkNotNull(savedStateHandle["enabledPlatforms"])
     val enabledPlatformsInChat = enabledPlatformString.split(',')
@@ -58,8 +77,8 @@ class ChatViewModel @Inject constructor(
     private val _isChatTitleDialogOpen = MutableStateFlow(false)
     val isChatTitleDialogOpen = _isChatTitleDialogOpen.asStateFlow()
 
-    private val _isEditQuestionDialogOpen = MutableStateFlow(false)
-    val isEditQuestionDialogOpen = _isEditQuestionDialogOpen.asStateFlow()
+    private val _messageEditSession = MutableStateFlow<MessageEditSession?>(null)
+    val messageEditSession = _messageEditSession.asStateFlow()
 
     private val _isSelectTextSheetOpen = MutableStateFlow(false)
     val isSelectTextSheetOpen = _isSelectTextSheetOpen.asStateFlow()
@@ -100,10 +119,6 @@ class ChatViewModel @Inject constructor(
     // Loading states for each platform
     private val _loadingStates = MutableStateFlow(List<LoadingState>(enabledPlatformsInChat.size) { LoadingState.Idle })
     val loadingStates = _loadingStates.asStateFlow()
-
-    // Used for passing user question to Edit User Message Dialog
-    private val _editedQuestion = MutableStateFlow(MessageV2(chatId = chatRoomId, content = "", platformType = null))
-    val editedQuestion = _editedQuestion.asStateFlow()
 
     // Used for text data to show in SelectText Bottom Sheet
     private val _selectedText = MutableStateFlow("")
@@ -162,9 +177,18 @@ class ChatViewModel @Inject constructor(
 
     fun closeChatTitleDialog() = _isChatTitleDialogOpen.update { false }
 
-    fun closeEditQuestionDialog() {
-        _editedQuestion.update { MessageV2(chatId = chatRoomId, content = "", platformType = null) }
-        _isEditQuestionDialogOpen.update { false }
+    fun discardMessageEditDialog() {
+        _messageEditSession.value?.attachments?.forEach { attachment ->
+            if (attachment.cleanupOnDiscard) {
+                attachment.preparedFilePath?.let { AttachmentPayloadCache.remove(it) }
+                deleteDraftFiles(attachment)
+            }
+        }
+        _messageEditSession.update { null }
+    }
+
+    fun finishMessageEditDialog() {
+        _messageEditSession.update { null }
     }
 
     fun closeSelectTextSheet() {
@@ -177,9 +201,30 @@ class ChatViewModel @Inject constructor(
     fun openChatTitleDialog() = _isChatTitleDialogOpen.update { true }
     fun openChatModelDialog() = _isChatModelDialogOpen.update { true }
 
-    fun openEditQuestionDialog(question: MessageV2) {
-        _editedQuestion.update { question }
-        _isEditQuestionDialogOpen.update { true }
+    fun openUserMessageEditDialog(question: MessageV2) {
+        _messageEditSession.update {
+            MessageEditSession(
+                message = question,
+                role = MessageEditRole.USER,
+                attachments = question.attachments.map(ChatAttachmentDraft::fromAttachment)
+            )
+        }
+    }
+
+    fun openAssistantMessageEditDialog(turnIndex: Int, platformIndex: Int) {
+        val assistantMessage = _groupedMessages.value.assistantMessages
+            .getOrNull(turnIndex)
+            ?.getOrNull(platformIndex)
+            ?: return
+        _messageEditSession.update {
+            MessageEditSession(
+                message = assistantMessage,
+                role = MessageEditRole.ASSISTANT,
+                turnIndex = turnIndex,
+                platformIndex = platformIndex,
+                attachments = assistantMessage.attachments.map(ChatAttachmentDraft::fromAttachment)
+            )
+        }
     }
 
     fun openSelectTextSheet(content: String) {
@@ -258,24 +303,37 @@ class ChatViewModel @Inject constructor(
     }
 
     fun addSelectedFile(filePath: String) {
-        if (_selectedAttachments.value.any { it.sourceFilePath == filePath }) {
-            return
-        }
-
-        _selectedAttachments.update { currentFiles ->
-            currentFiles + ChatAttachmentDraft(sourceFilePath = filePath)
-        }
-        preprocessAttachment(filePath)
+        addDraftFile(
+            currentAttachments = { _selectedAttachments.value },
+            updateAttachments = { attachments -> _selectedAttachments.update { attachments } },
+            filePath = filePath,
+            onNotice = { notice -> _attachmentNotice.update { notice } }
+        )
     }
 
     fun removeSelectedFile(filePath: String) {
-        val removedAttachment = _selectedAttachments.value.firstOrNull { it.sourceFilePath == filePath }
-        removedAttachment?.preparedFilePath?.let { AttachmentPayloadCache.remove(it) }
-        removedAttachment?.let(::deleteDraftFiles)
-        _selectedAttachments.update { currentFiles ->
-            currentFiles.filter { it.sourceFilePath != filePath }
-        }
+        removeDraftFile(
+            currentAttachments = { _selectedAttachments.value },
+            updateAttachments = { attachments -> _selectedAttachments.update { attachments } },
+            filePath = filePath
+        )
         trySendPendingQuestionIfReady()
+    }
+
+    fun addMessageEditFile(filePath: String) {
+        addDraftFile(
+            currentAttachments = { _messageEditSession.value?.attachments.orEmpty() },
+            updateAttachments = ::updateMessageEditAttachments,
+            filePath = filePath
+        )
+    }
+
+    fun removeMessageEditFile(filePath: String) {
+        removeDraftFile(
+            currentAttachments = { _messageEditSession.value?.attachments.orEmpty() },
+            updateAttachments = ::updateMessageEditAttachments,
+            filePath = filePath
+        )
     }
 
     fun clearSelectedFiles() {
@@ -289,7 +347,10 @@ class ChatViewModel @Inject constructor(
         _attachmentNotice.update { null }
     }
 
-    fun editQuestion(editedMessage: MessageV2) {
+    fun saveUserMessageEdit(
+        editedMessage: MessageV2,
+        attachments: List<ChatAttachmentDraft>
+    ) {
         val userMessages = _groupedMessages.value.userMessages
         val assistantMessages = _groupedMessages.value.assistantMessages
 
@@ -299,7 +360,10 @@ class ChatViewModel @Inject constructor(
 
         // Update the message content
         val updatedUserMessages = userMessages.toMutableList()
-        updatedUserMessages[messageIndex] = editedMessage.copy(createdAt = currentTimeStamp)
+        updatedUserMessages[messageIndex] = editedMessage.copy(
+            attachments = attachments.mapNotNull { it.attachment },
+            createdAt = currentTimeStamp
+        )
 
         // Remove all messages after the edited question (both user and assistant messages)
         val remainingUserMessages = updatedUserMessages.take(messageIndex + 1)
@@ -334,6 +398,70 @@ class ChatViewModel @Inject constructor(
         completeChat()
     }
 
+    fun saveAssistantMessageEdit(
+        editedMessage: MessageV2,
+        thoughts: String,
+        attachments: List<ChatAttachmentDraft>
+    ) {
+        val session = _messageEditSession.value ?: return
+        val turnIndex = session.turnIndex ?: return
+        val platformIndex = session.platformIndex ?: return
+        val currentMessage = _groupedMessages.value.assistantMessages
+            .getOrNull(turnIndex)
+            ?.getOrNull(platformIndex)
+            ?: return
+
+        val updatedContent = editedMessage.content
+        val updatedThoughts = thoughts
+        val updatedAttachments = attachments.mapNotNull { it.attachment }
+
+        val textChanged = currentMessage.content != updatedContent || currentMessage.thoughts != updatedThoughts
+        val updatedRevisions = if (textChanged) {
+            currentMessage.snapshotLatestAssistantRevision(currentTimeStamp)
+                ?.let { listOf(it) + currentMessage.revisions }
+                ?: currentMessage.revisions
+        } else {
+            currentMessage.revisions
+        }
+
+        _groupedMessages.update {
+            updateAssistantSlot(
+                groupedMessages = it,
+                turnIndex = turnIndex,
+                platformIndex = platformIndex
+            ) { assistantMessage ->
+                assistantMessage.copy(
+                    content = updatedContent,
+                    thoughts = updatedThoughts,
+                    attachments = updatedAttachments,
+                    revisions = updatedRevisions,
+                    createdAt = assistantMessage.createdAt
+                ).resetActiveRevision()
+            }
+        }
+    }
+
+    fun showPreviousAssistantRevision(turnIndex: Int, platformIndex: Int) {
+        updateAssistantRevisionSelection(turnIndex, platformIndex) { message ->
+            when {
+                message.revisions.isEmpty() -> message.activeRevisionIndex
+                message.activeRevisionIndex == ACTIVE_REVISION_LATEST -> 0
+                message.activeRevisionIndex < message.revisions.lastIndex -> message.activeRevisionIndex + 1
+                else -> message.activeRevisionIndex
+            }
+        }
+    }
+
+    fun showNextAssistantRevision(turnIndex: Int, platformIndex: Int) {
+        updateAssistantRevisionSelection(turnIndex, platformIndex) { message ->
+            when {
+                message.activeRevisionIndex == ACTIVE_REVISION_LATEST -> ACTIVE_REVISION_LATEST
+                message.activeRevisionIndex == 0 -> ACTIVE_REVISION_LATEST
+                else -> message.activeRevisionIndex - 1
+            }
+        }
+    }
+
     fun exportChat(): Pair<String, String> {
         // Build the chat history in Markdown format
         val chatHistoryMarkdown = buildString {
@@ -355,7 +483,7 @@ class ChatViewModel @Inject constructor(
                         ?.let { _platformsInApp.value.getPlatformName(it) }
                         ?: "Unknown"
                     appendLine("**Assistant ($platformName):**")
-                    appendLine(message.content)
+                    appendLine(message.effectiveContent())
                     appendLine()
                 }
             }
@@ -392,14 +520,60 @@ class ChatViewModel @Inject constructor(
         }
     }
 
-    private fun preprocessAttachment(filePath: String) {
+    private fun updateMessageEditAttachments(attachments: List<ChatAttachmentDraft>) {
+        _messageEditSession.update { session ->
+            session?.copy(attachments = attachments)
+        }
+    }
+
+    private fun addDraftFile(
+        currentAttachments: () -> List<ChatAttachmentDraft>,
+        updateAttachments: (List<ChatAttachmentDraft>) -> Unit,
+        filePath: String,
+        onNotice: (String?) -> Unit = {}
+    ) {
+        if (currentAttachments().any { it.sourceFilePath == filePath }) return
+
+        updateAttachments(currentAttachments() + ChatAttachmentDraft(sourceFilePath = filePath))
+        preprocessDraftAttachment(
+            currentAttachments = currentAttachments,
+            updateAttachments = updateAttachments,
+            filePath = filePath,
+            onNotice = onNotice
+        )
+    }
+
+    private fun removeDraftFile(
+        currentAttachments: () -> List<ChatAttachmentDraft>,
+        updateAttachments: (List<ChatAttachmentDraft>) -> Unit,
+        filePath: String
+    ) {
+        val removedAttachment = currentAttachments().firstOrNull { it.sourceFilePath == filePath }
+        removedAttachment?.preparedFilePath?.let { AttachmentPayloadCache.remove(it) }
+        if (removedAttachment?.cleanupOnDiscard == true) {
+            removedAttachment.let(::deleteDraftFiles)
+        }
+        updateAttachments(currentAttachments().filter { it.sourceFilePath != filePath })
+    }
+
+    private fun preprocessDraftAttachment(
+        currentAttachments: () -> List<ChatAttachmentDraft>,
+        updateAttachments: (List<ChatAttachmentDraft>) -> Unit,
+        filePath: String,
+        onNotice: (String?) -> Unit = {}
+    ) {
         viewModelScope.launch {
             val mimeType = withContext(Dispatchers.IO) {
                 FileUtils.getMimeType(context, filePath)
             }
 
             if (!FileUtils.isSupportedUploadMimeType(mimeType)) {
-                rejectAttachment(filePath, "Only image attachments are currently supported.")
+                rejectDraftAttachment(
+                    currentAttachments = currentAttachments,
+                    updateAttachments = updateAttachments,
+                    filePath = filePath,
+                    notice = "Only image attachments are currently supported."
+                )
                 trySendPendingQuestionIfReady()
                 return@launch
             }
@@ -409,19 +583,29 @@ class ChatViewModel @Inject constructor(
             }
 
             if (fileSize > FileUtils.MAX_UPLOAD_SIZE_BYTES) {
-                rejectAttachment(filePath, "Files larger than 50 MB cannot be attached.")
+                rejectDraftAttachment(
+                    currentAttachments = currentAttachments,
+                    updateAttachments = updateAttachments,
+                    filePath = filePath,
+                    notice = "Files larger than 50 MB cannot be attached."
+                )
                 trySendPendingQuestionIfReady()
                 return@launch
             }
 
             val currentDraftBytes = withContext(Dispatchers.IO) {
-                _selectedAttachments.value
+                currentAttachments()
                     .filter { it.sourceFilePath != filePath }
                     .sumOf { FileUtils.getFileSize(context, it.sourceFilePath).coerceAtLeast(0L) }
             }
 
             if (FileUtils.wouldExceedTotalUploadLimit(currentDraftBytes, fileSize)) {
-                rejectAttachment(filePath, "Total attachments cannot exceed 50 MB.")
+                rejectDraftAttachment(
+                    currentAttachments = currentAttachments,
+                    updateAttachments = updateAttachments,
+                    filePath = filePath,
+                    notice = "Total attachments cannot exceed 50 MB."
+                )
                 trySendPendingQuestionIfReady()
                 return@launch
             }
@@ -430,15 +614,15 @@ class ChatViewModel @Inject constructor(
                 attachmentUploadCoordinator.prepareLocalAttachment(context, filePath)
             }
 
-            if (_selectedAttachments.value.none { it.sourceFilePath == filePath }) {
+            if (currentAttachments().none { it.sourceFilePath == filePath }) {
                 if (preparationResult != null && preparationResult.preparedFilePath != filePath) {
                     java.io.File(preparationResult.preparedFilePath).delete()
                 }
                 return@launch
             }
 
-            _selectedAttachments.update { attachments ->
-                attachments.map { attachment ->
+            updateAttachments(
+                currentAttachments().map { attachment ->
                     if (attachment.sourceFilePath != filePath) {
                         attachment
                     } else if (preparationResult == null) {
@@ -452,6 +636,7 @@ class ChatViewModel @Inject constructor(
                             preparedFilePath = preparationResult.preparedFilePath,
                             mimeType = preparationResult.mimeType,
                             status = ChatAttachmentDraft.Status.Ready,
+                            cleanupOnDiscard = true,
                             notice = if (preparationResult.wasResized) {
                                 "Large images are resized before upload."
                             } else {
@@ -461,12 +646,12 @@ class ChatViewModel @Inject constructor(
                         )
                     }
                 }
-            }
+            )
 
             if (preparationResult?.wasResized == true) {
-                _attachmentNotice.update { "Large images are resized before upload." }
+                onNotice("Large images are resized before upload.")
             } else if (preparationResult == null) {
-                _attachmentNotice.update { "Failed to prepare attachment." }
+                onNotice("Failed to prepare attachment.")
             }
 
             trySendPendingQuestionIfReady()
@@ -511,13 +696,18 @@ class ChatViewModel @Inject constructor(
         completeChat()
     }
 
-    private fun rejectAttachment(filePath: String, notice: String) {
-        val rejectedAttachment = _selectedAttachments.value.firstOrNull { it.sourceFilePath == filePath }
+    private fun rejectDraftAttachment(
+        currentAttachments: () -> List<ChatAttachmentDraft>,
+        updateAttachments: (List<ChatAttachmentDraft>) -> Unit,
+        filePath: String,
+        notice: String
+    ) {
+        val rejectedAttachment = currentAttachments().firstOrNull { it.sourceFilePath == filePath }
         rejectedAttachment?.preparedFilePath?.let { AttachmentPayloadCache.remove(it) }
-        rejectedAttachment?.let(::deleteDraftFiles)
-        _selectedAttachments.update { attachments ->
-            attachments.filter { it.sourceFilePath != filePath }
+        if (rejectedAttachment?.cleanupOnDiscard == true) {
+            rejectedAttachment.let(::deleteDraftFiles)
         }
+        updateAttachments(currentAttachments().filter { it.sourceFilePath != filePath })
         _attachmentNotice.update { notice }
     }
 
@@ -527,10 +717,27 @@ class ChatViewModel @Inject constructor(
     }
 
     private fun deleteDraftFiles(attachment: ChatAttachmentDraft) {
+        if (!attachment.cleanupOnDiscard) return
         java.io.File(attachment.sourceFilePath).delete()
         attachment.preparedFilePath
             ?.takeIf { it != attachment.sourceFilePath }
             ?.let { java.io.File(it).delete() }
+    }
+
+    private fun updateAssistantRevisionSelection(
+        turnIndex: Int,
+        platformIndex: Int,
+        nextIndex: (MessageV2) -> Int
+    ) {
+        _groupedMessages.update {
+            updateAssistantSlot(
+                groupedMessages = it,
+                turnIndex = turnIndex,
+                platformIndex = platformIndex
+            ) { message ->
+                message.selectRevision(nextIndex(message))
+            }
+        }
     }
 
     private fun formatCurrentDateTime(): String {
@@ -660,7 +867,7 @@ class ChatViewModel @Inject constructor(
     private fun ungroupedMessages(): List<MessageV2> {
         // Flatten the grouped messages into a single list
         val merged = _groupedMessages.value.userMessages + _groupedMessages.value.assistantMessages.flatten()
-        return merged.filter { it.content.isNotBlank() }.sortedBy { it.createdAt }
+        return merged.filter { it.effectiveContent().isNotBlank() || it.attachments.isNotEmpty() }.sortedBy { it.createdAt }
     }
 }
 

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensions.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensions.kt
@@ -2,6 +2,7 @@ package dev.chungjungsoo.gptmobile.util
 
 import dev.chungjungsoo.gptmobile.data.dto.ApiState
 import dev.chungjungsoo.gptmobile.presentation.ui.chat.ChatViewModel
+import dev.chungjungsoo.gptmobile.presentation.ui.chat.updateAssistantSlot
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
@@ -11,6 +12,7 @@ private const val STREAM_PUBLISH_INTERVAL_MILLIS = 50L
 
 suspend fun Flow<ApiState>.handleStates(
     messageFlow: MutableStateFlow<ChatViewModel.GroupedMessages>,
+    turnIndex: Int,
     platformIdx: Int,
     onLoadingComplete: () -> Unit,
     nanoTimeProvider: () -> Long = System::nanoTime
@@ -24,12 +26,12 @@ suspend fun Flow<ApiState>.handleStates(
             when (chunk) {
                 is ApiState.Thinking -> {
                     buffer.appendThought(chunk.thinkingChunk)
-                    buffer.publishIfDue(messageFlow, platformIdx)
+                    buffer.publishIfDue(messageFlow, turnIndex, platformIdx)
                 }
 
                 is ApiState.Success -> {
                     buffer.appendContent(chunk.textChunk)
-                    buffer.publishIfDue(messageFlow, platformIdx)
+                    buffer.publishIfDue(messageFlow, turnIndex, platformIdx)
                 }
 
                 ApiState.Done -> {
@@ -44,10 +46,10 @@ suspend fun Flow<ApiState>.handleStates(
             }
         }
     } finally {
-        buffer.flush(messageFlow, platformIdx)
+        buffer.flush(messageFlow, turnIndex, platformIdx)
         when {
-            terminalError != null -> messageFlow.setErrorMessage(platformIdx, terminalError)
-            isCompletedSuccessfully -> messageFlow.setTimestamp(platformIdx)
+            terminalError != null -> messageFlow.setErrorMessage(turnIndex, platformIdx, terminalError)
+            isCompletedSuccessfully -> messageFlow.setTimestamp(turnIndex, platformIdx)
         }
         onLoadingComplete()
     }
@@ -76,6 +78,7 @@ private class StreamingMessageBuffer(
 
     fun publishIfDue(
         messageFlow: MutableStateFlow<ChatViewModel.GroupedMessages>,
+        turnIndex: Int,
         platformIdx: Int
     ) {
         if (!hasPendingChanges()) return
@@ -84,24 +87,27 @@ private class StreamingMessageBuffer(
         if (lastPublishedAtNanos == 0L ||
             now - lastPublishedAtNanos >= STREAM_PUBLISH_INTERVAL_MILLIS * 1_000_000
         ) {
-            publish(messageFlow, platformIdx, now)
+            publish(messageFlow, turnIndex, platformIdx, now)
         }
     }
 
     fun flush(
         messageFlow: MutableStateFlow<ChatViewModel.GroupedMessages>,
+        turnIndex: Int,
         platformIdx: Int
     ) {
         if (!hasPendingChanges()) return
-        publish(messageFlow, platformIdx, nanoTimeProvider())
+        publish(messageFlow, turnIndex, platformIdx, nanoTimeProvider())
     }
 
     private fun publish(
         messageFlow: MutableStateFlow<ChatViewModel.GroupedMessages>,
+        turnIndex: Int,
         platformIdx: Int,
         publishedAtNanos: Long
     ) {
         messageFlow.setBufferedText(
+            turnIndex = turnIndex,
             platformIdx = platformIdx,
             content = content.toString(),
             thoughts = thoughts.toString()
@@ -115,38 +121,45 @@ private class StreamingMessageBuffer(
 }
 
 private fun MutableStateFlow<ChatViewModel.GroupedMessages>.setBufferedText(
+    turnIndex: Int,
     platformIdx: Int,
     content: String,
     thoughts: String
 ) {
     update { groupedMessages ->
-        val updatedMessages = groupedMessages.assistantMessages.last().toMutableList()
-        val currentMessage = updatedMessages[platformIdx]
-        if (currentMessage.content == content && currentMessage.thoughts == thoughts) {
-            return@update groupedMessages
+        updateAssistantSlot(
+            groupedMessages = groupedMessages,
+            turnIndex = turnIndex,
+            platformIndex = platformIdx
+        ) { currentMessage ->
+            if (currentMessage.content == content && currentMessage.thoughts == thoughts) {
+                currentMessage
+            } else {
+                currentMessage.copy(
+                    content = content,
+                    thoughts = thoughts
+                )
+            }
         }
-        updatedMessages[platformIdx] = currentMessage.copy(
-            content = content,
-            thoughts = thoughts
-        )
-        val assistantMessages = groupedMessages.assistantMessages.toMutableList()
-        assistantMessages[assistantMessages.lastIndex] = updatedMessages
-
-        groupedMessages.copy(assistantMessages = assistantMessages)
     }
 }
 
-private fun MutableStateFlow<ChatViewModel.GroupedMessages>.setErrorMessage(platformIdx: Int, error: String) {
+private fun MutableStateFlow<ChatViewModel.GroupedMessages>.setErrorMessage(
+    turnIndex: Int,
+    platformIdx: Int,
+    error: String
+) {
     update { groupedMessages ->
-        val updatedMessages = groupedMessages.assistantMessages.last().toMutableList()
-        updatedMessages[platformIdx] = updatedMessages[platformIdx].copy(
-            content = buildAssistantErrorContent(updatedMessages[platformIdx].content, error),
-            createdAt = System.currentTimeMillis() / 1000
-        )
-        val assistantMessages = groupedMessages.assistantMessages.toMutableList()
-        assistantMessages[assistantMessages.lastIndex] = updatedMessages
-
-        groupedMessages.copy(assistantMessages = assistantMessages)
+        updateAssistantSlot(
+            groupedMessages = groupedMessages,
+            turnIndex = turnIndex,
+            platformIndex = platformIdx
+        ) { currentMessage ->
+            currentMessage.copy(
+                content = buildAssistantErrorContent(currentMessage.content, error),
+                createdAt = System.currentTimeMillis() / 1000
+            )
+        }
     }
 }
 
@@ -164,15 +177,14 @@ internal fun stripAssistantErrorNote(content: String): String {
     }
 }
 
-private fun MutableStateFlow<ChatViewModel.GroupedMessages>.setTimestamp(platformIdx: Int) {
+private fun MutableStateFlow<ChatViewModel.GroupedMessages>.setTimestamp(turnIndex: Int, platformIdx: Int) {
     update { groupedMessages ->
-        val updatedMessages = groupedMessages.assistantMessages.last().toMutableList()
-        updatedMessages[platformIdx] = updatedMessages[platformIdx].copy(
-            createdAt = System.currentTimeMillis() / 1000
-        )
-        val assistantMessages = groupedMessages.assistantMessages.toMutableList()
-        assistantMessages[assistantMessages.lastIndex] = updatedMessages
-
-        groupedMessages.copy(assistantMessages = assistantMessages)
+        updateAssistantSlot(
+            groupedMessages = groupedMessages,
+            turnIndex = turnIndex,
+            platformIndex = platformIdx
+        ) { currentMessage ->
+            currentMessage.copy(createdAt = System.currentTimeMillis() / 1000)
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,7 +204,10 @@
     <string name="token_input_warning">NOTE: OpenAI and Anthropic uses prepaid billing, so you MUST CHARGE CREDITS in each accounts before you use them. Otherwise, the response will return an error.</string>
     <string name="edit">Edit</string>
     <string name="edit_question">Edit User Message</string>
+    <string name="edit_assistant_message">Edit Assistant Message</string>
     <string name="user_message">User Message</string>
+    <string name="assistant_message">Assistant Message</string>
+    <string name="assistant_thoughts">Assistant Thoughts</string>
     <string name="export_chat">Export Chat</string>
     <string name="migration_assistant">Migration Assistant</string>
     <string name="migration_description">The migration assistant will guide you to smoothly migrate to the upgraded database and data structures for the renewed version. Please follow the steps below.</string>
@@ -280,4 +283,6 @@
     <string name="platform_added_successfully">Platform added successfully</string>
     <string name="at_least_one_platform_required">Add at least one platform to continue</string>
     <string name="remove">Remove</string>
+    <string name="latest_revision">Latest</string>
+    <string name="revision_counter">Revision %1$d/%2$d</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -285,4 +285,6 @@
     <string name="remove">Remove</string>
     <string name="latest_revision">Latest</string>
     <string name="revision_counter">Revision %1$d/%2$d</string>
+    <string name="previous_revision" translatable="false">Previous revision</string>
+    <string name="next_revision" translatable="false">Next revision</string>
 </resources>

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2MigrationsTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2MigrationsTest.kt
@@ -1,5 +1,6 @@
 package dev.chungjungsoo.gptmobile.data.database
 
+import dev.chungjungsoo.gptmobile.data.database.entity.AssistantRevisionListConverter
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatAttachmentListConverter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -18,5 +19,21 @@ class ChatDatabaseV2MigrationsTest {
         assertEquals("first.png", attachments[0].resolvedDisplayName)
         assertTrue(attachments[0].providerRefs.isEmpty())
         assertEquals("/tmp/second.webp", attachments[1].localFilePath)
+    }
+
+    @Test
+    fun `legacy revision list migrates to structured revisions`() {
+        val json = ChatDatabaseV2Migrations.legacyRevisionsToStructuredJson(
+            revisionsValue = "first revision,second revision",
+            createdAt = 1234L
+        )
+
+        val revisions = AssistantRevisionListConverter().fromString(json)
+
+        assertEquals(2, revisions.size)
+        assertEquals("first revision", revisions[0].content)
+        assertEquals("", revisions[0].thoughts)
+        assertEquals(1234L, revisions[0].createdAt)
+        assertEquals("second revision", revisions[1].content)
     }
 }

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModelRetryTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModelRetryTest.kt
@@ -7,6 +7,8 @@ import dev.chungjungsoo.gptmobile.data.database.entity.effectiveContent
 import dev.chungjungsoo.gptmobile.data.database.entity.effectiveThoughts
 import dev.chungjungsoo.gptmobile.data.database.entity.resetActiveRevision
 import dev.chungjungsoo.gptmobile.data.database.entity.selectRevision
+import dev.chungjungsoo.gptmobile.data.model.ChatAttachment
+import dev.chungjungsoo.gptmobile.data.repository.hasSendableAssistantPayload
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -127,5 +129,37 @@ class ChatViewModelRetryTest {
 
         assertEquals(0, assistantMessage.selectRevision(0).activeRevisionIndex)
         assertEquals(ACTIVE_REVISION_LATEST, assistantMessage.selectRevision(9).activeRevisionIndex)
+    }
+
+    @Test
+    fun `sendable assistant payload ignores synthetic error only content`() {
+        val errorOnlyMessage = MessageV2(
+            chatId = 5,
+            content = "Error: Request timed out.",
+            platformType = "platform-1"
+        )
+        val partialErrorMessage = MessageV2(
+            chatId = 5,
+            content = "Partial answer\n\n[Response stopped: Request timed out.]",
+            platformType = "platform-1"
+        )
+        val attachmentOnlyMessage = MessageV2(
+            chatId = 5,
+            content = "Error: Request timed out.",
+            attachments = listOf(
+                ChatAttachment(
+                    localFilePath = "/tmp/image.png",
+                    preparedFilePath = "/tmp/image.png",
+                    displayName = "image.png",
+                    mimeType = "image/png",
+                    sizeBytes = 12L
+                )
+            ),
+            platformType = "platform-1"
+        )
+
+        assertEquals(false, errorOnlyMessage.hasSendableAssistantPayload())
+        assertEquals(true, partialErrorMessage.hasSendableAssistantPayload())
+        assertEquals(true, attachmentOnlyMessage.hasSendableAssistantPayload())
     }
 }

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModelRetryTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModelRetryTest.kt
@@ -1,0 +1,87 @@
+package dev.chungjungsoo.gptmobile.presentation.ui.chat
+
+import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatViewModelRetryTest {
+
+    @Test
+    fun `normalizeAssistantRow pads sparse rows and preserves overflow messages`() {
+        val sparseAssistantRow = listOf(
+            MessageV2(chatId = 7, content = "Platform 2 answer", platformType = "platform-2"),
+            MessageV2(chatId = 7, content = "Legacy answer", platformType = "legacy-platform")
+        )
+
+        val normalizedRow = normalizeAssistantRow(
+            assistantMessages = sparseAssistantRow,
+            enabledPlatformsInChat = listOf("platform-1", "platform-2"),
+            chatId = 7
+        )
+
+        assertEquals(3, normalizedRow.size)
+        assertEquals("platform-1", normalizedRow[0].platformType)
+        assertEquals("", normalizedRow[0].content)
+        assertEquals("Platform 2 answer", normalizedRow[1].content)
+        assertEquals("legacy-platform", normalizedRow[2].platformType)
+        assertEquals("Legacy answer", normalizedRow[2].content)
+    }
+
+    @Test
+    fun `updateAssistantSlot only resets the targeted turn and platform`() {
+        val groupedMessages = ChatViewModel.GroupedMessages(
+            userMessages = listOf(
+                MessageV2(chatId = 7, content = "First", platformType = null),
+                MessageV2(chatId = 7, content = "Second", platformType = null)
+            ),
+            assistantMessages = listOf(
+                listOf(
+                    MessageV2(chatId = 7, content = "Keep me", platformType = "platform-1"),
+                    MessageV2(chatId = 7, content = "Keep me too", platformType = "platform-2")
+                ),
+                listOf(
+                    MessageV2(chatId = 7, content = "Other turn", platformType = "platform-1"),
+                    MessageV2(
+                        chatId = 7,
+                        content = "Partial answer\n\n[Response stopped: timeout]",
+                        platformType = "platform-2"
+                    )
+                )
+            )
+        )
+
+        val updatedMessages = updateAssistantSlot(
+            groupedMessages = groupedMessages,
+            turnIndex = 1,
+            platformIndex = 1
+        ) {
+            createEmptyAssistantMessage(chatId = 7, platformUid = "platform-2")
+        }
+
+        assertEquals("Keep me", updatedMessages.assistantMessages[0][0].content)
+        assertEquals("Keep me too", updatedMessages.assistantMessages[0][1].content)
+        assertEquals("Other turn", updatedMessages.assistantMessages[1][0].content)
+        assertEquals("", updatedMessages.assistantMessages[1][1].content)
+        assertEquals("platform-2", updatedMessages.assistantMessages[1][1].platformType)
+    }
+
+    @Test
+    fun `normalizeAssistantRow keeps known slots addressable when duplicates exist`() {
+        val rebuiltRow = listOf(
+            MessageV2(chatId = 9, content = "Primary answer", platformType = "platform-1"),
+            MessageV2(chatId = 9, content = "Duplicate answer", platformType = "platform-1"),
+            MessageV2(chatId = 9, content = "Second platform", platformType = "platform-2")
+        )
+
+        val normalizedRow = normalizeAssistantRow(
+            assistantMessages = rebuiltRow,
+            enabledPlatformsInChat = listOf("platform-1", "platform-2"),
+            chatId = 9
+        )
+
+        assertEquals("Primary answer", normalizedRow[0].content)
+        assertEquals("Second platform", normalizedRow[1].content)
+        assertTrue(normalizedRow.drop(2).any { it.content == "Duplicate answer" })
+    }
+}

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModelRetryTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModelRetryTest.kt
@@ -1,6 +1,12 @@
 package dev.chungjungsoo.gptmobile.presentation.ui.chat
 
+import dev.chungjungsoo.gptmobile.data.database.entity.ACTIVE_REVISION_LATEST
+import dev.chungjungsoo.gptmobile.data.database.entity.AssistantRevision
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
+import dev.chungjungsoo.gptmobile.data.database.entity.effectiveContent
+import dev.chungjungsoo.gptmobile.data.database.entity.effectiveThoughts
+import dev.chungjungsoo.gptmobile.data.database.entity.resetActiveRevision
+import dev.chungjungsoo.gptmobile.data.database.entity.selectRevision
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -83,5 +89,43 @@ class ChatViewModelRetryTest {
         assertEquals("Primary answer", normalizedRow[0].content)
         assertEquals("Second platform", normalizedRow[1].content)
         assertTrue(normalizedRow.drop(2).any { it.content == "Duplicate answer" })
+    }
+
+    @Test
+    fun `effective assistant content follows selected revision`() {
+        val assistantMessage = MessageV2(
+            chatId = 3,
+            content = "Latest answer",
+            thoughts = "Latest thoughts",
+            revisions = listOf(
+                AssistantRevision(
+                    content = "Previous answer",
+                    thoughts = "Previous thoughts",
+                    createdAt = 100L
+                )
+            ),
+            activeRevisionIndex = 0,
+            platformType = "platform-1"
+        )
+
+        assertEquals("Previous answer", assistantMessage.effectiveContent())
+        assertEquals("Previous thoughts", assistantMessage.effectiveThoughts())
+        assertEquals("Latest answer", assistantMessage.resetActiveRevision().effectiveContent())
+        assertEquals(ACTIVE_REVISION_LATEST, assistantMessage.resetActiveRevision().activeRevisionIndex)
+    }
+
+    @Test
+    fun `selectRevision falls back to latest when index is invalid`() {
+        val assistantMessage = MessageV2(
+            chatId = 5,
+            content = "Latest",
+            revisions = listOf(
+                AssistantRevision(content = "Older", createdAt = 10L)
+            ),
+            platformType = "platform-1"
+        )
+
+        assertEquals(0, assistantMessage.selectRevision(0).activeRevisionIndex)
+        assertEquals(ACTIVE_REVISION_LATEST, assistantMessage.selectRevision(9).activeRevisionIndex)
     }
 }

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensionsTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensionsTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -183,7 +184,8 @@ class ApiStateFlowExtensionsTest {
         )
 
         assertEquals(untouchedTimestamp, messageFlow.value.assistantMessages[0][0].createdAt)
-        assertTrue(messageFlow.value.assistantMessages[0][1].createdAt >= originalTimestamp)
+        assertNotEquals(originalTimestamp, messageFlow.value.assistantMessages[0][1].createdAt)
+        assertEquals(untouchedTimestamp, messageFlow.value.assistantMessages[1][0].createdAt)
         assertEquals(untouchedTimestamp, messageFlow.value.assistantMessages[1][1].createdAt)
     }
 }

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensionsTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensionsTest.kt
@@ -37,6 +37,7 @@ class ApiStateFlowExtensionsTest {
             ApiState.Error("Request timed out.")
         ).handleStates(
             messageFlow = messageFlow,
+            turnIndex = 0,
             platformIdx = 0,
             onLoadingComplete = {}
         )
@@ -63,6 +64,7 @@ class ApiStateFlowExtensionsTest {
             ApiState.Success("answer")
         ).handleStates(
             messageFlow = messageFlow,
+            turnIndex = 0,
             platformIdx = 0,
             onLoadingComplete = { loadingCompleteCalls += 1 },
             nanoTimeProvider = { 1L }
@@ -92,6 +94,7 @@ class ApiStateFlowExtensionsTest {
                 throw IllegalStateException("boom")
             }.handleStates(
                 messageFlow = messageFlow,
+                turnIndex = 0,
                 platformIdx = 0,
                 onLoadingComplete = { loadingCompleteCalls += 1 },
                 nanoTimeProvider = { 1L }
@@ -110,5 +113,77 @@ class ApiStateFlowExtensionsTest {
         val content = "Partial answer\n\n[Response stopped: Request timed out.]"
 
         assertEquals("Partial answer", stripAssistantErrorNote(content))
+    }
+
+    @Test
+    fun `handleStates updates only the requested turn and platform`() = runBlocking {
+        val untouchedTurn = listOf(
+            MessageV2(content = "Other platform", platformType = "platform-1"),
+            MessageV2(content = "Other turn", platformType = "platform-2")
+        )
+        val messageFlow = MutableStateFlow(
+            ChatViewModel.GroupedMessages(
+                userMessages = listOf(
+                    MessageV2(content = "Hello", platformType = null),
+                    MessageV2(content = "Again", platformType = null)
+                ),
+                assistantMessages = listOf(
+                    listOf(
+                        MessageV2(content = "Keep me", platformType = "platform-1"),
+                        MessageV2(content = "", platformType = "platform-2")
+                    ),
+                    untouchedTurn
+                )
+            )
+        )
+
+        flowOf(
+            ApiState.Success("Partial answer"),
+            ApiState.Error("Request timed out.")
+        ).handleStates(
+            messageFlow = messageFlow,
+            turnIndex = 0,
+            platformIdx = 1,
+            onLoadingComplete = {}
+        )
+
+        assertEquals("Keep me", messageFlow.value.assistantMessages[0][0].content)
+        assertTrue(messageFlow.value.assistantMessages[0][1].content.contains("Partial answer"))
+        assertEquals(untouchedTurn, messageFlow.value.assistantMessages[1])
+    }
+
+    @Test
+    fun `handleStates completion timestamps only the requested turn and platform`() = runBlocking {
+        val originalTimestamp = 10L
+        val untouchedTimestamp = 20L
+        val messageFlow = MutableStateFlow(
+            ChatViewModel.GroupedMessages(
+                userMessages = listOf(
+                    MessageV2(content = "Hello", platformType = null),
+                    MessageV2(content = "Again", platformType = null)
+                ),
+                assistantMessages = listOf(
+                    listOf(
+                        MessageV2(content = "Keep me", platformType = "platform-1", createdAt = untouchedTimestamp),
+                        MessageV2(content = "Stamp me", platformType = "platform-2", createdAt = originalTimestamp)
+                    ),
+                    listOf(
+                        MessageV2(content = "Other turn", platformType = "platform-1", createdAt = untouchedTimestamp),
+                        MessageV2(content = "Leave me", platformType = "platform-2", createdAt = untouchedTimestamp)
+                    )
+                )
+            )
+        )
+
+        flowOf(ApiState.Done).handleStates(
+            messageFlow = messageFlow,
+            turnIndex = 0,
+            platformIdx = 1,
+            onLoadingComplete = {}
+        )
+
+        assertEquals(untouchedTimestamp, messageFlow.value.assistantMessages[0][0].createdAt)
+        assertTrue(messageFlow.value.assistantMessages[0][1].createdAt >= originalTimestamp)
+        assertEquals(untouchedTimestamp, messageFlow.value.assistantMessages[1][1].createdAt)
     }
 }


### PR DESCRIPTION
## Summary
- route retry through the rendered turn and selected platform instead of implicitly mutating the last assistant row
- normalize known platform slots in the in-memory grouped chat model while preserving unknown platform messages as overflow
- make streaming/error/timestamp writes target only the requested assistant slot and add regression tests for sparse rows and non-target mutation

## Testing
- ./gradlew :app:testDebugUnitTest --tests "dev.chungjungsoo.gptmobile.presentation.ui.chat.ChatViewModelRetryTest" --tests "dev.chungjungsoo.gptmobile.util.ApiStateFlowExtensionsTest"
- ./gradlew :app:testDebugUnitTest

Closes #265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit assistant responses (text, “thoughts”, attachments), edit user messages, navigate revisions, and show attachments on message bubbles.

* **Bug Fixes**
  * Retry/streaming updates target specific assistant turn/platform so only the intended message is updated; exports use the currently selected revision.

* **Tests**
  * New/updated tests for row normalization, per-slot retry/reset, revision selection, and per-turn streaming/timestamps.

* **Chores**
  * Database schema and migration added to support structured assistant revisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->