### PR TITLE
Add Gemini safety settings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,12 +16,12 @@ plugins {
 
 extensions.configure<ApplicationExtension> {
     namespace = "dev.chungjungsoo.gptmobile"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "dev.chungjungsoo.gptmobile"
         minSdk = 31
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 21
         versionName = "0.7.5"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,10 @@ extensions.configure<ApplicationExtension> {
         generateLocaleConfig = true
     }
 
+    lint {
+        disable += "MissingTranslation"
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = true

--- a/app/schemas/dev.chungjungsoo.gptmobile.data.database.ChatDatabaseV2/5.json
+++ b/app/schemas/dev.chungjungsoo.gptmobile.data.database.ChatDatabaseV2/5.json
@@ -1,0 +1,320 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "62f0cea0d4949ae6aa3ade4ecdbbeca4",
+    "entities": [
+      {
+        "tableName": "chats_v2",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chat_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `enabled_platform` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "chat_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabledPlatform",
+            "columnName": "enabled_platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "chat_id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages_v2",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`message_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `chat_id` INTEGER NOT NULL, `thoughts` TEXT NOT NULL, `content` TEXT NOT NULL, `attachments` TEXT NOT NULL, `revisions` TEXT NOT NULL, `active_revision_index` INTEGER NOT NULL, `linked_message_id` INTEGER NOT NULL, `platform_type` TEXT, `created_at` INTEGER NOT NULL, FOREIGN KEY(`chat_id`) REFERENCES `chats_v2`(`chat_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "message_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chat_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thoughts",
+            "columnName": "thoughts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attachments",
+            "columnName": "attachments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revisions",
+            "columnName": "revisions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeRevisionIndex",
+            "columnName": "active_revision_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkedMessageId",
+            "columnName": "linked_message_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platformType",
+            "columnName": "platform_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "message_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_v2_chat_id",
+            "unique": false,
+            "columnNames": [
+              "chat_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_v2_chat_id` ON `${TABLE_NAME}` (`chat_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chats_v2",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chat_id"
+            ],
+            "referencedColumns": [
+              "chat_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "platform_v2",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`platform_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `uid` TEXT NOT NULL, `name` TEXT NOT NULL, `compatible_type` TEXT NOT NULL, `enabled` INTEGER NOT NULL, `api_url` TEXT NOT NULL, `token` TEXT, `model` TEXT NOT NULL, `temperature` REAL, `top_p` REAL, `system_prompt` TEXT, `stream` INTEGER NOT NULL, `reasoning` INTEGER NOT NULL, `timeout` INTEGER NOT NULL, `harassment_safety_threshold` TEXT NOT NULL DEFAULT 'BLOCK_NONE', `hate_speech_safety_threshold` TEXT NOT NULL DEFAULT 'BLOCK_NONE', `sexually_explicit_safety_threshold` TEXT NOT NULL DEFAULT 'BLOCK_NONE', `dangerous_content_safety_threshold` TEXT NOT NULL DEFAULT 'BLOCK_NONE')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "platform_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "compatibleType",
+            "columnName": "compatible_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiUrl",
+            "columnName": "api_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "token",
+            "columnName": "token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "top_p",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "systemPrompt",
+            "columnName": "system_prompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stream",
+            "columnName": "stream",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reasoning",
+            "columnName": "reasoning",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeout",
+            "columnName": "timeout",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "harassmentSafetyThreshold",
+            "columnName": "harassment_safety_threshold",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'BLOCK_NONE'"
+          },
+          {
+            "fieldPath": "hateSpeechSafetyThreshold",
+            "columnName": "hate_speech_safety_threshold",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'BLOCK_NONE'"
+          },
+          {
+            "fieldPath": "sexuallyExplicitSafetyThreshold",
+            "columnName": "sexually_explicit_safety_threshold",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'BLOCK_NONE'"
+          },
+          {
+            "fieldPath": "dangerousContentSafetyThreshold",
+            "columnName": "dangerous_content_safety_threshold",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'BLOCK_NONE'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "platform_id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_platform_model_v2",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chat_id` INTEGER NOT NULL, `platform_uid` TEXT NOT NULL, `model` TEXT NOT NULL, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`chat_id`, `platform_uid`), FOREIGN KEY(`chat_id`) REFERENCES `chats_v2`(`chat_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "chatId",
+            "columnName": "chat_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platformUid",
+            "columnName": "platform_uid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chat_id",
+            "platform_uid"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "chats_v2",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chat_id"
+            ],
+            "referencedColumns": [
+              "chat_id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '62f0cea0d4949ae6aa3ade4ecdbbeca4')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2.kt
@@ -17,7 +17,7 @@ import dev.chungjungsoo.gptmobile.data.database.entity.StringListConverter
 
 @Database(
     entities = [ChatRoomV2::class, MessageV2::class, PlatformV2::class, ChatPlatformModelV2::class],
-    version = 4,
+    version = 5,
     exportSchema = true
 )
 @TypeConverters(

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2Migrations.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2Migrations.kt
@@ -213,6 +213,19 @@ object ChatDatabaseV2Migrations {
         }
     }
 
+    val GEMINI_SAFETY_COLUMN_MIGRATIONS = listOf(
+        "ALTER TABLE `platform_v2` ADD COLUMN `harassment_safety_threshold` TEXT NOT NULL DEFAULT 'BLOCK_NONE'",
+        "ALTER TABLE `platform_v2` ADD COLUMN `hate_speech_safety_threshold` TEXT NOT NULL DEFAULT 'BLOCK_NONE'",
+        "ALTER TABLE `platform_v2` ADD COLUMN `sexually_explicit_safety_threshold` TEXT NOT NULL DEFAULT 'BLOCK_NONE'",
+        "ALTER TABLE `platform_v2` ADD COLUMN `dangerous_content_safety_threshold` TEXT NOT NULL DEFAULT 'BLOCK_NONE'"
+    )
+
+    val MIGRATION_4_5 = object : Migration(4, 5) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            GEMINI_SAFETY_COLUMN_MIGRATIONS.forEach(db::execSQL)
+        }
+    }
+
     internal fun legacyFilesToAttachmentsJson(filesValue: String): String {
         val attachments = filesValue
             .split(",")

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/PlatformV2.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/PlatformV2.kt
@@ -4,6 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import dev.chungjungsoo.gptmobile.data.model.ClientType
+import dev.chungjungsoo.gptmobile.data.model.GeminiSafetySettings
 import java.util.*
 
 @Entity(tableName = "platform_v2")
@@ -49,5 +50,17 @@ data class PlatformV2(
     val reasoning: Boolean = false,
 
     @ColumnInfo(name = "timeout")
-    val timeout: Int = 30
+    val timeout: Int = 30,
+
+    @ColumnInfo(name = "harassment_safety_threshold", defaultValue = "'BLOCK_NONE'")
+    val harassmentSafetyThreshold: String = GeminiSafetySettings.BLOCK_NONE,
+
+    @ColumnInfo(name = "hate_speech_safety_threshold", defaultValue = "'BLOCK_NONE'")
+    val hateSpeechSafetyThreshold: String = GeminiSafetySettings.BLOCK_NONE,
+
+    @ColumnInfo(name = "sexually_explicit_safety_threshold", defaultValue = "'BLOCK_NONE'")
+    val sexuallyExplicitSafetyThreshold: String = GeminiSafetySettings.BLOCK_NONE,
+
+    @ColumnInfo(name = "dangerous_content_safety_threshold", defaultValue = "'BLOCK_NONE'")
+    val dangerousContentSafetyThreshold: String = GeminiSafetySettings.BLOCK_NONE
 )

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/dto/google/request/GenerateContentRequest.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/dto/google/request/GenerateContentRequest.kt
@@ -18,7 +18,11 @@ data class GenerateContentRequest(
 
     @SerialName("systemInstruction")
     @EncodeDefault(EncodeDefault.Mode.NEVER)
-    val systemInstruction: Content? = null
+    val systemInstruction: Content? = null,
+
+    @SerialName("safetySettings")
+    @EncodeDefault(EncodeDefault.Mode.NEVER)
+    val safetySettings: List<SafetySetting>? = null
 )
 
 @OptIn(ExperimentalSerializationApi::class)
@@ -47,6 +51,18 @@ data class GenerationConfig(
     @SerialName("thinkingConfig")
     @EncodeDefault(EncodeDefault.Mode.NEVER)
     val thinkingConfig: ThinkingConfig? = null
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class SafetySetting(
+    @SerialName("category")
+    @EncodeDefault(EncodeDefault.Mode.NEVER)
+    val category: String,
+
+    @SerialName("threshold")
+    @EncodeDefault(EncodeDefault.Mode.NEVER)
+    val threshold: String
 )
 
 @OptIn(ExperimentalSerializationApi::class)

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/dto/google/response/GenerateContentResponse.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/dto/google/response/GenerateContentResponse.kt
@@ -19,7 +19,7 @@ data class GenerateContentResponse(
 @Serializable
 data class Candidate(
     @SerialName("content")
-    val content: Content,
+    val content: Content? = null,
 
     @SerialName("finishReason")
     val finishReason: String? = null,

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/model/GeminiSafetySettings.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/model/GeminiSafetySettings.kt
@@ -1,5 +1,8 @@
 package dev.chungjungsoo.gptmobile.data.model
 
+import androidx.annotation.StringRes
+import dev.chungjungsoo.gptmobile.R
+
 object GeminiSafetySettings {
     const val BLOCK_NONE = "BLOCK_NONE"
     const val BLOCK_ONLY_HIGH = "BLOCK_ONLY_HIGH"
@@ -15,10 +18,11 @@ object GeminiSafetySettings {
 
     fun normalizeThreshold(value: String?): String = value?.takeIf { it in supportedThresholds } ?: BLOCK_NONE
 
-    fun labelFor(threshold: String): String = when (normalizeThreshold(threshold)) {
-        BLOCK_ONLY_HIGH -> "Block high only"
-        BLOCK_MEDIUM_AND_ABOVE -> "Block medium and above"
-        BLOCK_LOW_AND_ABOVE -> "Block low and above"
-        else -> "Block none"
+    @StringRes
+    fun labelResFor(threshold: String): Int = when (normalizeThreshold(threshold)) {
+        BLOCK_ONLY_HIGH -> R.string.gemini_safety_block_only_high
+        BLOCK_MEDIUM_AND_ABOVE -> R.string.gemini_safety_block_medium_and_above
+        BLOCK_LOW_AND_ABOVE -> R.string.gemini_safety_block_low_and_above
+        else -> R.string.gemini_safety_block_none
     }
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/model/GeminiSafetySettings.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/model/GeminiSafetySettings.kt
@@ -1,0 +1,24 @@
+package dev.chungjungsoo.gptmobile.data.model
+
+object GeminiSafetySettings {
+    const val BLOCK_NONE = "BLOCK_NONE"
+    const val BLOCK_ONLY_HIGH = "BLOCK_ONLY_HIGH"
+    const val BLOCK_MEDIUM_AND_ABOVE = "BLOCK_MEDIUM_AND_ABOVE"
+    const val BLOCK_LOW_AND_ABOVE = "BLOCK_LOW_AND_ABOVE"
+
+    const val HARM_CATEGORY_HARASSMENT = "HARM_CATEGORY_HARASSMENT"
+    const val HARM_CATEGORY_HATE_SPEECH = "HARM_CATEGORY_HATE_SPEECH"
+    const val HARM_CATEGORY_SEXUALLY_EXPLICIT = "HARM_CATEGORY_SEXUALLY_EXPLICIT"
+    const val HARM_CATEGORY_DANGEROUS_CONTENT = "HARM_CATEGORY_DANGEROUS_CONTENT"
+
+    val supportedThresholds = listOf(BLOCK_NONE, BLOCK_ONLY_HIGH, BLOCK_MEDIUM_AND_ABOVE, BLOCK_LOW_AND_ABOVE)
+
+    fun normalizeThreshold(value: String?): String = value?.takeIf { it in supportedThresholds } ?: BLOCK_NONE
+
+    fun labelFor(threshold: String): String = when (normalizeThreshold(threshold)) {
+        BLOCK_ONLY_HIGH -> "Block high only"
+        BLOCK_MEDIUM_AND_ABOVE -> "Block medium and above"
+        BLOCK_LOW_AND_ABOVE -> "Block low and above"
+        else -> "Block none"
+    }
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImpl.kt
@@ -31,6 +31,7 @@ import dev.chungjungsoo.gptmobile.data.dto.google.common.Part
 import dev.chungjungsoo.gptmobile.data.dto.google.common.Role as GoogleRole
 import dev.chungjungsoo.gptmobile.data.dto.google.request.GenerateContentRequest
 import dev.chungjungsoo.gptmobile.data.dto.google.request.GenerationConfig
+import dev.chungjungsoo.gptmobile.data.dto.google.request.SafetySetting
 import dev.chungjungsoo.gptmobile.data.dto.groq.request.GroqChatCompletionRequest
 import dev.chungjungsoo.gptmobile.data.dto.openai.common.ImageContent as OpenAIImageContent
 import dev.chungjungsoo.gptmobile.data.dto.openai.common.ImageUrl
@@ -50,6 +51,7 @@ import dev.chungjungsoo.gptmobile.data.dto.openai.response.ResponseErrorEvent
 import dev.chungjungsoo.gptmobile.data.dto.openai.response.ResponseFailedEvent
 import dev.chungjungsoo.gptmobile.data.model.ApiType
 import dev.chungjungsoo.gptmobile.data.model.ClientType
+import dev.chungjungsoo.gptmobile.data.model.GeminiSafetySettings
 import dev.chungjungsoo.gptmobile.data.network.AnthropicAPI
 import dev.chungjungsoo.gptmobile.data.network.GoogleAPI
 import dev.chungjungsoo.gptmobile.data.network.GroqAPI
@@ -646,7 +648,8 @@ class ChatRepositoryImpl @Inject constructor(
                         Content(
                             parts = listOf(Part.text(it))
                         )
-                    }
+                    },
+                    safetySettings = platform.toGoogleSafetySettings()
                 )
             },
             stream = { request ->
@@ -679,6 +682,25 @@ class ChatRepositoryImpl @Inject constructor(
     } catch (e: Exception) {
         flowOf(ApiState.Error(e.message ?: "Failed to complete chat"))
     }
+
+    private fun PlatformV2.toGoogleSafetySettings(): List<SafetySetting> = listOf(
+        SafetySetting(
+            category = GeminiSafetySettings.HARM_CATEGORY_HARASSMENT,
+            threshold = GeminiSafetySettings.normalizeThreshold(harassmentSafetyThreshold)
+        ),
+        SafetySetting(
+            category = GeminiSafetySettings.HARM_CATEGORY_HATE_SPEECH,
+            threshold = GeminiSafetySettings.normalizeThreshold(hateSpeechSafetyThreshold)
+        ),
+        SafetySetting(
+            category = GeminiSafetySettings.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+            threshold = GeminiSafetySettings.normalizeThreshold(sexuallyExplicitSafetyThreshold)
+        ),
+        SafetySetting(
+            category = GeminiSafetySettings.HARM_CATEGORY_DANGEROUS_CONTENT,
+            threshold = GeminiSafetySettings.normalizeThreshold(dangerousContentSafetyThreshold)
+        )
+    )
 
     private suspend fun transformMessageV2ToGoogle(message: MessageV2, role: GoogleRole, platformUid: String): Content {
         val parts = mutableListOf<Part>()

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImpl.kt
@@ -658,8 +658,16 @@ class ChatRepositoryImpl @Inject constructor(
                         when {
                             response.error != null -> emit(ApiState.Error(response.error.message))
 
+                            response.promptFeedback?.blockReason != null -> {
+                                emit(ApiState.Error("Gemini safety settings blocked the prompt: ${response.promptFeedback.blockReason}"))
+                            }
+
+                            response.candidates?.firstOrNull()?.finishReason == GOOGLE_SAFETY_FINISH_REASON -> {
+                                emit(ApiState.Error("Gemini safety settings blocked the response."))
+                            }
+
                             response.candidates?.firstOrNull()?.content?.parts != null -> {
-                                val parts = response.candidates.first().content.parts
+                                val parts = response.candidates.first().content?.parts.orEmpty()
                                 parts.forEach { part ->
                                     part.text?.let { text ->
                                         if (part.thought == true) {
@@ -681,6 +689,10 @@ class ChatRepositoryImpl @Inject constructor(
         }
     } catch (e: Exception) {
         flowOf(ApiState.Error(e.message ?: "Failed to complete chat"))
+    }
+
+    private companion object {
+        private const val GOOGLE_SAFETY_FINISH_REASON = "SAFETY"
     }
 
     private fun PlatformV2.toGoogleSafetySettings(): List<SafetySetting> = listOf(

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/di/DatabaseModule.kt
@@ -59,6 +59,7 @@ object DatabaseModule {
     ).addMigrations(
         ChatDatabaseV2Migrations.MIGRATION_1_2,
         ChatDatabaseV2Migrations.MIGRATION_2_3,
-        ChatDatabaseV2Migrations.MIGRATION_3_4
+        ChatDatabaseV2Migrations.MIGRATION_3_4,
+        ChatDatabaseV2Migrations.MIGRATION_4_5
     ).build()
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/home/HomeScreen.kt
@@ -94,6 +94,9 @@ fun HomeScreen(
     val lifecycleOwner = LocalLifecycleOwner.current
     val lifecycleState by lifecycleOwner.lifecycle.currentStateFlow.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    val selectedChatCount = chatListState.selectedChats.count { it }
+    val duplicatedChatMessage = stringResource(R.string.duplicated_chat)
+    val deletedChatsMessage = stringResource(R.string.deleted_chats, selectedChatCount)
 
     LaunchedEffect(lifecycleState) {
         if (lifecycleState == Lifecycle.State.RESUMED && !chatListState.isSelectionMode && !chatListState.isSearchMode) {
@@ -116,7 +119,7 @@ fun HomeScreen(
             HomeTopAppBar(
                 isSelectionMode = chatListState.isSelectionMode,
                 isSearchMode = chatListState.isSearchMode,
-                selectedChats = chatListState.selectedChats.count { it },
+                selectedChats = selectedChatCount,
                 scrollBehavior = scrollBehavior,
                 actionOnClick = {
                     if (chatListState.isSelectionMode) {
@@ -127,7 +130,7 @@ fun HomeScreen(
                 },
                 duplicateOnClick = {
                     homeViewModel.duplicateSelectedChat()
-                    Toast.makeText(context, context.getString(R.string.duplicated_chat), Toast.LENGTH_SHORT).show()
+                    Toast.makeText(context, duplicatedChatMessage, Toast.LENGTH_SHORT).show()
                 },
                 navigationOnClick = {
                     if (chatListState.isSelectionMode) {
@@ -237,9 +240,8 @@ fun HomeScreen(
             DeleteWarningDialog(
                 onDismissRequest = homeViewModel::closeDeleteWarningDialog,
                 onConfirm = {
-                    val deletedChatRoomCount = chatListState.selectedChats.count { it }
                     homeViewModel.deleteSelectedChats()
-                    Toast.makeText(context, context.getString(R.string.deleted_chats, deletedChatRoomCount), Toast.LENGTH_SHORT).show()
+                    Toast.makeText(context, deletedChatsMessage, Toast.LENGTH_SHORT).show()
                     homeViewModel.closeDeleteWarningDialog()
                 }
             )

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingDialogs.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingDialogs.kt
@@ -11,6 +11,11 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
@@ -30,6 +35,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import dev.chungjungsoo.gptmobile.R
+import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
+import dev.chungjungsoo.gptmobile.data.model.GeminiSafetySettings
 import dev.chungjungsoo.gptmobile.util.isValidUrl
 import kotlin.math.roundToInt
 
@@ -156,6 +163,21 @@ fun TimeoutDialog(
             initialValue = timeoutSeconds,
             onDismissRequest = settingViewModel::closeTimeoutDialog,
             onConfirmRequest = settingViewModel::updateTimeout
+        )
+    }
+}
+
+@Composable
+fun GeminiSafetySettingsDialog(
+    dialogState: PlatformSettingViewModel.DialogState,
+    platform: PlatformV2,
+    settingViewModel: PlatformSettingViewModel
+) {
+    if (dialogState.isGeminiSafetyDialogOpen) {
+        GeminiSafetySettingsDialog(
+            platform = platform,
+            onDismissRequest = settingViewModel::closeGeminiSafetyDialog,
+            onConfirmRequest = settingViewModel::updateGeminiSafetySettings
         )
     }
 }
@@ -661,6 +683,111 @@ private fun SystemPromptDialog(
             }
         }
     )
+}
+
+@Composable
+private fun GeminiSafetySettingsDialog(
+    platform: PlatformV2,
+    onDismissRequest: () -> Unit,
+    onConfirmRequest: (String, String, String, String) -> Unit
+) {
+    val configuration = LocalWindowInfo.current
+    val screenWidth = with(LocalDensity.current) { configuration.containerSize.width.toDp() }
+    val screenHeight = with(LocalDensity.current) { configuration.containerSize.height.toDp() }
+    var harassment by remember { mutableStateOf(GeminiSafetySettings.normalizeThreshold(platform.harassmentSafetyThreshold)) }
+    var hateSpeech by remember { mutableStateOf(GeminiSafetySettings.normalizeThreshold(platform.hateSpeechSafetyThreshold)) }
+    var sexuallyExplicit by remember { mutableStateOf(GeminiSafetySettings.normalizeThreshold(platform.sexuallyExplicitSafetyThreshold)) }
+    var dangerousContent by remember { mutableStateOf(GeminiSafetySettings.normalizeThreshold(platform.dangerousContentSafetyThreshold)) }
+
+    AlertDialog(
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+        modifier = Modifier
+            .widthIn(max = screenWidth - 40.dp)
+            .heightIn(max = screenHeight - 80.dp),
+        title = { Text(text = stringResource(R.string.gemini_safety_settings)) },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState())
+            ) {
+                SafetyThresholdDropdown(
+                    label = stringResource(R.string.gemini_safety_harassment),
+                    selectedThreshold = harassment,
+                    onThresholdSelected = { harassment = it }
+                )
+                SafetyThresholdDropdown(
+                    label = stringResource(R.string.gemini_safety_hate_speech),
+                    selectedThreshold = hateSpeech,
+                    onThresholdSelected = { hateSpeech = it }
+                )
+                SafetyThresholdDropdown(
+                    label = stringResource(R.string.gemini_safety_sexually_explicit),
+                    selectedThreshold = sexuallyExplicit,
+                    onThresholdSelected = { sexuallyExplicit = it }
+                )
+                SafetyThresholdDropdown(
+                    label = stringResource(R.string.gemini_safety_dangerous_content),
+                    selectedThreshold = dangerousContent,
+                    onThresholdSelected = { dangerousContent = it }
+                )
+            }
+        },
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirmRequest(harassment, hateSpeech, sexuallyExplicit, dangerousContent) }
+            ) {
+                Text(stringResource(R.string.confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SafetyThresholdDropdown(
+    label: String,
+    selectedThreshold: String,
+    onThresholdSelected: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it }
+    ) {
+        OutlinedTextField(
+            modifier = Modifier
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable, true)
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
+            value = GeminiSafetySettings.labelFor(selectedThreshold),
+            onValueChange = {},
+            readOnly = true,
+            label = { Text(label) },
+            trailingIcon = {
+                ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+            }
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            GeminiSafetySettings.supportedThresholds.forEach { threshold ->
+                DropdownMenuItem(
+                    text = { Text(GeminiSafetySettings.labelFor(threshold)) },
+                    onClick = {
+                        onThresholdSelected(threshold)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingDialogs.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingDialogs.kt
@@ -765,7 +765,7 @@ private fun SafetyThresholdDropdown(
                 .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable, true)
                 .fillMaxWidth()
                 .padding(vertical = 8.dp),
-            value = GeminiSafetySettings.labelFor(selectedThreshold),
+            value = stringResource(GeminiSafetySettings.labelResFor(selectedThreshold)),
             onValueChange = {},
             readOnly = true,
             label = { Text(label) },
@@ -779,7 +779,7 @@ private fun SafetyThresholdDropdown(
         ) {
             GeminiSafetySettings.supportedThresholds.forEach { threshold ->
                 DropdownMenuItem(
-                    text = { Text(GeminiSafetySettings.labelFor(threshold)) },
+                    text = { Text(stringResource(GeminiSafetySettings.labelResFor(threshold))) },
                     onClick = {
                         onThresholdSelected(threshold)
                         expanded = false

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingScreen.kt
@@ -226,6 +226,23 @@ fun PlatformSettingScreen(
                         )
                     }
                 )
+                if (platformData.compatibleType == ClientType.GOOGLE) {
+                    SettingItem(
+                        modifier = Modifier.height(64.dp),
+                        title = stringResource(R.string.gemini_safety_settings),
+                        description = stringResource(R.string.gemini_safety_settings_description),
+                        enabled = platformData.enabled,
+                        onItemClick = settingViewModel::openGeminiSafetyDialog,
+                        showTrailingIcon = false,
+                        showLeadingIcon = true,
+                        leadingIcon = {
+                            Icon(
+                                ImageVector.vectorResource(id = R.drawable.ic_info),
+                                contentDescription = stringResource(R.string.gemini_safety_settings_icon)
+                            )
+                        }
+                    )
+                }
                 ExtendedThinkingSwitch(
                     modifier = Modifier.height(64.dp),
                     enabled = platformData.enabled,
@@ -241,6 +258,7 @@ fun PlatformSettingScreen(
                 TopPDialog(dialogState, platformData.topP, settingViewModel)
                 SystemPromptDialog(dialogState, platformData.systemPrompt ?: "", settingViewModel)
                 TimeoutDialog(dialogState, platformData.timeout, settingViewModel)
+                GeminiSafetySettingsDialog(dialogState, platformData, settingViewModel)
                 DeletePlatformDialog(dialogState, settingViewModel)
             }
         }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingViewModel.kt
@@ -85,6 +85,9 @@ class PlatformSettingViewModel @Inject constructor(
     fun openTimeoutDialog() = _dialogState.update { it.copy(isTimeoutDialogOpen = true) }
     fun closeTimeoutDialog() = _dialogState.update { it.copy(isTimeoutDialogOpen = false) }
 
+    fun openGeminiSafetyDialog() = _dialogState.update { it.copy(isGeminiSafetyDialogOpen = true) }
+    fun closeGeminiSafetyDialog() = _dialogState.update { it.copy(isGeminiSafetyDialogOpen = false) }
+
     fun updatePlatformName(name: String) {
         _platformState.value?.let { platform ->
             updatePlatform(platform.copy(name = name.trim()))
@@ -142,6 +145,25 @@ class PlatformSettingViewModel @Inject constructor(
         }
     }
 
+    fun updateGeminiSafetySettings(
+        harassmentSafetyThreshold: String,
+        hateSpeechSafetyThreshold: String,
+        sexuallyExplicitSafetyThreshold: String,
+        dangerousContentSafetyThreshold: String
+    ) {
+        _platformState.value?.let { platform ->
+            updatePlatform(
+                platform.copy(
+                    harassmentSafetyThreshold = harassmentSafetyThreshold,
+                    hateSpeechSafetyThreshold = hateSpeechSafetyThreshold,
+                    sexuallyExplicitSafetyThreshold = sexuallyExplicitSafetyThreshold,
+                    dangerousContentSafetyThreshold = dangerousContentSafetyThreshold
+                )
+            )
+            closeGeminiSafetyDialog()
+        }
+    }
+
     fun openDeleteDialog() = _dialogState.update { it.copy(isDeleteDialogOpen = true) }
     fun closeDeleteDialog() = _dialogState.update { it.copy(isDeleteDialogOpen = false) }
 
@@ -164,6 +186,7 @@ class PlatformSettingViewModel @Inject constructor(
         val isTopPDialogOpen: Boolean = false,
         val isSystemPromptDialogOpen: Boolean = false,
         val isTimeoutDialogOpen: Boolean = false,
+        val isGeminiSafetyDialogOpen: Boolean = false,
         val isDeleteDialogOpen: Boolean = false
     )
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
+import dev.chungjungsoo.gptmobile.data.model.GeminiSafetySettings
 import dev.chungjungsoo.gptmobile.data.repository.SettingRepository
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -154,10 +155,10 @@ class PlatformSettingViewModel @Inject constructor(
         _platformState.value?.let { platform ->
             updatePlatform(
                 platform.copy(
-                    harassmentSafetyThreshold = harassmentSafetyThreshold,
-                    hateSpeechSafetyThreshold = hateSpeechSafetyThreshold,
-                    sexuallyExplicitSafetyThreshold = sexuallyExplicitSafetyThreshold,
-                    dangerousContentSafetyThreshold = dangerousContentSafetyThreshold
+                    harassmentSafetyThreshold = GeminiSafetySettings.normalizeThreshold(harassmentSafetyThreshold),
+                    hateSpeechSafetyThreshold = GeminiSafetySettings.normalizeThreshold(hateSpeechSafetyThreshold),
+                    sexuallyExplicitSafetyThreshold = GeminiSafetySettings.normalizeThreshold(sexuallyExplicitSafetyThreshold),
+                    dangerousContentSafetyThreshold = GeminiSafetySettings.normalizeThreshold(dangerousContentSafetyThreshold)
                 )
             )
             closeGeminiSafetyDialog()

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -153,4 +153,11 @@
     <string name="select_groq_model">حدد نموذج دردشة Groq</string>
     <string name="select_groq_model_description">يرجى تحديد نموذج دردشة Groq. إذا كنت تريد نماذج غير موجودة في القائمة، فراجع موقع وثائق Groq API وشاهد ما هو متاح.</string>
     <string name="export_chat">تصدير الدردشة</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -153,11 +153,15 @@
     <string name="select_groq_model">حدد نموذج دردشة Groq</string>
     <string name="select_groq_model_description">يرجى تحديد نموذج دردشة Groq. إذا كنت تريد نماذج غير موجودة في القائمة، فراجع موقع وثائق Groq API وشاهد ما هو متاح.</string>
     <string name="export_chat">تصدير الدردشة</string>
-    <string name="gemini_safety_settings">Gemini safety settings</string>
-    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
-    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
-    <string name="gemini_safety_harassment">Harassment</string>
-    <string name="gemini_safety_hate_speech">Hate speech</string>
-    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
-    <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_settings">إعدادات أمان Gemini</string>
+    <string name="gemini_safety_settings_description">المضايقة، خطاب الكراهية، المحتوى الجنسي، المحتوى الخطير</string>
+    <string name="gemini_safety_settings_icon">أيقونة إعدادات أمان Gemini</string>
+    <string name="gemini_safety_harassment">المضايقة</string>
+    <string name="gemini_safety_hate_speech">خطاب الكراهية</string>
+    <string name="gemini_safety_sexually_explicit">محتوى جنسي صريح</string>
+    <string name="gemini_safety_dangerous_content">محتوى خطير</string>
+    <string name="gemini_safety_block_none">عدم الحظر</string>
+    <string name="gemini_safety_block_only_high">حظر العالي فقط</string>
+    <string name="gemini_safety_block_medium_and_above">حظر المتوسط وما فوق</string>
+    <string name="gemini_safety_block_low_and_above">حظر المنخفض وما فوق</string>
 </resources>

--- a/app/src/main/res/values-ars/strings.xml
+++ b/app/src/main/res/values-ars/strings.xml
@@ -152,11 +152,15 @@
     <string name="default_mode">افتراضي</string>
     <string name="ai_generated">تم إنشاؤه بواسطة الذكاء الاصطناعي (تجريبي)</string>
     <string name="update">تحديث</string>
-    <string name="gemini_safety_settings">Gemini safety settings</string>
-    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
-    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
-    <string name="gemini_safety_harassment">Harassment</string>
-    <string name="gemini_safety_hate_speech">Hate speech</string>
-    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
-    <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_settings">إعدادات أمان Gemini</string>
+    <string name="gemini_safety_settings_description">المضايقة، خطاب الكراهية، المحتوى الجنسي، المحتوى الخطير</string>
+    <string name="gemini_safety_settings_icon">أيقونة إعدادات أمان Gemini</string>
+    <string name="gemini_safety_harassment">المضايقة</string>
+    <string name="gemini_safety_hate_speech">خطاب الكراهية</string>
+    <string name="gemini_safety_sexually_explicit">محتوى جنسي صريح</string>
+    <string name="gemini_safety_dangerous_content">محتوى خطير</string>
+    <string name="gemini_safety_block_none">عدم الحظر</string>
+    <string name="gemini_safety_block_only_high">حظر العالي فقط</string>
+    <string name="gemini_safety_block_medium_and_above">حظر المتوسط وما فوق</string>
+    <string name="gemini_safety_block_low_and_above">حظر المنخفض وما فوق</string>
 </resources>

--- a/app/src/main/res/values-ars/strings.xml
+++ b/app/src/main/res/values-ars/strings.xml
@@ -152,4 +152,11 @@
     <string name="default_mode">افتراضي</string>
     <string name="ai_generated">تم إنشاؤه بواسطة الذكاء الاصطناعي (تجريبي)</string>
     <string name="update">تحديث</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -83,4 +83,11 @@
     <string name="retry">Wiederholen</string>
     <string name="ask_a_question">Stelle eine Frage…</string>
     <string name="some_platforms_disabled">Einige APIs sind deaktiviert</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -83,11 +83,15 @@
     <string name="retry">Wiederholen</string>
     <string name="ask_a_question">Stelle eine Frage…</string>
     <string name="some_platforms_disabled">Einige APIs sind deaktiviert</string>
-    <string name="gemini_safety_settings">Gemini safety settings</string>
-    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
-    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
-    <string name="gemini_safety_harassment">Harassment</string>
-    <string name="gemini_safety_hate_speech">Hate speech</string>
-    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
-    <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_settings">Gemini-Sicherheitseinstellungen</string>
+    <string name="gemini_safety_settings_description">Belästigung, Hassrede, sexuelle und gefährliche Inhalte</string>
+    <string name="gemini_safety_settings_icon">Symbol für Gemini-Sicherheitseinstellungen</string>
+    <string name="gemini_safety_harassment">Belästigung</string>
+    <string name="gemini_safety_hate_speech">Hassrede</string>
+    <string name="gemini_safety_sexually_explicit">Sexuell explizit</string>
+    <string name="gemini_safety_dangerous_content">Gefährliche Inhalte</string>
+    <string name="gemini_safety_block_none">Nichts blockieren</string>
+    <string name="gemini_safety_block_only_high">Nur hoch blockieren</string>
+    <string name="gemini_safety_block_medium_and_above">Mittel und höher blockieren</string>
+    <string name="gemini_safety_block_low_and_above">Niedrig und höher blockieren</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -153,11 +153,15 @@
     <string name="f_droid_icon">F-Droid Icono</string>
     <string name="play_store_icon">Play Store Icono</string>
     <string name="url_icon">URL Icono</string>
-    <string name="gemini_safety_settings">Gemini safety settings</string>
-    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
-    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
-    <string name="gemini_safety_harassment">Harassment</string>
-    <string name="gemini_safety_hate_speech">Hate speech</string>
-    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
-    <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_settings">Configuración de seguridad de Gemini</string>
+    <string name="gemini_safety_settings_description">Acoso, discurso de odio, contenido sexual y peligroso</string>
+    <string name="gemini_safety_settings_icon">Icono de configuración de seguridad de Gemini</string>
+    <string name="gemini_safety_harassment">Acoso</string>
+    <string name="gemini_safety_hate_speech">Discurso de odio</string>
+    <string name="gemini_safety_sexually_explicit">Sexualmente explícito</string>
+    <string name="gemini_safety_dangerous_content">Contenido peligroso</string>
+    <string name="gemini_safety_block_none">No bloquear</string>
+    <string name="gemini_safety_block_only_high">Bloquear solo alto</string>
+    <string name="gemini_safety_block_medium_and_above">Bloquear medio y superior</string>
+    <string name="gemini_safety_block_low_and_above">Bloquear bajo y superior</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -153,4 +153,11 @@
     <string name="f_droid_icon">F-Droid Icono</string>
     <string name="play_store_icon">Play Store Icono</string>
     <string name="url_icon">URL Icono</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -3,11 +3,15 @@
     <string name="app_name">جی‌پی‌تی موبایل</string>
     <string name="gpt_mobile_introduction_logo">لوگوی معرفی جی‌پی‌تی موبایل</string>
     <string name="welcome_title">بهترین دستیار هوش‌مصنوعی\nشما میتونید ان را در\nتفلن همراه خود داشته باشید</string>
-    <string name="gemini_safety_settings">Gemini safety settings</string>
-    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
-    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
-    <string name="gemini_safety_harassment">Harassment</string>
-    <string name="gemini_safety_hate_speech">Hate speech</string>
-    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
-    <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_settings">تنظیمات ایمنی Gemini</string>
+    <string name="gemini_safety_settings_description">آزار، نفرت پراکنی، محتوای جنسی، محتوای خطرناک</string>
+    <string name="gemini_safety_settings_icon">نماد تنظیمات ایمنی Gemini</string>
+    <string name="gemini_safety_harassment">آزار</string>
+    <string name="gemini_safety_hate_speech">نفرت پراکنی</string>
+    <string name="gemini_safety_sexually_explicit">محتوای جنسی صریح</string>
+    <string name="gemini_safety_dangerous_content">محتوای خطرناک</string>
+    <string name="gemini_safety_block_none">مسدود نکن</string>
+    <string name="gemini_safety_block_only_high">فقط سطح بالا را مسدود کن</string>
+    <string name="gemini_safety_block_medium_and_above">سطح متوسط و بالاتر را مسدود کن</string>
+    <string name="gemini_safety_block_low_and_above">سطح پایین و بالاتر را مسدود کن</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -3,4 +3,11 @@
     <string name="app_name">جی‌پی‌تی موبایل</string>
     <string name="gpt_mobile_introduction_logo">لوگوی معرفی جی‌پی‌تی موبایل</string>
     <string name="welcome_title">بهترین دستیار هوش‌مصنوعی\nشما میتونید ان را در\nتفلن همراه خود داشته باشید</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">GPTMobile</string>
-    <string name="gemini_safety_settings">Gemini safety settings</string>
-    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
-    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
-    <string name="gemini_safety_harassment">Harassment</string>
-    <string name="gemini_safety_hate_speech">Hate speech</string>
-    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
-    <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_settings">Paramètres de sécurité Gemini</string>
+    <string name="gemini_safety_settings_description">Harcèlement, discours haineux, contenu sexuel et dangereux</string>
+    <string name="gemini_safety_settings_icon">Icône des paramètres de sécurité Gemini</string>
+    <string name="gemini_safety_harassment">Harcèlement</string>
+    <string name="gemini_safety_hate_speech">Discours haineux</string>
+    <string name="gemini_safety_sexually_explicit">Sexuellement explicite</string>
+    <string name="gemini_safety_dangerous_content">Contenu dangereux</string>
+    <string name="gemini_safety_block_none">Ne rien bloquer</string>
+    <string name="gemini_safety_block_only_high">Bloquer uniquement le niveau élevé</string>
+    <string name="gemini_safety_block_medium_and_above">Bloquer le niveau moyen et supérieur</string>
+    <string name="gemini_safety_block_low_and_above">Bloquer le niveau faible et supérieur</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">GPTMobile</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -243,11 +243,15 @@
     <string name="at_least_one_platform_required">Tambahkan setidaknya satu platform untuk melanjutkan</string>
     <string name="remove">Hapus</string>
     <string name="revision_counter">Revisi %1$d/%2$d</string>
-    <string name="gemini_safety_settings">Gemini safety settings</string>
-    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
-    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
-    <string name="gemini_safety_harassment">Harassment</string>
-    <string name="gemini_safety_hate_speech">Hate speech</string>
-    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
-    <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_settings">Setelan keamanan Gemini</string>
+    <string name="gemini_safety_settings_description">Pelecehan, ujaran kebencian, konten seksual, konten berbahaya</string>
+    <string name="gemini_safety_settings_icon">Ikon setelan keamanan Gemini</string>
+    <string name="gemini_safety_harassment">Pelecehan</string>
+    <string name="gemini_safety_hate_speech">Ujaran kebencian</string>
+    <string name="gemini_safety_sexually_explicit">Seksual eksplisit</string>
+    <string name="gemini_safety_dangerous_content">Konten berbahaya</string>
+    <string name="gemini_safety_block_none">Jangan blokir</string>
+    <string name="gemini_safety_block_only_high">Blokir hanya tingkat tinggi</string>
+    <string name="gemini_safety_block_medium_and_above">Blokir tingkat sedang ke atas</string>
+    <string name="gemini_safety_block_low_and_above">Blokir tingkat rendah ke atas</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -243,4 +243,11 @@
     <string name="at_least_one_platform_required">Tambahkan setidaknya satu platform untuk melanjutkan</string>
     <string name="remove">Hapus</string>
     <string name="revision_counter">Revisi %1$d/%2$d</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -153,4 +153,11 @@
     <string name="api_address_description">אנא הזן את כתובת ה-API של Ollama שלך כולל מספר הפורט. האפליקציה תשתמש בנקודת קצה v1/chat/completions, אז אנא הזן רק את החלק הקדמי של הכתובת המלאה. הכתובת חייבת להסתיים ב-\'/\'. למשל) http://192.168.1.100:11434/</string>
     <string name="select_groq_model_description">אנא בחר את מודל הצ\'אט של Groq. אם אתה רוצה דגמים שאינם ברשימה, בדוק את אתר התיעוד של Groq API והזן שם של מודל זמין.</string>
     <string name="default_mode">ברירת מחדל</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -153,11 +153,15 @@
     <string name="api_address_description">אנא הזן את כתובת ה-API של Ollama שלך כולל מספר הפורט. האפליקציה תשתמש בנקודת קצה v1/chat/completions, אז אנא הזן רק את החלק הקדמי של הכתובת המלאה. הכתובת חייבת להסתיים ב-\'/\'. למשל) http://192.168.1.100:11434/</string>
     <string name="select_groq_model_description">אנא בחר את מודל הצ\'אט של Groq. אם אתה רוצה דגמים שאינם ברשימה, בדוק את אתר התיעוד של Groq API והזן שם של מודל זמין.</string>
     <string name="default_mode">ברירת מחדל</string>
-    <string name="gemini_safety_settings">Gemini safety settings</string>
-    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
-    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
-    <string name="gemini_safety_harassment">Harassment</string>
-    <string name="gemini_safety_hate_speech">Hate speech</string>
-    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
-    <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_settings">הגדרות בטיחות Gemini</string>
+    <string name="gemini_safety_settings_description">הטרדה, דברי שטנה, תוכן מיני, תוכן מסוכן</string>
+    <string name="gemini_safety_settings_icon">סמל הגדרות בטיחות Gemini</string>
+    <string name="gemini_safety_harassment">הטרדה</string>
+    <string name="gemini_safety_hate_speech">דברי שטנה</string>
+    <string name="gemini_safety_sexually_explicit">מיני מפורש</string>
+    <string name="gemini_safety_dangerous_content">תוכן מסוכן</string>
+    <string name="gemini_safety_block_none">לא לחסום</string>
+    <string name="gemini_safety_block_only_high">חסום רק רמה גבוהה</string>
+    <string name="gemini_safety_block_medium_and_above">חסום רמה בינונית ומעלה</string>
+    <string name="gemini_safety_block_low_and_above">חסום רמה נמוכה ומעלה</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -153,11 +153,15 @@
     <string name="user_message">ユーザーメッセージ</string>
     <string name="export_chat">チャットのエクスポート</string>
     <string name="top_p_setting_description">nucleus samplingでは、確率順に減少させ、この値で指定された特定の確率に達すると、その後のトークンの全オプションに累積分布を計算します。\nほとんどのモデルでは、通常この値または温度のどちらかを変更することをお勧めしますが、両方を同時に変更することは推奨しません。</string>
-    <string name="gemini_safety_settings">Gemini safety settings</string>
-    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
-    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
-    <string name="gemini_safety_harassment">Harassment</string>
-    <string name="gemini_safety_hate_speech">Hate speech</string>
-    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
-    <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_settings">Gemini の安全設定</string>
+    <string name="gemini_safety_settings_description">嫌がらせ、ヘイトスピーチ、性的、危険なコンテンツ</string>
+    <string name="gemini_safety_settings_icon">Gemini の安全設定アイコン</string>
+    <string name="gemini_safety_harassment">嫌がらせ</string>
+    <string name="gemini_safety_hate_speech">ヘイトスピーチ</string>
+    <string name="gemini_safety_sexually_explicit">性的に露骨</string>
+    <string name="gemini_safety_dangerous_content">危険なコンテンツ</string>
+    <string name="gemini_safety_block_none">ブロックしない</string>
+    <string name="gemini_safety_block_only_high">高のみブロック</string>
+    <string name="gemini_safety_block_medium_and_above">中以上をブロック</string>
+    <string name="gemini_safety_block_low_and_above">低以上をブロック</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -153,4 +153,11 @@
     <string name="user_message">ユーザーメッセージ</string>
     <string name="export_chat">チャットのエクスポート</string>
     <string name="top_p_setting_description">nucleus samplingでは、確率順に減少させ、この値で指定された特定の確率に達すると、その後のトークンの全オプションに累積分布を計算します。\nほとんどのモデルでは、通常この値または温度のどちらかを変更することをお勧めしますが、両方を同時に変更することは推奨しません。</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -156,11 +156,15 @@
     <string name="not_set">설정되지 않음</string>
     <string name="export_chat">채팅 내보내기</string>
     <string name="migration_assistant">마이그레이션 도구</string>
-    <string name="gemini_safety_settings">Gemini safety settings</string>
-    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
-    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
-    <string name="gemini_safety_harassment">Harassment</string>
-    <string name="gemini_safety_hate_speech">Hate speech</string>
-    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
-    <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_settings">Gemini 안전 설정</string>
+    <string name="gemini_safety_settings_description">괴롭힘, 혐오 발언, 성적 콘텐츠, 위험한 콘텐츠</string>
+    <string name="gemini_safety_settings_icon">Gemini 안전 설정 아이콘</string>
+    <string name="gemini_safety_harassment">괴롭힘</string>
+    <string name="gemini_safety_hate_speech">혐오 발언</string>
+    <string name="gemini_safety_sexually_explicit">노골적인 성적 콘텐츠</string>
+    <string name="gemini_safety_dangerous_content">위험한 콘텐츠</string>
+    <string name="gemini_safety_block_none">차단 안 함</string>
+    <string name="gemini_safety_block_only_high">높음만 차단</string>
+    <string name="gemini_safety_block_medium_and_above">중간 이상 차단</string>
+    <string name="gemini_safety_block_low_and_above">낮음 이상 차단</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -156,4 +156,11 @@
     <string name="not_set">설정되지 않음</string>
     <string name="export_chat">채팅 내보내기</string>
     <string name="migration_assistant">마이그레이션 도구</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -153,11 +153,15 @@
     <string name="openai_description">Twórca Chata GPT.</string>
     <string name="enter_api_key">Podaj klucz API</string>
     <string name="token_input_description">Wprowadź klucz API wybranej przez Ciebie platformy. Nasza aplikacja nie zbiera tych danych. Klucze API i historia czatów są zapisywane tylko na Twoim urządzeniu, i nie zostaną nigdzie wysłane, z wyjątkiem serwerów odbiorczych API.</string>
-    <string name="gemini_safety_settings">Gemini safety settings</string>
-    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
-    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
-    <string name="gemini_safety_harassment">Harassment</string>
-    <string name="gemini_safety_hate_speech">Hate speech</string>
-    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
-    <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_settings">Ustawienia bezpieczeństwa Gemini</string>
+    <string name="gemini_safety_settings_description">Nękanie, mowa nienawiści, treści seksualne, treści niebezpieczne</string>
+    <string name="gemini_safety_settings_icon">Ikona ustawień bezpieczeństwa Gemini</string>
+    <string name="gemini_safety_harassment">Nękanie</string>
+    <string name="gemini_safety_hate_speech">Mowa nienawiści</string>
+    <string name="gemini_safety_sexually_explicit">Treści jednoznacznie seksualne</string>
+    <string name="gemini_safety_dangerous_content">Treści niebezpieczne</string>
+    <string name="gemini_safety_block_none">Nie blokuj</string>
+    <string name="gemini_safety_block_only_high">Blokuj tylko wysoki poziom</string>
+    <string name="gemini_safety_block_medium_and_above">Blokuj średni i wyższy poziom</string>
+    <string name="gemini_safety_block_low_and_above">Blokuj niski i wyższy poziom</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -153,4 +153,11 @@
     <string name="openai_description">Twórca Chata GPT.</string>
     <string name="enter_api_key">Podaj klucz API</string>
     <string name="token_input_description">Wprowadź klucz API wybranej przez Ciebie platformy. Nasza aplikacja nie zbiera tych danych. Klucze API i historia czatów są zapisywane tylko na Twoim urządzeniu, i nie zostaną nigdzie wysłane, z wyjątkiem serwerów odbiorczych API.</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -152,11 +152,15 @@
     <string name="user_message">Mensagem do Usuário</string>
     <string name="title_length_limit">Limite de comprimento do título: %1$s/50</string>
     <string name="ai_generated">Gerado por IA (Beta)</string>
-    <string name="gemini_safety_settings">Gemini safety settings</string>
-    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
-    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
-    <string name="gemini_safety_harassment">Harassment</string>
-    <string name="gemini_safety_hate_speech">Hate speech</string>
-    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
-    <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_settings">Configurações de segurança do Gemini</string>
+    <string name="gemini_safety_settings_description">Assédio, discurso de ódio, conteúdo sexual, conteúdo perigoso</string>
+    <string name="gemini_safety_settings_icon">Ícone das configurações de segurança do Gemini</string>
+    <string name="gemini_safety_harassment">Assédio</string>
+    <string name="gemini_safety_hate_speech">Discurso de ódio</string>
+    <string name="gemini_safety_sexually_explicit">Sexualmente explícito</string>
+    <string name="gemini_safety_dangerous_content">Conteúdo perigoso</string>
+    <string name="gemini_safety_block_none">Não bloquear</string>
+    <string name="gemini_safety_block_only_high">Bloquear apenas alto</string>
+    <string name="gemini_safety_block_medium_and_above">Bloquear médio e acima</string>
+    <string name="gemini_safety_block_low_and_above">Bloquear baixo e acima</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -152,4 +152,11 @@
     <string name="user_message">Mensagem do Usuário</string>
     <string name="title_length_limit">Limite de comprimento do título: %1$s/50</string>
     <string name="ai_generated">Gerado por IA (Beta)</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -150,4 +150,11 @@
     <string name="edit">Editar</string>
     <string name="edit_question">Editar Mensagem do Utilizador</string>
     <string name="user_message">Mensagem do Utilizador</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -150,11 +150,15 @@
     <string name="edit">Editar</string>
     <string name="edit_question">Editar Mensagem do Utilizador</string>
     <string name="user_message">Mensagem do Utilizador</string>
-    <string name="gemini_safety_settings">Gemini safety settings</string>
-    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
-    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
-    <string name="gemini_safety_harassment">Harassment</string>
-    <string name="gemini_safety_hate_speech">Hate speech</string>
-    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
-    <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_settings">Configurações de segurança do Gemini</string>
+    <string name="gemini_safety_settings_description">Assédio, discurso de ódio, conteúdo sexual, conteúdo perigoso</string>
+    <string name="gemini_safety_settings_icon">Ícone das configurações de segurança do Gemini</string>
+    <string name="gemini_safety_harassment">Assédio</string>
+    <string name="gemini_safety_hate_speech">Discurso de ódio</string>
+    <string name="gemini_safety_sexually_explicit">Sexualmente explícito</string>
+    <string name="gemini_safety_dangerous_content">Conteúdo perigoso</string>
+    <string name="gemini_safety_block_none">Não bloquear</string>
+    <string name="gemini_safety_block_only_high">Bloquear apenas alto</string>
+    <string name="gemini_safety_block_medium_and_above">Bloquear médio e acima</string>
+    <string name="gemini_safety_block_low_and_above">Bloquear baixo e acima</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -243,4 +243,11 @@
     <string name="assistant_message">Сообщение ассистента</string>
     <string name="assistant_thoughts">Размышления ассистента</string>
     <string name="revision_counter">Редакция %1$d/%2$d</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -243,11 +243,15 @@
     <string name="assistant_message">Сообщение ассистента</string>
     <string name="assistant_thoughts">Размышления ассистента</string>
     <string name="revision_counter">Редакция %1$d/%2$d</string>
-    <string name="gemini_safety_settings">Gemini safety settings</string>
-    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
-    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
-    <string name="gemini_safety_harassment">Harassment</string>
-    <string name="gemini_safety_hate_speech">Hate speech</string>
-    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
-    <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_settings">Настройки безопасности Gemini</string>
+    <string name="gemini_safety_settings_description">Домогательства, язык ненависти, сексуальный и опасный контент</string>
+    <string name="gemini_safety_settings_icon">Значок настроек безопасности Gemini</string>
+    <string name="gemini_safety_harassment">Домогательства</string>
+    <string name="gemini_safety_hate_speech">Язык ненависти</string>
+    <string name="gemini_safety_sexually_explicit">Откровенно сексуальный контент</string>
+    <string name="gemini_safety_dangerous_content">Опасный контент</string>
+    <string name="gemini_safety_block_none">Не блокировать</string>
+    <string name="gemini_safety_block_only_high">Блокировать только высокий уровень</string>
+    <string name="gemini_safety_block_medium_and_above">Блокировать средний и выше</string>
+    <string name="gemini_safety_block_low_and_above">Блокировать низкий и выше</string>
 </resources>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -152,4 +152,11 @@
     <string name="token_input_warning">குறிப்பு: ஓப்பனாய் மற்றும் ஆந்த்ரிக் ப்ரீபெய்ட் பில்லிங்கைப் பயன்படுத்துகின்றன, எனவே நீங்கள் ஒவ்வொரு கணக்குகளிலும் அவற்றைப் பயன்படுத்துவதற்கு முன்பு வரவுகளை வசூலிக்க வேண்டும். இல்லையெனில், பதில் பிழையைத் தரும்.</string>
     <string name="edit_question">பயனர் செய்தியைத் திருத்தவும்</string>
     <string name="user_message">பயனர் செய்தி</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
 </resources>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -152,11 +152,15 @@
     <string name="token_input_warning">குறிப்பு: ஓப்பனாய் மற்றும் ஆந்த்ரிக் ப்ரீபெய்ட் பில்லிங்கைப் பயன்படுத்துகின்றன, எனவே நீங்கள் ஒவ்வொரு கணக்குகளிலும் அவற்றைப் பயன்படுத்துவதற்கு முன்பு வரவுகளை வசூலிக்க வேண்டும். இல்லையெனில், பதில் பிழையைத் தரும்.</string>
     <string name="edit_question">பயனர் செய்தியைத் திருத்தவும்</string>
     <string name="user_message">பயனர் செய்தி</string>
-    <string name="gemini_safety_settings">Gemini safety settings</string>
-    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
-    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
-    <string name="gemini_safety_harassment">Harassment</string>
-    <string name="gemini_safety_hate_speech">Hate speech</string>
-    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
-    <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_settings">Gemini பாதுகாப்பு அமைப்புகள்</string>
+    <string name="gemini_safety_settings_description">தொல்லை, வெறுப்பு பேச்சு, பாலியல் உள்ளடக்கம், ஆபத்தான உள்ளடக்கம்</string>
+    <string name="gemini_safety_settings_icon">Gemini பாதுகாப்பு அமைப்புகள் ஐகான்</string>
+    <string name="gemini_safety_harassment">தொல்லை</string>
+    <string name="gemini_safety_hate_speech">வெறுப்பு பேச்சு</string>
+    <string name="gemini_safety_sexually_explicit">வெளிப்படையான பாலியல்</string>
+    <string name="gemini_safety_dangerous_content">ஆபத்தான உள்ளடக்கம்</string>
+    <string name="gemini_safety_block_none">தடுக்க வேண்டாம்</string>
+    <string name="gemini_safety_block_only_high">உயர் மட்டத்தை மட்டும் தடு</string>
+    <string name="gemini_safety_block_medium_and_above">நடுத்தரமும் அதற்கு மேலுமுள்ளதை தடு</string>
+    <string name="gemini_safety_block_low_and_above">குறைந்ததும் அதற்கு மேலுமுள்ளதை தடு</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -192,11 +192,15 @@
     <string name="edit_question">Kullanıcı Mesajını Düzenle</string>
     <string name="user_message">Kullanıcı Mesajı</string>
     <string name="export_chat">Sohbeti Dışa Aktar</string>
-    <string name="gemini_safety_settings">Gemini safety settings</string>
-    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
-    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
-    <string name="gemini_safety_harassment">Harassment</string>
-    <string name="gemini_safety_hate_speech">Hate speech</string>
-    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
-    <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_settings">Gemini güvenlik ayarları</string>
+    <string name="gemini_safety_settings_description">Taciz, nefret söylemi, cinsel içerik, tehlikeli içerik</string>
+    <string name="gemini_safety_settings_icon">Gemini güvenlik ayarları simgesi</string>
+    <string name="gemini_safety_harassment">Taciz</string>
+    <string name="gemini_safety_hate_speech">Nefret söylemi</string>
+    <string name="gemini_safety_sexually_explicit">Cinsel açıdan açık</string>
+    <string name="gemini_safety_dangerous_content">Tehlikeli içerik</string>
+    <string name="gemini_safety_block_none">Engelleme</string>
+    <string name="gemini_safety_block_only_high">Yalnızca yüksek olanı engelle</string>
+    <string name="gemini_safety_block_medium_and_above">Orta ve üzerini engelle</string>
+    <string name="gemini_safety_block_low_and_above">Düşük ve üzerini engelle</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -192,4 +192,11 @@
     <string name="edit_question">Kullanıcı Mesajını Düzenle</string>
     <string name="user_message">Kullanıcı Mesajı</string>
     <string name="export_chat">Sohbeti Dışa Aktar</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -226,4 +226,11 @@
     <string name="platform_added_successfully">提供商添加成功</string>
     <string name="at_least_one_platform_required">请至少启用一个提供商</string>
     <string name="remove">移除</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -226,11 +226,15 @@
     <string name="platform_added_successfully">提供商添加成功</string>
     <string name="at_least_one_platform_required">请至少启用一个提供商</string>
     <string name="remove">移除</string>
-    <string name="gemini_safety_settings">Gemini safety settings</string>
-    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
-    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
-    <string name="gemini_safety_harassment">Harassment</string>
-    <string name="gemini_safety_hate_speech">Hate speech</string>
-    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
-    <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_settings">Gemini 安全设置</string>
+    <string name="gemini_safety_settings_description">骚扰、仇恨言论、性内容、危险内容</string>
+    <string name="gemini_safety_settings_icon">Gemini 安全设置图标</string>
+    <string name="gemini_safety_harassment">骚扰</string>
+    <string name="gemini_safety_hate_speech">仇恨言论</string>
+    <string name="gemini_safety_sexually_explicit">露骨色情内容</string>
+    <string name="gemini_safety_dangerous_content">危险内容</string>
+    <string name="gemini_safety_block_none">不屏蔽</string>
+    <string name="gemini_safety_block_only_high">仅屏蔽高风险</string>
+    <string name="gemini_safety_block_medium_and_above">屏蔽中等及以上</string>
+    <string name="gemini_safety_block_low_and_above">屏蔽低及以上</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,6 +124,13 @@
     <string name="timeout_seconds_label">Timeout (seconds)</string>
     <string name="timeout_setting_description">Maximum idle time between streamed response chunks. Set to 0 to disable the timeout.</string>
     <string name="timeout_invalid">Enter 0 or a positive number of seconds.</string>
+    <string name="gemini_safety_settings">Gemini safety settings</string>
+    <string name="gemini_safety_settings_description">Harassment, hate speech, sexual, dangerous content</string>
+    <string name="gemini_safety_settings_icon">Gemini safety settings icon</string>
+    <string name="gemini_safety_harassment">Harassment</string>
+    <string name="gemini_safety_hate_speech">Hate speech</string>
+    <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
+    <string name="gemini_safety_dangerous_content">Dangerous content</string>
     <string name="about">About</string>
     <string name="about_description">Version, License, Feedback</string>
     <string name="version">Version</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,6 +131,10 @@
     <string name="gemini_safety_hate_speech">Hate speech</string>
     <string name="gemini_safety_sexually_explicit">Sexually explicit</string>
     <string name="gemini_safety_dangerous_content">Dangerous content</string>
+    <string name="gemini_safety_block_none">Block none</string>
+    <string name="gemini_safety_block_only_high">Block high only</string>
+    <string name="gemini_safety_block_medium_and_above">Block medium and above</string>
+    <string name="gemini_safety_block_low_and_above">Block low and above</string>
     <string name="about">About</string>
     <string name="about_description">Version, License, Feedback</string>
     <string name="version">Version</string>

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2MigrationsTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2MigrationsTest.kt
@@ -2,11 +2,42 @@ package dev.chungjungsoo.gptmobile.data.database
 
 import dev.chungjungsoo.gptmobile.data.database.entity.AssistantRevisionListConverter
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatAttachmentListConverter
+import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
+import dev.chungjungsoo.gptmobile.data.model.ClientType
+import dev.chungjungsoo.gptmobile.data.model.GeminiSafetySettings
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ChatDatabaseV2MigrationsTest {
+    @Test
+    fun `new platform defaults Gemini safety thresholds to block none`() {
+        val platform = PlatformV2(
+            name = "Google",
+            compatibleType = ClientType.GOOGLE,
+            apiUrl = "https://generativelanguage.googleapis.com",
+            model = "gemini-3-pro-preview"
+        )
+
+        assertEquals(GeminiSafetySettings.BLOCK_NONE, platform.harassmentSafetyThreshold)
+        assertEquals(GeminiSafetySettings.BLOCK_NONE, platform.hateSpeechSafetyThreshold)
+        assertEquals(GeminiSafetySettings.BLOCK_NONE, platform.sexuallyExplicitSafetyThreshold)
+        assertEquals(GeminiSafetySettings.BLOCK_NONE, platform.dangerousContentSafetyThreshold)
+    }
+
+    @Test
+    fun `version five migration adds Gemini safety columns with block none defaults`() {
+        assertEquals(
+            listOf(
+                "ALTER TABLE `platform_v2` ADD COLUMN `harassment_safety_threshold` TEXT NOT NULL DEFAULT 'BLOCK_NONE'",
+                "ALTER TABLE `platform_v2` ADD COLUMN `hate_speech_safety_threshold` TEXT NOT NULL DEFAULT 'BLOCK_NONE'",
+                "ALTER TABLE `platform_v2` ADD COLUMN `sexually_explicit_safety_threshold` TEXT NOT NULL DEFAULT 'BLOCK_NONE'",
+                "ALTER TABLE `platform_v2` ADD COLUMN `dangerous_content_safety_threshold` TEXT NOT NULL DEFAULT 'BLOCK_NONE'"
+            ),
+            ChatDatabaseV2Migrations.GEMINI_SAFETY_COLUMN_MIGRATIONS
+        )
+    }
+
     @Test
     fun `legacy file list migrates to attachment json`() {
         val json = ChatDatabaseV2Migrations.legacyFilesToAttachmentsJson("/tmp/first.png,/tmp/second.webp")

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/dto/ProviderAttachmentSerializationTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/dto/ProviderAttachmentSerializationTest.kt
@@ -1,7 +1,10 @@
 package dev.chungjungsoo.gptmobile.data.dto
 
 import dev.chungjungsoo.gptmobile.data.dto.anthropic.common.ImageSource
+import dev.chungjungsoo.gptmobile.data.dto.google.common.Content
 import dev.chungjungsoo.gptmobile.data.dto.google.common.Part
+import dev.chungjungsoo.gptmobile.data.dto.google.request.GenerateContentRequest
+import dev.chungjungsoo.gptmobile.data.dto.google.request.SafetySetting
 import dev.chungjungsoo.gptmobile.data.dto.openai.request.ResponseContentPart
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertFalse
@@ -38,5 +41,26 @@ class ProviderAttachmentSerializationTest {
         assertTrue(payload.contains("\"file_data\""))
         assertTrue(payload.contains("\"file_uri\":\"google-uri\""))
         assertFalse(payload.contains("inline_data"))
+    }
+
+    @Test
+    fun `google generate content request serializes safety settings`() {
+        val payload = json.encodeToString(
+            GenerateContentRequest(
+                contents = listOf(
+                    Content(parts = listOf(Part.text("hello")))
+                ),
+                safetySettings = listOf(
+                    SafetySetting(
+                        category = "HARM_CATEGORY_HARASSMENT",
+                        threshold = "BLOCK_NONE"
+                    )
+                )
+            )
+        )
+
+        assertTrue(payload.contains("\"safetySettings\""))
+        assertTrue(payload.contains("\"category\":\"HARM_CATEGORY_HARASSMENT\""))
+        assertTrue(payload.contains("\"threshold\":\"BLOCK_NONE\""))
     }
 }

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImplTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImplTest.kt
@@ -19,6 +19,7 @@ import dev.chungjungsoo.gptmobile.data.dto.openai.response.ChatCompletionChunk
 import dev.chungjungsoo.gptmobile.data.dto.openai.response.ResponsesStreamEvent
 import dev.chungjungsoo.gptmobile.data.model.ChatAttachment
 import dev.chungjungsoo.gptmobile.data.model.ClientType
+import dev.chungjungsoo.gptmobile.data.model.GeminiSafetySettings
 import dev.chungjungsoo.gptmobile.data.network.AnthropicAPI
 import dev.chungjungsoo.gptmobile.data.network.GoogleAPI
 import dev.chungjungsoo.gptmobile.data.network.GroqAPI
@@ -183,6 +184,29 @@ class ChatRepositoryImplTest {
     }
 
     @Test
+    fun `google request includes configured safety settings`() = runBlocking {
+        val googleAPI = FakeGoogleAPI()
+        val repository = createRepository(googleAPI = googleAPI)
+
+        repository.completeChat(
+            userMessages = listOf(MessageV2(content = "Hi", platformType = null)),
+            assistantMessages = emptyList(),
+            platform = googlePlatform()
+        ).toList()
+
+        assertEquals(1, googleAPI.streamCalls)
+        assertEquals(
+            listOf(
+                GeminiSafetySettings.HARM_CATEGORY_HARASSMENT to GeminiSafetySettings.BLOCK_LOW_AND_ABOVE,
+                GeminiSafetySettings.HARM_CATEGORY_HATE_SPEECH to GeminiSafetySettings.BLOCK_MEDIUM_AND_ABOVE,
+                GeminiSafetySettings.HARM_CATEGORY_SEXUALLY_EXPLICIT to GeminiSafetySettings.BLOCK_ONLY_HIGH,
+                GeminiSafetySettings.HARM_CATEGORY_DANGEROUS_CONTENT to GeminiSafetySettings.BLOCK_NONE
+            ),
+            googleAPI.lastRequest?.safetySettings?.map { it.category to it.threshold }
+        )
+    }
+
+    @Test
     fun `failed historical turn is excluded from subsequent inline budget checks`() = runBlocking {
         val openAIAPI = RecordingOpenAIAPI()
         val repository = createRepository(openAIAPI = openAIAPI)
@@ -242,7 +266,8 @@ class ChatRepositoryImplTest {
 
     private fun createRepository(
         groqAPI: GroqAPI = FakeGroqAPI(emptyFlow()),
-        openAIAPI: OpenAIAPI = RecordingOpenAIAPI()
+        openAIAPI: OpenAIAPI = RecordingOpenAIAPI(),
+        googleAPI: GoogleAPI = FakeGoogleAPI()
     ): ChatRepositoryImpl = ChatRepositoryImpl(
         context = ContextWrapper(null),
         chatRoomDao = proxy(),
@@ -254,11 +279,11 @@ class ChatRepositoryImplTest {
         openAIAPI = openAIAPI,
         groqAPI = groqAPI,
         anthropicAPI = FakeAnthropicAPI(),
-        googleAPI = FakeGoogleAPI(),
+        googleAPI = googleAPI,
         attachmentUploadCoordinator = AttachmentUploadCoordinator(
             openAIAPI,
             FakeAnthropicAPI(),
-            FakeGoogleAPI()
+            googleAPI
         ),
         contextBuilder = ContextBuilder()
     )
@@ -270,6 +295,18 @@ class ChatRepositoryImplTest {
         apiUrl = "https://api.groq.com/openai/",
         model = model,
         reasoning = reasoning
+    )
+
+    private fun googlePlatform() = PlatformV2(
+        uid = "google-platform",
+        name = "Google",
+        compatibleType = ClientType.GOOGLE,
+        apiUrl = "https://generativelanguage.googleapis.com",
+        model = "gemini-3-pro-preview",
+        harassmentSafetyThreshold = GeminiSafetySettings.BLOCK_LOW_AND_ABOVE,
+        hateSpeechSafetyThreshold = GeminiSafetySettings.BLOCK_MEDIUM_AND_ABOVE,
+        sexuallyExplicitSafetyThreshold = GeminiSafetySettings.BLOCK_ONLY_HIGH,
+        dangerousContentSafetyThreshold = GeminiSafetySettings.BLOCK_NONE
     )
 
     private fun customPlatform() = PlatformV2(
@@ -360,6 +397,9 @@ class ChatRepositoryImplTest {
     }
 
     private class FakeGoogleAPI : GoogleAPI {
+        var streamCalls = 0
+        var lastRequest: GenerateContentRequest? = null
+
         override fun setToken(token: String?) = Unit
 
         override fun setAPIUrl(url: String) = Unit
@@ -368,7 +408,11 @@ class ChatRepositoryImplTest {
             request: GenerateContentRequest,
             model: String,
             timeoutSeconds: Int
-        ): Flow<GenerateContentResponse> = emptyFlow()
+        ): Flow<GenerateContentResponse> {
+            streamCalls += 1
+            lastRequest = request
+            return emptyFlow()
+        }
 
         override suspend fun uploadFile(
             filePath: String,

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImplTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImplTest.kt
@@ -8,7 +8,9 @@ import dev.chungjungsoo.gptmobile.data.dto.ApiState
 import dev.chungjungsoo.gptmobile.data.dto.anthropic.request.MessageRequest
 import dev.chungjungsoo.gptmobile.data.dto.anthropic.response.MessageResponseChunk
 import dev.chungjungsoo.gptmobile.data.dto.google.request.GenerateContentRequest
+import dev.chungjungsoo.gptmobile.data.dto.google.response.Candidate
 import dev.chungjungsoo.gptmobile.data.dto.google.response.GenerateContentResponse
+import dev.chungjungsoo.gptmobile.data.dto.google.response.PromptFeedback
 import dev.chungjungsoo.gptmobile.data.dto.groq.request.GroqChatCompletionRequest
 import dev.chungjungsoo.gptmobile.data.dto.groq.response.GroqChatCompletionChunk
 import dev.chungjungsoo.gptmobile.data.dto.groq.response.GroqChoice
@@ -207,6 +209,62 @@ class ChatRepositoryImplTest {
     }
 
     @Test
+    fun `google prompt safety block emits error`() = runBlocking {
+        val repository = createRepository(
+            googleAPI = FakeGoogleAPI(
+                flowOf(
+                    GenerateContentResponse(
+                        promptFeedback = PromptFeedback(blockReason = "SAFETY")
+                    )
+                )
+            )
+        )
+
+        val states = repository.completeChat(
+            userMessages = listOf(MessageV2(content = "Hi", platformType = null)),
+            assistantMessages = emptyList(),
+            platform = googlePlatform()
+        ).toList()
+
+        assertEquals(
+            listOf(
+                ApiState.Loading,
+                ApiState.Error("Gemini safety settings blocked the prompt: SAFETY"),
+                ApiState.Done
+            ),
+            states
+        )
+    }
+
+    @Test
+    fun `google safety finish reason emits error`() = runBlocking {
+        val repository = createRepository(
+            googleAPI = FakeGoogleAPI(
+                flowOf(
+                    GenerateContentResponse(
+                        candidates = listOf(Candidate(finishReason = "SAFETY"))
+                    )
+                )
+            )
+        )
+
+        val states = repository.completeChat(
+            userMessages = listOf(MessageV2(content = "Hi", platformType = null)),
+            assistantMessages = emptyList(),
+            platform = googlePlatform()
+        ).toList()
+
+        assertEquals(
+            listOf(
+                ApiState.Loading,
+                ApiState.Error("Gemini safety settings blocked the response."),
+                ApiState.Done
+            ),
+            states
+        )
+    }
+
+    @Test
     fun `failed historical turn is excluded from subsequent inline budget checks`() = runBlocking {
         val openAIAPI = RecordingOpenAIAPI()
         val repository = createRepository(openAIAPI = openAIAPI)
@@ -396,7 +454,9 @@ class ChatRepositoryImplTest {
         override suspend fun isFileAvailable(fileId: String): Boolean = false
     }
 
-    private class FakeGoogleAPI : GoogleAPI {
+    private class FakeGoogleAPI(
+        private val chunks: Flow<GenerateContentResponse> = emptyFlow()
+    ) : GoogleAPI {
         var streamCalls = 0
         var lastRequest: GenerateContentRequest? = null
 
@@ -411,7 +471,7 @@ class ChatRepositoryImplTest {
         ): Flow<GenerateContentResponse> {
             streamCalls += 1
             lastRequest = request
-            return emptyFlow()
+            return chunks
         }
 
         override suspend fun uploadFile(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,23 @@
 [versions]
-agp = "9.1.1"
-autoLicense = "13.2.1"
-kotlin = "2.3.20"
-coreKtx = "1.18.0"
+agp = "9.2.1"
+autoLicense = "14.2.1"
+kotlin = "2.3.21"
+coreKtx = "1.19.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
-lifecycleRuntime = "2.10.0"
+lifecycleRuntime = "2.11.0"
 activityCompose = "1.13.0"
-composeBom = "2026.03.00"
+composeBom = "2026.06.00"
 datastore = "1.2.1"
 hilt = "2.59.2"
 ksp = "2.3.4" # Also change with Kotlin version
-ktor = "3.4.1"
+ktor = "3.5.0"
 material3 = "1.4.0"
 androidxHilt = "1.3.0"
-navigation = "2.9.7"
-markdownRenderer = "0.39.2"
-serialization = "1.10.0" # Should not update due to kotlin version
+navigation = "2.9.8"
+markdownRenderer = "0.41.0"
+serialization = "1.11.0" # Should not update due to kotlin version
 splashscreen = "1.2.0"
 room = "2.8.4"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon May 20 13:06:02 KST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- Add per-platform Gemini safety thresholds with BLOCK_NONE defaults
- Persist settings through Room migration 4 -> 5
- Send Gemini safetySettings in Google requests
- Add Google-only settings UI and focused tests

## Verification
- [x] ./gradlew :app:testDebugUnitTest --tests "dev.chungjungsoo.gptmobile.data.dto.ProviderAttachmentSerializationTest"
- [x] ./gradlew :app:testDebugUnitTest --tests "dev.chungjungsoo.gptmobile.data.database.ChatDatabaseV2MigrationsTest"
- [x] ./gradlew :app:testDebugUnitTest --tests "dev.chungjungsoo.gptmobile.data.repository.ChatRepositoryImplTest"
- [x] ./gradlew :app:compileDebugKotlin
- [x] ./gradlew :app:lintDebug (fails on pre-existing project-wide lint; first failure is HomeScreen.kt LocalContextGetResourceValueCall, and the generated report has no gemini_safety matches)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Gemini safety settings for Google platforms, with configurable blocking thresholds for harassment, hate speech, sexually explicit content, and dangerous content.
  * Added a Gemini safety settings dialog with dropdowns per category and selectable block levels.
  * Persisted the new safety thresholds and updated the database schema/migrations; added localized UI strings for all supported languages.

* **Bug Fixes**
  * When safety rules block content, the app now shows an error state instead of omitting the response.

* **Tests**
  * Expanded safety settings, serialization, migration, and blocked-response error coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->