### PR TITLE
Persist assistant revisions and retry history

### DIFF
--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/AssistantRevisionListConverter.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/AssistantRevisionListConverter.kt
@@ -1,6 +1,7 @@
 package dev.chungjungsoo.gptmobile.data.database.entity
 
 import androidx.room.TypeConverter
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 
 class AssistantRevisionListConverter {
@@ -13,7 +14,11 @@ class AssistantRevisionListConverter {
     fun fromString(value: String): List<AssistantRevision> = if (value.isBlank()) {
         emptyList()
     } else {
-        json.decodeFromString(value)
+        try {
+            json.decodeFromString(value)
+        } catch (e: SerializationException) {
+            emptyList()
+        }
     }
 
     @TypeConverter

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
@@ -76,7 +76,10 @@ fun UserChatBubble(
                 modifier = Modifier.padding(16.dp)
             )
         }
-        MessageFileThumbnailRow(files = files)
+        MessageFileThumbnailRow(
+            files = files,
+            modifier = Modifier.padding(top = 8.dp)
+        )
     }
 }
 
@@ -166,7 +169,7 @@ fun OpponentChatBubble(
 
                 revisionIndexLabel?.let { label ->
                     Row(
-                        modifier = Modifier.padding(start = 16.dp),
+                        modifier = Modifier.padding(start = 8.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         IconButton(
@@ -180,7 +183,8 @@ fun OpponentChatBubble(
                         }
                         Text(
                             text = label,
-                            style = MaterialTheme.typography.labelMedium
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                         IconButton(
                             enabled = canShowNextRevision,
@@ -329,6 +333,7 @@ fun OpponentChatBubblePreview() {
             text = sampleText,
             canRetry = true,
             isLoading = false,
+            revisionIndexLabel = "Revision 1/1",
             onCopyClick = {},
             onRetryClick = {}
         )
@@ -336,10 +341,10 @@ fun OpponentChatBubblePreview() {
 }
 
 @Composable
-fun MessageFileThumbnailRow(
+internal fun MessageFileThumbnailRow(
     files: List<String>,
-    usePrimaryColors: Boolean = true,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    usePrimaryColors: Boolean = true
 ) {
     // Filter out empty strings and check if we have valid files
     val validFiles = files.filter { it.isNotEmpty() && it.isNotBlank() }
@@ -350,7 +355,6 @@ fun MessageFileThumbnailRow(
 
     Row(
         modifier = modifier
-            .padding(top = 8.dp)
             .wrapContentHeight()
             .horizontalScroll(rememberScrollState()),
         horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp)

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatDialogs.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatDialogs.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -30,6 +31,9 @@ import dev.chungjungsoo.gptmobile.R
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
 import dev.chungjungsoo.gptmobile.data.database.entity.effectiveContent
 import dev.chungjungsoo.gptmobile.data.database.entity.effectiveThoughts
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 fun ChatModelDialog(
@@ -178,17 +182,22 @@ fun UserMessageEditDialog(
     val screenWidth = with(LocalDensity.current) { configuration.containerSize.width.toDp() }
     val screenHeight = with(LocalDensity.current) { configuration.containerSize.height.toDp() }
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     var question by remember { mutableStateOf(initialQuestion.content) }
     val questionFieldMaxLines = 8
     val filePickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { uri ->
         uri?.let {
-            val filePath = copyFileToAppDirectory(context, it)
-            if (filePath != null) {
-                onFileSelected(filePath)
-            } else {
-                onCopyFailed()
+            scope.launch {
+                val filePath = withContext(Dispatchers.IO) {
+                    copyFileToAppDirectory(context, it)
+                }
+                if (filePath != null) {
+                    onFileSelected(filePath)
+                } else {
+                    onCopyFailed()
+                }
             }
         }
     }
@@ -214,7 +223,7 @@ fun UserMessageEditDialog(
                 )
                 AttachmentEditorSection(
                     attachments = attachments,
-                    onAttachFileClick = { filePickerLauncher.launch("*/*") },
+                    onAttachFileClick = { filePickerLauncher.launch("image/*") },
                     onFileRemoved = onFileRemoved
                 )
             }
@@ -224,7 +233,7 @@ fun UserMessageEditDialog(
             val hasPendingOrFailedAttachments = attachments.any { it.status != ChatAttachmentDraft.Status.Ready }
             TextButton(
                 enabled = !hasPendingOrFailedAttachments &&
-                    question.isNotBlank() &&
+                    (question.isNotBlank() || attachments.isNotEmpty()) &&
                     (question != initialQuestion.content || attachments.mapNotNull { it.attachment } != initialQuestion.attachments),
                 onClick = { onConfirmRequest(initialQuestion.copy(content = question)) }
             ) {
@@ -255,17 +264,22 @@ fun AssistantMessageEditDialog(
     val screenWidth = with(LocalDensity.current) { configuration.containerSize.width.toDp() }
     val screenHeight = with(LocalDensity.current) { configuration.containerSize.height.toDp() }
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     var responseText by remember { mutableStateOf(initialMessage.effectiveContent()) }
     var thoughtsText by remember { mutableStateOf(initialMessage.effectiveThoughts()) }
     val filePickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { uri ->
         uri?.let {
-            val filePath = copyFileToAppDirectory(context, it)
-            if (filePath != null) {
-                onFileSelected(filePath)
-            } else {
-                onCopyFailed()
+            scope.launch {
+                val filePath = withContext(Dispatchers.IO) {
+                    copyFileToAppDirectory(context, it)
+                }
+                if (filePath != null) {
+                    onFileSelected(filePath)
+                } else {
+                    onCopyFailed()
+                }
             }
         }
     }
@@ -302,7 +316,7 @@ fun AssistantMessageEditDialog(
                 )
                 AttachmentEditorSection(
                     attachments = attachments,
-                    onAttachFileClick = { filePickerLauncher.launch("*/*") },
+                    onAttachFileClick = { filePickerLauncher.launch("image/*") },
                     onFileRemoved = onFileRemoved
                 )
             }
@@ -312,7 +326,7 @@ fun AssistantMessageEditDialog(
             val hasPendingOrFailedAttachments = attachments.any { it.status != ChatAttachmentDraft.Status.Ready }
             TextButton(
                 enabled = !hasPendingOrFailedAttachments &&
-                    responseText.isNotBlank() &&
+                    (responseText.isNotBlank() || thoughtsText.isNotBlank() || attachments.isNotEmpty()) &&
                     (
                         responseText != initialMessage.effectiveContent() ||
                             thoughtsText != initialMessage.effectiveThoughts() ||

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
@@ -96,8 +96,10 @@ import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
 import dev.chungjungsoo.gptmobile.data.database.entity.effectiveContent
 import dev.chungjungsoo.gptmobile.data.database.entity.effectiveThoughts
 import java.io.File
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -482,15 +484,18 @@ private fun ChatMessagePair(
                 attachments = selectedAssistantMessage?.attachments.orEmpty().map { it.filePathForDisplay },
                 contentIdentity = "$messageIndex:$selectedPlatformUid",
                 revisionIndexLabel = selectedAssistantMessage?.let { assistantMessage ->
-                    if (assistantMessage.revisions.isEmpty()) {
-                        null
-                    } else if (assistantMessage.activeRevisionIndex == ACTIVE_REVISION_LATEST) {
-                        stringResource(R.string.latest_revision)
+                    val totalRevisions = assistantMessage.revisions.size + 1
+                    if (assistantMessage.activeRevisionIndex == ACTIVE_REVISION_LATEST) {
+                        stringResource(
+                            R.string.revision_counter,
+                            totalRevisions,
+                            totalRevisions
+                        )
                     } else {
                         stringResource(
                             R.string.revision_counter,
-                            assistantMessage.activeRevisionIndex + 1,
-                            assistantMessage.revisions.size
+                            assistantMessage.revisions.size - assistantMessage.activeRevisionIndex,
+                            totalRevisions
                         )
                     }
                 },
@@ -679,6 +684,7 @@ fun ChatInputBox(
     val localStyle = LocalTextStyle.current
     val mergedStyle = localStyle.merge(TextStyle(color = LocalContentColor.current))
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     val chatInputLineLimits = TextFieldLineLimits.MultiLine(maxHeightInLines = 5)
     val hasQuestionText = inputState.text.isNotEmpty()
 
@@ -686,8 +692,12 @@ fun ChatInputBox(
         contract = ActivityResultContracts.GetContent()
     ) { uri ->
         uri?.let {
-            val filePath = copyFileToAppDirectory(context, it)
-            filePath?.let { path -> onFileSelected(path) }
+            scope.launch {
+                val filePath = withContext(Dispatchers.IO) {
+                    copyFileToAppDirectory(context, it)
+                }
+                filePath?.let { path -> onFileSelected(path) }
+            }
         }
     }
 
@@ -720,7 +730,7 @@ fun ChatInputBox(
                 ) {
                     IconButton(
                         enabled = chatEnabled,
-                        onClick = { filePickerLauncher.launch("*/*") }
+                        onClick = { filePickerLauncher.launch("image/*") }
                     ) {
                         Icon(
                             imageVector = ImageVector.vectorResource(R.drawable.ic_attach_file),
@@ -755,7 +765,7 @@ fun ChatInputBox(
 }
 
 @Composable
-fun FileThumbnailRow(
+internal fun FileThumbnailRow(
     selectedAttachments: List<ChatAttachmentDraft>,
     onFileRemoved: (String) -> Unit
 ) {
@@ -776,7 +786,7 @@ fun FileThumbnailRow(
 }
 
 @Composable
-fun FileThumbnail(
+internal fun FileThumbnail(
     attachment: ChatAttachmentDraft,
     onRemove: () -> Unit
 ) {
@@ -879,9 +889,9 @@ fun FileThumbnail(
     }
 }
 
-fun copyFileToAppDirectory(context: Context, uri: android.net.Uri): String? {
+internal fun copyFileToAppDirectory(context: Context, uri: android.net.Uri): String? {
     return try {
-        val inputStream = context.contentResolver.openInputStream(uri)
+        val inputStream = context.contentResolver.openInputStream(uri) ?: return null
         val rawFileName = getFileName(context, uri)
         val sanitizedFileName = sanitizeFileName(rawFileName)
 
@@ -911,7 +921,7 @@ fun copyFileToAppDirectory(context: Context, uri: android.net.Uri): String? {
             return null
         }
 
-        inputStream?.use { input ->
+        inputStream.use { input ->
             targetFile.outputStream().use { output ->
                 input.copyTo(output)
             }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModel.kt
@@ -14,6 +14,7 @@ import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoomV2
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
 import dev.chungjungsoo.gptmobile.data.database.entity.effectiveContent
+import dev.chungjungsoo.gptmobile.data.database.entity.effectiveThoughts
 import dev.chungjungsoo.gptmobile.data.database.entity.resetActiveRevision
 import dev.chungjungsoo.gptmobile.data.database.entity.selectRevision
 import dev.chungjungsoo.gptmobile.data.database.entity.snapshotLatestAssistantRevision
@@ -252,21 +253,30 @@ class ChatViewModel @Inject constructor(
         if (platformIndex >= enabledPlatformsInChat.size || platformIndex < 0) return
         val platform = _enabledPlatformsInApp.value.firstOrNull { it.uid == enabledPlatformsInChat[platformIndex] } ?: return
         val platformWithChatModel = resolvePlatformModel(platform)
+        val revisionToAppendOnSuccess = _groupedMessages.value.assistantMessages
+            .getOrNull(turnIndex)
+            ?.getOrNull(platformIndex)
+            ?.snapshotLatestAssistantRevision(currentTimeStamp)
         _loadingStates.update { it.toMutableList().apply { this[platformIndex] = LoadingState.Loading } }
         _groupedMessages.update {
             updateAssistantSlot(
                 groupedMessages = it,
                 turnIndex = turnIndex,
                 platformIndex = platformIndex
-            ) {
-                createEmptyAssistantMessage(chatRoomId, platformWithChatModel.uid)
+            ) { currentMessage ->
+                createRetryAssistantMessage(
+                    currentMessage = currentMessage,
+                    chatId = chatRoomId,
+                    platformUid = platformWithChatModel.uid
+                )
             }
         }
 
         viewModelScope.launch {
+            val retryContext = groupedMessagesThroughTurn(_groupedMessages.value, turnIndex)
             chatRepository.completeChat(
-                _groupedMessages.value.userMessages,
-                _groupedMessages.value.assistantMessages,
+                retryContext.userMessages,
+                retryContext.assistantMessages,
                 platformWithChatModel
             ).handleStates(
                 messageFlow = _groupedMessages,
@@ -274,7 +284,8 @@ class ChatViewModel @Inject constructor(
                 platformIdx = platformIndex,
                 onLoadingComplete = {
                     _loadingStates.update { it.toMutableList().apply { this[platformIndex] = LoadingState.Idle } }
-                }
+                },
+                revisionToAppendOnSuccess = revisionToAppendOnSuccess
             )
         }
     }
@@ -454,6 +465,7 @@ class ChatViewModel @Inject constructor(
                 ).resetActiveRevision()
             }
         }
+        persistCurrentChatSnapshot()
         return true
     }
 
@@ -740,6 +752,10 @@ class ChatViewModel @Inject constructor(
             ?.let { java.io.File(it).delete() }
     }
 
+    /**
+     * Assistant revisions are stored newest-first: revisions[0] is the newest
+     * saved answer, and ACTIVE_REVISION_LATEST points at the live content.
+     */
     private fun updateAssistantRevisionSelection(
         turnIndex: Int,
         platformIndex: Int,
@@ -754,6 +770,7 @@ class ChatViewModel @Inject constructor(
                 message.selectRevision(nextIndex(message))
             }
         }
+        persistCurrentChatSnapshot()
     }
 
     private fun formatCurrentDateTime(): String {
@@ -857,13 +874,23 @@ class ChatViewModel @Inject constructor(
                     (_groupedMessages.value.userMessages.isNotEmpty() && _groupedMessages.value.assistantMessages.isNotEmpty()) &&
                     (_groupedMessages.value.userMessages.size == _groupedMessages.value.assistantMessages.size)
                 ) {
-                    // Save the chat & chat room
-                    _chatRoom.update {
+                    val chatRoom = _chatRoom.value
+                    val groupedMessages = _groupedMessages.value
+                    val chatPlatformModels = _chatPlatformModels.value
+
+                    val savedChatRoom = withContext(Dispatchers.IO) {
                         chatRepository.saveChat(
-                            chatRoom = _chatRoom.value,
-                            messages = ungroupedMessages(),
-                            chatPlatformModels = _chatPlatformModels.value
+                            chatRoom = chatRoom,
+                            messages = persistableMessages(groupedMessages),
+                            chatPlatformModels = chatPlatformModels
                         )
+                    }
+                    _chatRoom.update { currentChatRoom ->
+                        if (currentChatRoom.id == chatRoom.id && chatRoom.id == 0) {
+                            savedChatRoom
+                        } else {
+                            currentChatRoom
+                        }
                     }
 
                     // Sync message ids
@@ -880,17 +907,56 @@ class ChatViewModel @Inject constructor(
         return platform.copy(model = chatModel)
     }
 
-    private fun ungroupedMessages(): List<MessageV2> {
-        // Flatten the grouped messages into a single list
-        val merged = _groupedMessages.value.userMessages + _groupedMessages.value.assistantMessages.flatten()
-        return merged.filter { it.effectiveContent().isNotBlank() || it.attachments.isNotEmpty() }.sortedBy { it.createdAt }
+    private fun persistCurrentChatSnapshot() {
+        viewModelScope.launch {
+            val chatRoom = _chatRoom.value
+            val groupedMessages = _groupedMessages.value
+            if (chatRoom.id <= 0) return@launch
+            if (groupedMessages.userMessages.isEmpty()) return@launch
+            if (groupedMessages.userMessages.size != groupedMessages.assistantMessages.size) return@launch
+
+            withContext(Dispatchers.IO) {
+                chatRepository.saveChat(
+                    chatRoom = chatRoom,
+                    messages = persistableMessages(groupedMessages),
+                    chatPlatformModels = _chatPlatformModels.value
+                )
+            }
+        }
     }
+}
+
+internal fun groupedMessagesThroughTurn(
+    groupedMessages: ChatViewModel.GroupedMessages,
+    turnIndex: Int
+): ChatViewModel.GroupedMessages = groupedMessages.copy(
+    userMessages = groupedMessages.userMessages.take(turnIndex + 1),
+    assistantMessages = groupedMessages.assistantMessages.take(turnIndex + 1)
+)
+
+internal fun persistableMessages(groupedMessages: ChatViewModel.GroupedMessages): List<MessageV2> {
+    val merged = groupedMessages.userMessages + groupedMessages.assistantMessages.flatten()
+    return merged
+        .filter {
+            it.effectiveContent().isNotBlank() ||
+                it.effectiveThoughts().isNotBlank() ||
+                it.attachments.isNotEmpty()
+        }
+        .sortedBy { it.createdAt }
 }
 
 internal fun createEmptyAssistantMessage(chatId: Int, platformUid: String): MessageV2 = MessageV2(
     chatId = chatId,
     content = "",
     platformType = platformUid
+)
+
+internal fun createRetryAssistantMessage(
+    currentMessage: MessageV2,
+    chatId: Int,
+    platformUid: String
+): MessageV2 = createEmptyAssistantMessage(chatId, platformUid).copy(
+    revisions = currentMessage.revisions
 )
 
 internal fun normalizeAssistantRow(

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensions.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensions.kt
@@ -1,5 +1,7 @@
 package dev.chungjungsoo.gptmobile.util
 
+import dev.chungjungsoo.gptmobile.data.database.entity.AssistantRevision
+import dev.chungjungsoo.gptmobile.data.database.entity.resetActiveRevision
 import dev.chungjungsoo.gptmobile.data.dto.ApiState
 import dev.chungjungsoo.gptmobile.presentation.ui.chat.ChatViewModel
 import dev.chungjungsoo.gptmobile.presentation.ui.chat.updateAssistantSlot
@@ -15,7 +17,9 @@ suspend fun Flow<ApiState>.handleStates(
     turnIndex: Int,
     platformIdx: Int,
     onLoadingComplete: () -> Unit,
-    nanoTimeProvider: () -> Long = System::nanoTime
+    nanoTimeProvider: () -> Long = System::nanoTime,
+    currentTimeProvider: () -> Long = { System.currentTimeMillis() / 1000 },
+    revisionToAppendOnSuccess: AssistantRevision? = null
 ) {
     val buffer = StreamingMessageBuffer(nanoTimeProvider = nanoTimeProvider)
     var isCompletedSuccessfully = false
@@ -48,8 +52,20 @@ suspend fun Flow<ApiState>.handleStates(
     } finally {
         buffer.flush(messageFlow, turnIndex, platformIdx)
         when {
-            terminalError != null -> messageFlow.setErrorMessage(turnIndex, platformIdx, terminalError)
-            isCompletedSuccessfully -> messageFlow.setTimestamp(turnIndex, platformIdx)
+            terminalError != null -> messageFlow.setErrorMessage(
+                turnIndex = turnIndex,
+                platformIdx = platformIdx,
+                error = terminalError,
+                currentTimeProvider = currentTimeProvider,
+                revisionToAppend = revisionToAppendOnSuccess
+            )
+
+            isCompletedSuccessfully -> messageFlow.setTimestamp(
+                turnIndex = turnIndex,
+                platformIdx = platformIdx,
+                currentTimeProvider = currentTimeProvider,
+                revisionToAppend = revisionToAppendOnSuccess
+            )
         }
         onLoadingComplete()
     }
@@ -147,7 +163,9 @@ private fun MutableStateFlow<ChatViewModel.GroupedMessages>.setBufferedText(
 private fun MutableStateFlow<ChatViewModel.GroupedMessages>.setErrorMessage(
     turnIndex: Int,
     platformIdx: Int,
-    error: String
+    error: String,
+    currentTimeProvider: () -> Long,
+    revisionToAppend: AssistantRevision?
 ) {
     update { groupedMessages ->
         updateAssistantSlot(
@@ -157,7 +175,10 @@ private fun MutableStateFlow<ChatViewModel.GroupedMessages>.setErrorMessage(
         ) { currentMessage ->
             currentMessage.copy(
                 content = buildAssistantErrorContent(currentMessage.content, error),
-                createdAt = System.currentTimeMillis() / 1000
+                createdAt = currentTimeProvider(),
+                revisions = revisionToAppend
+                    ?.let { listOf(it) + currentMessage.revisions }
+                    ?: currentMessage.revisions
             )
         }
     }
@@ -177,14 +198,24 @@ internal fun stripAssistantErrorNote(content: String): String {
     }
 }
 
-private fun MutableStateFlow<ChatViewModel.GroupedMessages>.setTimestamp(turnIndex: Int, platformIdx: Int) {
+private fun MutableStateFlow<ChatViewModel.GroupedMessages>.setTimestamp(
+    turnIndex: Int,
+    platformIdx: Int,
+    currentTimeProvider: () -> Long,
+    revisionToAppend: AssistantRevision?
+) {
     update { groupedMessages ->
         updateAssistantSlot(
             groupedMessages = groupedMessages,
             turnIndex = turnIndex,
             platformIndex = platformIdx
         ) { currentMessage ->
-            currentMessage.copy(createdAt = System.currentTimeMillis() / 1000)
+            currentMessage.copy(
+                createdAt = currentTimeProvider(),
+                revisions = revisionToAppend
+                    ?.let { listOf(it) + currentMessage.revisions }
+                    ?: currentMessage.revisions
+            ).resetActiveRevision()
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -283,7 +283,6 @@
     <string name="platform_added_successfully">Platform added successfully</string>
     <string name="at_least_one_platform_required">Add at least one platform to continue</string>
     <string name="remove">Remove</string>
-    <string name="latest_revision">Latest</string>
     <string name="revision_counter">Revision %1$d/%2$d</string>
     <string name="previous_revision" translatable="false">Previous revision</string>
     <string name="next_revision" translatable="false">Next revision</string>

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2MigrationsTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2MigrationsTest.kt
@@ -35,5 +35,41 @@ class ChatDatabaseV2MigrationsTest {
         assertEquals("", revisions[0].thoughts)
         assertEquals(1234L, revisions[0].createdAt)
         assertEquals("second revision", revisions[1].content)
+        assertEquals(1234L, revisions[1].createdAt)
+    }
+
+    @Test
+    fun `blank legacy revision list migrates to empty structured revisions`() {
+        val json = ChatDatabaseV2Migrations.legacyRevisionsToStructuredJson(
+            revisionsValue = "",
+            createdAt = 1234L
+        )
+
+        val revisions = AssistantRevisionListConverter().fromString(json)
+
+        assertTrue(revisions.isEmpty())
+    }
+
+    @Test
+    fun `legacy revision migration filters blank segments and applies timestamp`() {
+        val json = ChatDatabaseV2Migrations.legacyRevisionsToStructuredJson(
+            revisionsValue = "a, ,b",
+            createdAt = 1234L
+        )
+
+        val revisions = AssistantRevisionListConverter().fromString(json)
+
+        assertEquals(2, revisions.size)
+        assertEquals("a", revisions[0].content)
+        assertEquals(1234L, revisions[0].createdAt)
+        assertEquals("b", revisions[1].content)
+        assertEquals(1234L, revisions[1].createdAt)
+    }
+
+    @Test
+    fun `corrupt assistant revision json decodes to empty list`() {
+        val revisions = AssistantRevisionListConverter().fromString("[")
+
+        assertTrue(revisions.isEmpty())
     }
 }

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModelRetryTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModelRetryTest.kt
@@ -75,6 +75,29 @@ class ChatViewModelRetryTest {
     }
 
     @Test
+    fun `retry assistant replacement preserves historical revisions`() {
+        val currentMessage = MessageV2(
+            chatId = 7,
+            content = "Current answer",
+            revisions = listOf(
+                AssistantRevision(content = "Older answer", createdAt = 100L)
+            ),
+            platformType = "platform-1"
+        )
+
+        val retryMessage = createRetryAssistantMessage(
+            currentMessage = currentMessage,
+            chatId = 7,
+            platformUid = "platform-1"
+        )
+
+        assertEquals("", retryMessage.content)
+        assertEquals("", retryMessage.thoughts)
+        assertEquals(listOf(AssistantRevision(content = "Older answer", createdAt = 100L)), retryMessage.revisions)
+        assertEquals(ACTIVE_REVISION_LATEST, retryMessage.activeRevisionIndex)
+    }
+
+    @Test
     fun `normalizeAssistantRow keeps known slots addressable when duplicates exist`() {
         val rebuiltRow = listOf(
             MessageV2(chatId = 9, content = "Primary answer", platformType = "platform-1"),
@@ -114,6 +137,64 @@ class ChatViewModelRetryTest {
         assertEquals("Previous thoughts", assistantMessage.effectiveThoughts())
         assertEquals("Latest answer", assistantMessage.resetActiveRevision().effectiveContent())
         assertEquals(ACTIVE_REVISION_LATEST, assistantMessage.resetActiveRevision().activeRevisionIndex)
+    }
+
+    @Test
+    fun `retry context trims future turns`() {
+        val groupedMessages = ChatViewModel.GroupedMessages(
+            userMessages = listOf(
+                MessageV2(chatId = 7, content = "First", platformType = null),
+                MessageV2(chatId = 7, content = "Second", platformType = null),
+                MessageV2(chatId = 7, content = "Future", platformType = null)
+            ),
+            assistantMessages = listOf(
+                listOf(MessageV2(chatId = 7, content = "First answer", platformType = "platform-1")),
+                listOf(MessageV2(chatId = 7, content = "", platformType = "platform-1")),
+                listOf(MessageV2(chatId = 7, content = "Future answer", platformType = "platform-1"))
+            )
+        )
+
+        val retryContext = groupedMessagesThroughTurn(groupedMessages, turnIndex = 1)
+
+        assertEquals(listOf("First", "Second"), retryContext.userMessages.map { it.content })
+        assertEquals(2, retryContext.assistantMessages.size)
+        assertEquals("", retryContext.assistantMessages[1][0].content)
+    }
+
+    @Test
+    fun `persistable messages keep thought only assistant messages`() {
+        val groupedMessages = ChatViewModel.GroupedMessages(
+            userMessages = listOf(MessageV2(chatId = 7, content = "Question", platformType = null, createdAt = 1L)),
+            assistantMessages = listOf(
+                listOf(
+                    MessageV2(chatId = 7, content = "", thoughts = "Internal reasoning", platformType = "platform-1", createdAt = 2L),
+                    MessageV2(
+                        chatId = 7,
+                        content = "",
+                        thoughts = "",
+                        attachments = listOf(
+                            ChatAttachment(
+                                localFilePath = "/tmp/a.png",
+                                preparedFilePath = "/tmp/a.png",
+                                displayName = "a.png",
+                                mimeType = "image/png",
+                                sizeBytes = 1L
+                            )
+                        ),
+                        platformType = "platform-2",
+                        createdAt = 3L
+                    ),
+                    MessageV2(chatId = 7, content = "", thoughts = "", platformType = "platform-2", createdAt = 3L)
+                )
+            )
+        )
+
+        val messages = persistableMessages(groupedMessages)
+
+        assertEquals(3, messages.size)
+        assertEquals("Question", messages[0].content)
+        assertEquals("Internal reasoning", messages[1].thoughts)
+        assertEquals(1, messages[2].attachments.size)
     }
 
     @Test

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensionsTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensionsTest.kt
@@ -1,5 +1,7 @@
 package dev.chungjungsoo.gptmobile.util
 
+import dev.chungjungsoo.gptmobile.data.database.entity.ACTIVE_REVISION_LATEST
+import dev.chungjungsoo.gptmobile.data.database.entity.AssistantRevision
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
 import dev.chungjungsoo.gptmobile.data.dto.ApiState
 import dev.chungjungsoo.gptmobile.presentation.ui.chat.ChatViewModel
@@ -8,7 +10,6 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -180,12 +181,87 @@ class ApiStateFlowExtensionsTest {
             messageFlow = messageFlow,
             turnIndex = 0,
             platformIdx = 1,
-            onLoadingComplete = {}
+            onLoadingComplete = {},
+            currentTimeProvider = { 1234L }
         )
 
         assertEquals(untouchedTimestamp, messageFlow.value.assistantMessages[0][0].createdAt)
-        assertNotEquals(originalTimestamp, messageFlow.value.assistantMessages[0][1].createdAt)
+        assertEquals(1234L, messageFlow.value.assistantMessages[0][1].createdAt)
         assertEquals(untouchedTimestamp, messageFlow.value.assistantMessages[1][0].createdAt)
         assertEquals(untouchedTimestamp, messageFlow.value.assistantMessages[1][1].createdAt)
+    }
+
+    @Test
+    fun `handleStates appends retry revision only when stream succeeds`() = runBlocking {
+        val messageFlow = MutableStateFlow(
+            ChatViewModel.GroupedMessages(
+                userMessages = listOf(MessageV2(content = "Hello", platformType = null)),
+                assistantMessages = listOf(
+                    listOf(
+                        MessageV2(
+                            content = "",
+                            revisions = listOf(AssistantRevision(content = "Older answer", createdAt = 5L)),
+                            platformType = "platform-1"
+                        )
+                    )
+                )
+            )
+        )
+
+        flowOf(
+            ApiState.Success("New answer"),
+            ApiState.Done
+        ).handleStates(
+            messageFlow = messageFlow,
+            turnIndex = 0,
+            platformIdx = 0,
+            onLoadingComplete = {},
+            nanoTimeProvider = { 1L },
+            currentTimeProvider = { 1234L },
+            revisionToAppendOnSuccess = AssistantRevision(content = "Previous answer", thoughts = "Previous thoughts", createdAt = 100L)
+        )
+
+        val assistantMessage = messageFlow.value.assistantMessages[0][0]
+        assertEquals("New answer", assistantMessage.content)
+        assertEquals(ACTIVE_REVISION_LATEST, assistantMessage.activeRevisionIndex)
+        assertEquals(2, assistantMessage.revisions.size)
+        assertEquals("Previous answer", assistantMessage.revisions[0].content)
+        assertEquals("Previous thoughts", assistantMessage.revisions[0].thoughts)
+        assertEquals("Older answer", assistantMessage.revisions[1].content)
+    }
+
+    @Test
+    fun `handleStates preserves previous retry revision when stream errors`() = runBlocking {
+        val messageFlow = MutableStateFlow(
+            ChatViewModel.GroupedMessages(
+                userMessages = listOf(MessageV2(content = "Hello", platformType = null)),
+                assistantMessages = listOf(
+                    listOf(
+                        MessageV2(
+                            content = "",
+                            revisions = listOf(AssistantRevision(content = "Older answer", createdAt = 5L)),
+                            platformType = "platform-1"
+                        )
+                    )
+                )
+            )
+        )
+
+        flowOf(
+            ApiState.Success("Partial answer"),
+            ApiState.Error("Request timed out.")
+        ).handleStates(
+            messageFlow = messageFlow,
+            turnIndex = 0,
+            platformIdx = 0,
+            onLoadingComplete = {},
+            revisionToAppendOnSuccess = AssistantRevision(content = "Previous answer", createdAt = 100L)
+        )
+
+        val assistantMessage = messageFlow.value.assistantMessages[0][0]
+        assertTrue(assistantMessage.content.contains("Partial answer"))
+        assertEquals(2, assistantMessage.revisions.size)
+        assertEquals("Previous answer", assistantMessage.revisions[0].content)
+        assertEquals("Older answer", assistantMessage.revisions[1].content)
     }
 }


### PR DESCRIPTION
## Summary
- persist assistant edit and revision-selection updates immediately
- trim retry context to the requested turn and keep thought-only assistant messages when saving
- move edit-dialog attachment copies to Dispatchers.IO, narrow pickers to image/*, and avoid returning paths for failed stream opens
- keep shared attachment helpers internal and harden assistant revision JSON decoding

## Verification
- ktlint on changed Kotlin files
- ANDROID_HOME=/Users/taewanpark/Library/Android/sdk ANDROID_SDK_ROOT=/Users/taewanpark/Library/Android/sdk GRADLE_USER_HOME=/tmp/gradle-home-pr273 ./gradlew :app:testDebugUnitTest

## Notes
- :app:lintDebug still fails on existing project lint backlog outside this branch; first failure is HomeScreen.kt:130 (LocalContext.current resource lookup). Touched files no longer appear in the lint text report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safely handles malformed revision data by falling back to empty revisions.
  * Prevents attachment-related hangs by performing copies in background and failing immediately when input is unavailable.
  * Removed the no-longer-available "Latest" revision label.

* **Improvements**
  * Attachment picker now restricts to images.
  * Confirm buttons allow empty text when attachments or thoughts exist.
  * Consistent revision counters; chat bubble spacing and color tweaks.
  * More reliable chat snapshot saving and smarter retry behavior.

* **Tests**
  * Added migration, retry, and timestamp/append behavior tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->