### PR TITLE
feat: add agent persistence and secure secrets

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,34 @@
+---
+name: Pull request validation
+
+"on":
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-validation-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Unit tests and Android lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v6
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v4
+
+      - name: Validate
+        run: ./gradlew :app:testDebugUnitTest :app:lintDebug

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Check out source
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up JDK
         uses: actions/setup-java@v5

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 @file:Suppress("UnstableApiUsage")
 
 import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import org.gradle.kotlin.dsl.aboutLibraries
 import org.gradle.kotlin.dsl.configure
 
@@ -62,6 +63,12 @@ extensions.configure<ApplicationExtension> {
             excludes += "META-INF/INDEX.LIST"
             excludes += "META-INF/io.netty.versions.properties"
         }
+    }
+}
+
+extensions.configure<ApplicationAndroidComponentsExtension> {
+    onVariants { variant ->
+        variant.androidTest?.sources?.assets?.addStaticSourceDirectory("$projectDir/schemas")
     }
 }
 
@@ -127,6 +134,7 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.ui.test.junit4)
+    androidTestImplementation(libs.room.testing)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/app/schemas/dev.chungjungsoo.gptmobile.data.database.ChatDatabaseV2/7.json
+++ b/app/schemas/dev.chungjungsoo.gptmobile.data.database.ChatDatabaseV2/7.json
@@ -1,0 +1,790 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "019e647a67993863f8c16017da07d74a",
+    "entities": [
+      {
+        "tableName": "chats_v2",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chat_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `enabled_platform` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "chat_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabledPlatform",
+            "columnName": "enabled_platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "chat_id"
+          ]
+        }
+      },
+      {
+        "tableName": "messages_v2",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`message_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `chat_id` INTEGER NOT NULL, `thoughts` TEXT NOT NULL, `content` TEXT NOT NULL, `attachments` TEXT NOT NULL, `revisions` TEXT NOT NULL, `active_revision_index` INTEGER NOT NULL, `linked_message_id` INTEGER NOT NULL, `platform_type` TEXT, `current_run_id` TEXT, `created_at` INTEGER NOT NULL, FOREIGN KEY(`chat_id`) REFERENCES `chats_v2`(`chat_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "message_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chat_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thoughts",
+            "columnName": "thoughts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attachments",
+            "columnName": "attachments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "revisions",
+            "columnName": "revisions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activeRevisionIndex",
+            "columnName": "active_revision_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkedMessageId",
+            "columnName": "linked_message_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platformType",
+            "columnName": "platform_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "currentRunId",
+            "columnName": "current_run_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "message_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_v2_chat_id",
+            "unique": false,
+            "columnNames": [
+              "chat_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_v2_chat_id` ON `${TABLE_NAME}` (`chat_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chats_v2",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chat_id"
+            ],
+            "referencedColumns": [
+              "chat_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "platform_v2",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`platform_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `uid` TEXT NOT NULL, `name` TEXT NOT NULL, `compatible_type` TEXT NOT NULL, `enabled` INTEGER NOT NULL, `api_url` TEXT NOT NULL, `token` TEXT, `secret_ref` TEXT, `model` TEXT NOT NULL, `temperature` REAL, `top_p` REAL, `system_prompt` TEXT, `stream` INTEGER NOT NULL, `reasoning` INTEGER NOT NULL, `timeout` INTEGER NOT NULL, `harassment_safety_threshold` TEXT NOT NULL DEFAULT 'BLOCK_NONE', `hate_speech_safety_threshold` TEXT NOT NULL DEFAULT 'BLOCK_NONE', `sexually_explicit_safety_threshold` TEXT NOT NULL DEFAULT 'BLOCK_NONE', `dangerous_content_safety_threshold` TEXT NOT NULL DEFAULT 'BLOCK_NONE')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "platform_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "compatibleType",
+            "columnName": "compatible_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "apiUrl",
+            "columnName": "api_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "token",
+            "columnName": "token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "secretRef",
+            "columnName": "secret_ref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "temperature",
+            "columnName": "temperature",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "topP",
+            "columnName": "top_p",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "systemPrompt",
+            "columnName": "system_prompt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stream",
+            "columnName": "stream",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reasoning",
+            "columnName": "reasoning",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeout",
+            "columnName": "timeout",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "harassmentSafetyThreshold",
+            "columnName": "harassment_safety_threshold",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'BLOCK_NONE'"
+          },
+          {
+            "fieldPath": "hateSpeechSafetyThreshold",
+            "columnName": "hate_speech_safety_threshold",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'BLOCK_NONE'"
+          },
+          {
+            "fieldPath": "sexuallyExplicitSafetyThreshold",
+            "columnName": "sexually_explicit_safety_threshold",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'BLOCK_NONE'"
+          },
+          {
+            "fieldPath": "dangerousContentSafetyThreshold",
+            "columnName": "dangerous_content_safety_threshold",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'BLOCK_NONE'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "platform_id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_platform_model_v2",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chat_id` INTEGER NOT NULL, `platform_uid` TEXT NOT NULL, `model` TEXT NOT NULL, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`chat_id`, `platform_uid`), FOREIGN KEY(`chat_id`) REFERENCES `chats_v2`(`chat_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "chatId",
+            "columnName": "chat_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platformUid",
+            "columnName": "platform_uid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chat_id",
+            "platform_uid"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "chats_v2",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chat_id"
+            ],
+            "referencedColumns": [
+              "chat_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tool_connections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`connection_uid` TEXT NOT NULL, `name` TEXT NOT NULL, `alias` TEXT NOT NULL, `type` TEXT NOT NULL, `endpoint_url` TEXT, `auth_type` TEXT NOT NULL, `secret_ref` TEXT, `oauth_client_id` TEXT, `allow_cleartext` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`connection_uid`))",
+        "fields": [
+          {
+            "fieldPath": "connectionUid",
+            "columnName": "connection_uid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endpointUrl",
+            "columnName": "endpoint_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "authType",
+            "columnName": "auth_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "secretRef",
+            "columnName": "secret_ref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "oauthClientId",
+            "columnName": "oauth_client_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "allowCleartext",
+            "columnName": "allow_cleartext",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "connection_uid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tool_connections_alias",
+            "unique": true,
+            "columnNames": [
+              "alias"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tool_connections_alias` ON `${TABLE_NAME}` (`alias`)"
+          }
+        ]
+      },
+      {
+        "tableName": "agent_tool_bindings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`binding_uid` TEXT NOT NULL, `profile_uid` TEXT NOT NULL, `connection_uid` TEXT, `tool_name` TEXT NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`binding_uid`), FOREIGN KEY(`connection_uid`) REFERENCES `tool_connections`(`connection_uid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bindingUid",
+            "columnName": "binding_uid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileUid",
+            "columnName": "profile_uid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connectionUid",
+            "columnName": "connection_uid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toolName",
+            "columnName": "tool_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "binding_uid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_agent_tool_bindings_profile_uid",
+            "unique": false,
+            "columnNames": [
+              "profile_uid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_agent_tool_bindings_profile_uid` ON `${TABLE_NAME}` (`profile_uid`)"
+          },
+          {
+            "name": "index_agent_tool_bindings_connection_uid",
+            "unique": false,
+            "columnNames": [
+              "connection_uid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_agent_tool_bindings_connection_uid` ON `${TABLE_NAME}` (`connection_uid`)"
+          },
+          {
+            "name": "index_agent_tool_bindings_profile_uid_connection_uid_tool_name",
+            "unique": true,
+            "columnNames": [
+              "profile_uid",
+              "connection_uid",
+              "tool_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_agent_tool_bindings_profile_uid_connection_uid_tool_name` ON `${TABLE_NAME}` (`profile_uid`, `connection_uid`, `tool_name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tool_connections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "connection_uid"
+            ],
+            "referencedColumns": [
+              "connection_uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "agent_runs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`run_id` TEXT NOT NULL, `chat_id` INTEGER NOT NULL, `user_message_id` INTEGER NOT NULL, `assistant_message_id` INTEGER NOT NULL, `profile_uid` TEXT NOT NULL, `provider_snapshot` TEXT NOT NULL, `model_snapshot` TEXT NOT NULL, `status` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `started_at` INTEGER, `completed_at` INTEGER, `terminal_error` TEXT, PRIMARY KEY(`run_id`), FOREIGN KEY(`chat_id`) REFERENCES `chats_v2`(`chat_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`user_message_id`) REFERENCES `messages_v2`(`message_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`assistant_message_id`) REFERENCES `messages_v2`(`message_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "runId",
+            "columnName": "run_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chat_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userMessageId",
+            "columnName": "user_message_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assistantMessageId",
+            "columnName": "assistant_message_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileUid",
+            "columnName": "profile_uid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerSnapshot",
+            "columnName": "provider_snapshot",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelSnapshot",
+            "columnName": "model_snapshot",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "terminalError",
+            "columnName": "terminal_error",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "run_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_agent_runs_chat_id",
+            "unique": false,
+            "columnNames": [
+              "chat_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_agent_runs_chat_id` ON `${TABLE_NAME}` (`chat_id`)"
+          },
+          {
+            "name": "index_agent_runs_user_message_id",
+            "unique": false,
+            "columnNames": [
+              "user_message_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_agent_runs_user_message_id` ON `${TABLE_NAME}` (`user_message_id`)"
+          },
+          {
+            "name": "index_agent_runs_assistant_message_id",
+            "unique": false,
+            "columnNames": [
+              "assistant_message_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_agent_runs_assistant_message_id` ON `${TABLE_NAME}` (`assistant_message_id`)"
+          },
+          {
+            "name": "index_agent_runs_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_agent_runs_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chats_v2",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "chat_id"
+            ],
+            "referencedColumns": [
+              "chat_id"
+            ]
+          },
+          {
+            "table": "messages_v2",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "user_message_id"
+            ],
+            "referencedColumns": [
+              "message_id"
+            ]
+          },
+          {
+            "table": "messages_v2",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "assistant_message_id"
+            ],
+            "referencedColumns": [
+              "message_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tool_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`event_id` TEXT NOT NULL, `run_id` TEXT NOT NULL, `sequence` INTEGER NOT NULL, `call_id` TEXT NOT NULL, `connection_uid_snapshot` TEXT, `connection_name_snapshot` TEXT, `tool_name` TEXT NOT NULL, `model_tool_name` TEXT NOT NULL, `arguments` TEXT NOT NULL, `result` TEXT, `result_type` TEXT, `status` TEXT NOT NULL, `is_error` INTEGER NOT NULL, `started_at` INTEGER, `completed_at` INTEGER, `error` TEXT, PRIMARY KEY(`event_id`), FOREIGN KEY(`run_id`) REFERENCES `agent_runs`(`run_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "eventId",
+            "columnName": "event_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runId",
+            "columnName": "run_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "callId",
+            "columnName": "call_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connectionUidSnapshot",
+            "columnName": "connection_uid_snapshot",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "connectionNameSnapshot",
+            "columnName": "connection_name_snapshot",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toolName",
+            "columnName": "tool_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelToolName",
+            "columnName": "model_tool_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arguments",
+            "columnName": "arguments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "result",
+            "columnName": "result",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultType",
+            "columnName": "result_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isError",
+            "columnName": "is_error",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "started_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completed_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "event_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_tool_events_run_id",
+            "unique": false,
+            "columnNames": [
+              "run_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tool_events_run_id` ON `${TABLE_NAME}` (`run_id`)"
+          },
+          {
+            "name": "index_tool_events_run_id_sequence",
+            "unique": true,
+            "columnNames": [
+              "run_id",
+              "sequence"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_tool_events_run_id_sequence` ON `${TABLE_NAME}` (`run_id`, `sequence`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "agent_runs",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "run_id"
+            ],
+            "referencedColumns": [
+              "run_id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '019e647a67993863f8c16017da07d74a')"
+    ]
+  }
+}

--- a/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/backup/SanitizedChatBackupInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/backup/SanitizedChatBackupInstrumentedTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.io.File
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -40,5 +41,21 @@ class SanitizedChatBackupInstrumentedTest {
         }
         source.delete()
         destination.delete()
+    }
+
+    @Test
+    fun deleteStagedFile_removesPreviousCopyAndReportsFailure() {
+        val staged = SanitizedChatBackup.stagedFile(context)
+        staged.parentFile?.mkdirs()
+        staged.writeText("stale")
+
+        assertTrue(SanitizedChatBackup.deleteStagedFile(context))
+        assertFalse(staged.exists())
+
+        staged.mkdirs()
+        File(staged, "blocked").writeText("stale")
+        assertFalse(SanitizedChatBackup.deleteStagedFile(context))
+        File(staged, "blocked").delete()
+        staged.delete()
     }
 }

--- a/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/backup/SanitizedChatBackupInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/backup/SanitizedChatBackupInstrumentedTest.kt
@@ -1,0 +1,44 @@
+package dev.chungjungsoo.gptmobile.data.backup
+
+import android.database.sqlite.SQLiteDatabase
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SanitizedChatBackupInstrumentedTest {
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    @Test
+    fun createSanitizedCopy_preservesChatsAndClearsPlaintextTokens() {
+        val source = File(context.cacheDir, "backup-source.db")
+        val destination = File(context.cacheDir, "backup-destination.db")
+        source.delete()
+        destination.delete()
+        SQLiteDatabase.openOrCreateDatabase(source, null).use { database ->
+            database.execSQL("CREATE TABLE chats_v2 (chat_id INTEGER PRIMARY KEY, title TEXT NOT NULL)")
+            database.execSQL("CREATE TABLE platform_v2 (platform_id INTEGER PRIMARY KEY, token TEXT, secret_ref TEXT)")
+            database.execSQL("INSERT INTO chats_v2 VALUES (1, 'Keep me')")
+            database.execSQL("INSERT INTO platform_v2 VALUES (1, 'plaintext-secret', NULL)")
+        }
+
+        SanitizedChatBackup.createSanitizedCopy(source, destination)
+
+        SQLiteDatabase.openDatabase(destination.path, null, SQLiteDatabase.OPEN_READONLY).use { database ->
+            database.rawQuery("SELECT title FROM chats_v2", null).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals("Keep me", cursor.getString(0))
+            }
+            database.rawQuery("SELECT token FROM platform_v2", null).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertTrue(cursor.isNull(0))
+            }
+        }
+        source.delete()
+        destination.delete()
+    }
+}

--- a/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/database/AgentPersistenceDaoInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/database/AgentPersistenceDaoInstrumentedTest.kt
@@ -1,15 +1,18 @@
 package dev.chungjungsoo.gptmobile.data.database
 
+import android.database.sqlite.SQLiteConstraintException
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import dev.chungjungsoo.gptmobile.data.database.entity.AgentRunDraft
 import dev.chungjungsoo.gptmobile.data.database.entity.AgentRunStatus
+import dev.chungjungsoo.gptmobile.data.database.entity.AssistantRevision
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoomV2
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
 import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentRetryRequest
 import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentTurnRequest
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
+import dev.chungjungsoo.gptmobile.data.model.ChatAttachment
 import dev.chungjungsoo.gptmobile.data.model.ClientType
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -28,7 +31,7 @@ class AgentPersistenceDaoInstrumentedTest {
         database = Room.inMemoryDatabaseBuilder(
             InstrumentationRegistry.getInstrumentation().targetContext,
             ChatDatabaseV2::class.java
-        ).build()
+        ).addCallback(ChatDatabaseV2Migrations.AGENT_TOOL_BINDING_CALLBACK).build()
     }
 
     @After
@@ -108,7 +111,10 @@ class AgentPersistenceDaoInstrumentedTest {
         )
         val firstAnswer = persisted.assistantMessages.single().copy(
             content = "First answer",
-            thoughts = "First thoughts"
+            thoughts = "First thoughts",
+            attachments = listOf(ChatAttachment("/tmp/stale.txt", "/tmp/stale.txt", "stale.txt", "text/plain", 1)),
+            revisions = listOf(AssistantRevision(content = "Older answer", createdAt = 90L)),
+            activeRevisionIndex = 0
         )
         database.messageDao().editMessages(firstAnswer)
         database.agentRunDao().updateStatus("run-1", AgentRunStatus.COMPLETED, 200L, 250L, null)
@@ -123,12 +129,33 @@ class AgentPersistenceDaoInstrumentedTest {
 
         assertEquals(firstAnswer.id, retried.assistantMessage.id)
         assertEquals("", retried.assistantMessage.content)
+        assertEquals(emptyList<ChatAttachment>(), retried.assistantMessage.attachments)
+        assertEquals(-1, retried.assistantMessage.activeRevisionIndex)
         assertEquals("run-2", retried.assistantMessage.currentRunId)
-        assertEquals("First answer", retried.assistantMessage.revisions.single().content)
-        assertEquals("run-1", retried.assistantMessage.revisions.single().runId)
+        assertEquals("First answer", retried.assistantMessage.revisions.first().content)
+        assertEquals("run-1", retried.assistantMessage.revisions.first().runId)
         assertEquals(AgentRunStatus.COMPLETED, database.agentRunDao().getById("run-1")?.status)
         assertEquals(AgentRunStatus.QUEUED, database.agentRunDao().getById("run-2")?.status)
         assertEquals(firstAnswer.id, database.agentRunDao().getById("run-2")?.assistantMessageId)
+    }
+
+    @Test
+    fun finishAgentRun_persistsAssistantAndTerminalStatusTogether() = runBlocking {
+        val persisted = persistTurn(newChat(), "Question", "run-1", 100L)
+        database.agentRunDao().updateStatus("run-1", AgentRunStatus.RUNNING, 101L, null, null)
+        val answer = persisted.assistantMessages.single().copy(content = "Final answer", thoughts = "Reasoning")
+
+        database.agentPersistenceDao().finishAgentRun(
+            assistantMessage = answer,
+            runId = "run-1",
+            status = AgentRunStatus.COMPLETED,
+            startedAt = 101L,
+            completedAt = 102L,
+            terminalError = null
+        )
+
+        assertEquals("Final answer", database.messageDao().loadMessages(persisted.chatRoom.id).first { it.id == answer.id }.content)
+        assertEquals(AgentRunStatus.COMPLETED, database.agentRunDao().getById("run-1")?.status)
     }
 
     @Test
@@ -243,6 +270,26 @@ class AgentPersistenceDaoInstrumentedTest {
             assertEquals(0, cursor.getInt(0))
         }
         assertEquals(emptyList<PlatformV2>(), database.platformDao().getPlatforms())
+    }
+
+    @Test
+    fun builtInToolBinding_rejectsDuplicateProfileAndTool() {
+        database.openHelper.writableDatabase.execSQL(
+            "INSERT INTO agent_tool_bindings (binding_uid, profile_uid, connection_uid, tool_name, created_at) " +
+                "VALUES ('binding-1', 'profile-1', NULL, 'read_url', 1)"
+        )
+
+        var error: Throwable? = null
+        try {
+            database.openHelper.writableDatabase.execSQL(
+                "INSERT INTO agent_tool_bindings (binding_uid, profile_uid, connection_uid, tool_name, created_at) " +
+                    "VALUES ('binding-2', 'profile-1', NULL, 'read_url', 2)"
+            )
+        } catch (thrown: Throwable) {
+            error = thrown
+        }
+
+        assertTrue(error is SQLiteConstraintException)
     }
 
     private suspend fun persistTurn(

--- a/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/database/AgentPersistenceDaoInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/database/AgentPersistenceDaoInstrumentedTest.kt
@@ -1,0 +1,281 @@
+package dev.chungjungsoo.gptmobile.data.database
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRunDraft
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRunStatus
+import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoomV2
+import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
+import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentRetryRequest
+import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentTurnRequest
+import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
+import dev.chungjungsoo.gptmobile.data.model.ClientType
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AgentPersistenceDaoInstrumentedTest {
+    private lateinit var database: ChatDatabaseV2
+
+    @Before
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            ChatDatabaseV2::class.java
+        ).build()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun persistAgentTurn_assignsIdsAndQueuesEveryProfileInOneTransaction() = runBlocking {
+        val result = database.agentPersistenceDao().persistAgentTurn(
+            PersistAgentTurnRequest(
+                chatRoom = ChatRoomV2(
+                    title = "Untitled Chat",
+                    enabledPlatform = listOf("profile-1", "profile-2"),
+                    createdAt = 100L,
+                    updatedAt = 100L
+                ),
+                userMessage = MessageV2(
+                    content = "Question",
+                    platformType = null,
+                    createdAt = 101L
+                ),
+                runs = listOf(
+                    AgentRunDraft("run-1", "profile-1", "OPENAI", "gpt-5"),
+                    AgentRunDraft("run-2", "profile-2", "ANTHROPIC", "claude")
+                ),
+                chatPlatformModels = mapOf(
+                    "profile-1" to "gpt-5",
+                    "profile-2" to "claude"
+                )
+            )
+        )
+
+        assertTrue(result.chatRoom.id > 0)
+        assertTrue(result.userMessage.id > 0)
+        assertEquals(listOf("profile-1", "profile-2"), result.assistantMessages.map { it.platformType })
+        assertTrue(result.assistantMessages.all { it.id > 0 })
+        assertEquals(listOf("run-1", "run-2"), result.assistantMessages.map { it.currentRunId })
+        assertEquals(listOf(AgentRunStatus.QUEUED, AgentRunStatus.QUEUED), result.runs.map { it.status })
+        assertEquals(result.userMessage.id, result.runs[0].userMessageId)
+        assertEquals(result.assistantMessages[0].id, result.runs[0].assistantMessageId)
+
+        assertEquals(3, database.messageDao().loadMessages(result.chatRoom.id).size)
+        assertEquals(2, database.agentRunDao().getByChatId(result.chatRoom.id).size)
+        assertEquals(2, database.chatPlatformModelDao().getByChatId(result.chatRoom.id).size)
+    }
+
+    @Test
+    fun interruptActiveRuns_marksQueuedAndRunningWithoutTouchingTerminalRuns() = runBlocking {
+        val persisted = database.agentPersistenceDao().persistAgentTurn(
+            PersistAgentTurnRequest(
+                chatRoom = ChatRoomV2(title = "Chat", enabledPlatform = listOf("profile-1")),
+                userMessage = MessageV2(content = "Question", platformType = null),
+                runs = listOf(AgentRunDraft("run-1", "profile-1", "OPENAI", "gpt-5")),
+                chatPlatformModels = mapOf("profile-1" to "gpt-5")
+            )
+        )
+        database.agentRunDao().updateStatus("run-1", AgentRunStatus.RUNNING, 200L, null, null)
+
+        val interrupted = database.agentRunDao().interruptActiveRuns(completedAt = 300L)
+
+        assertEquals(1, interrupted)
+        assertEquals(AgentRunStatus.INTERRUPTED, database.agentRunDao().getById("run-1")?.status)
+        assertEquals(300L, database.agentRunDao().getById("run-1")?.completedAt)
+        assertEquals(persisted.chatRoom.id, database.agentRunDao().getById("run-1")?.chatId)
+    }
+
+    @Test
+    fun persistAgentRetry_preservesPriorRunRevisionAndQueuesNewRun() = runBlocking {
+        val persisted = database.agentPersistenceDao().persistAgentTurn(
+            PersistAgentTurnRequest(
+                chatRoom = ChatRoomV2(title = "Chat", enabledPlatform = listOf("profile-1")),
+                userMessage = MessageV2(content = "Question", platformType = null),
+                runs = listOf(AgentRunDraft("run-1", "profile-1", "OPENAI", "gpt-5")),
+                chatPlatformModels = mapOf("profile-1" to "gpt-5")
+            )
+        )
+        val firstAnswer = persisted.assistantMessages.single().copy(
+            content = "First answer",
+            thoughts = "First thoughts"
+        )
+        database.messageDao().editMessages(firstAnswer)
+        database.agentRunDao().updateStatus("run-1", AgentRunStatus.COMPLETED, 200L, 250L, null)
+
+        val retried = database.agentPersistenceDao().persistAgentRetry(
+            PersistAgentRetryRequest(
+                userMessage = persisted.userMessage,
+                assistantMessage = firstAnswer,
+                run = AgentRunDraft("run-2", "profile-1", "OPENAI", "gpt-5", createdAt = 300L)
+            )
+        )
+
+        assertEquals(firstAnswer.id, retried.assistantMessage.id)
+        assertEquals("", retried.assistantMessage.content)
+        assertEquals("run-2", retried.assistantMessage.currentRunId)
+        assertEquals("First answer", retried.assistantMessage.revisions.single().content)
+        assertEquals("run-1", retried.assistantMessage.revisions.single().runId)
+        assertEquals(AgentRunStatus.COMPLETED, database.agentRunDao().getById("run-1")?.status)
+        assertEquals(AgentRunStatus.QUEUED, database.agentRunDao().getById("run-2")?.status)
+        assertEquals(firstAnswer.id, database.agentRunDao().getById("run-2")?.assistantMessageId)
+    }
+
+    @Test
+    fun editedTurn_truncatesFutureHistoryBeforeQueuingReplacementRun() = runBlocking {
+        val first = persistTurn(chatRoom = newChat(), question = "First", runId = "run-1", createdAt = 100L)
+        val second = persistTurn(
+            chatRoom = first.chatRoom,
+            question = "Second",
+            runId = "run-2",
+            createdAt = 200L
+        )
+        persistTurn(
+            chatRoom = first.chatRoom,
+            question = "Future",
+            runId = "run-3",
+            createdAt = 300L
+        )
+        val editedUser = second.userMessage.copy(content = "Edited second", createdAt = 400L)
+
+        database.agentPersistenceDao().saveChatSnapshot(
+            chatRoom = first.chatRoom.copy(updatedAt = 400L),
+            messages = listOf(first.userMessage, first.assistantMessages.single(), editedUser),
+            chatPlatformModels = mapOf("profile-1" to "gpt-5")
+        )
+        val replacement = database.agentPersistenceDao().persistAgentTurn(
+            PersistAgentTurnRequest(
+                chatRoom = first.chatRoom.copy(updatedAt = 400L),
+                userMessage = editedUser,
+                runs = listOf(AgentRunDraft("run-4", "profile-1", "OPENAI", "gpt-5", createdAt = 401L)),
+                chatPlatformModels = mapOf("profile-1" to "gpt-5")
+            )
+        )
+
+        val messages = database.messageDao().loadMessages(first.chatRoom.id).sortedWith(compareBy(MessageV2::createdAt, MessageV2::id))
+        assertEquals(listOf("First", "", "Edited second", ""), messages.map { it.content })
+        assertEquals(second.userMessage.id, replacement.userMessage.id)
+        assertEquals("run-4", replacement.assistantMessages.single().currentRunId)
+        assertEquals(listOf("run-1", "run-4"), database.agentRunDao().getByChatId(first.chatRoom.id).map { it.runId })
+    }
+
+    @Test
+    fun duplicateChatWithHistory_regeneratesMessageRunAndEventIds() = runBlocking {
+        val persisted = database.agentPersistenceDao().persistAgentTurn(
+            PersistAgentTurnRequest(
+                chatRoom = ChatRoomV2(title = "Chat", enabledPlatform = listOf("profile-1")),
+                userMessage = MessageV2(content = "Question", platformType = null, createdAt = 100L),
+                runs = listOf(AgentRunDraft("run-1", "profile-1", "OPENAI", "gpt-5", createdAt = 101L)),
+                chatPlatformModels = mapOf("profile-1" to "gpt-5")
+            )
+        )
+        database.messageDao().editMessages(persisted.assistantMessages.single().copy(content = "Answer"))
+        database.agentRunDao().updateStatus("run-1", AgentRunStatus.COMPLETED, 102L, 103L, null)
+        database.openHelper.writableDatabase.execSQL(
+            """
+            INSERT INTO tool_events (
+                event_id, run_id, sequence, call_id, connection_uid_snapshot,
+                connection_name_snapshot, tool_name, model_tool_name, arguments,
+                result, result_type, status, is_error, started_at, completed_at, error
+            ) VALUES (
+                'event-1', 'run-1', 0, 'call-1', 'connection-1', 'Fixture',
+                'lookup', 'fixture__lookup', '{}', 'ok', 'TEXT', 'COMPLETED', 0, 102, 103, NULL
+            )
+            """.trimIndent()
+        )
+
+        val duplicate = database.agentPersistenceDao().duplicateChatWithHistory(
+            sourceChatId = persisted.chatRoom.id,
+            title = "Chat (copy)",
+            timestamp = 500L
+        )
+        val duplicateMessages = database.messageDao().loadMessages(duplicate.id)
+        val duplicateRuns = database.agentRunDao().getByChatId(duplicate.id)
+
+        assertTrue(duplicate.id != persisted.chatRoom.id)
+        assertEquals(listOf("Question", "Answer"), duplicateMessages.sortedBy { it.createdAt }.map { it.content })
+        assertTrue(duplicateMessages.none { it.id in listOf(persisted.userMessage.id, persisted.assistantMessages.single().id) })
+        assertEquals(1, duplicateRuns.size)
+        assertTrue(duplicateRuns.single().runId != "run-1")
+        assertEquals(AgentRunStatus.COMPLETED, duplicateRuns.single().status)
+        assertEquals(duplicateRuns.single().runId, duplicateMessages.first { it.platformType != null }.currentRunId)
+        database.openHelper.writableDatabase.query(
+            "SELECT event_id, run_id, call_id FROM tool_events WHERE run_id = ?",
+            arrayOf(duplicateRuns.single().runId)
+        ).use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertTrue(cursor.getString(0) != "event-1")
+            assertEquals(duplicateRuns.single().runId, cursor.getString(1))
+            assertEquals("call-1", cursor.getString(2))
+        }
+        assertEquals(mapOf("profile-1" to "gpt-5"), database.chatPlatformModelDao().getByChatId(duplicate.id).associate { it.platformUid to it.model })
+    }
+
+    @Test
+    fun deletePlatform_removesItsToolBindings() = runBlocking {
+        val platform = PlatformV2(
+            uid = "profile-1",
+            name = "OpenAI",
+            compatibleType = ClientType.OPENAI,
+            apiUrl = "https://api.openai.com/v1/",
+            model = "gpt-5"
+        )
+        val platformId = database.platformDao().addPlatform(platform)
+        database.openHelper.writableDatabase.execSQL(
+            "INSERT INTO agent_tool_bindings (binding_uid, profile_uid, connection_uid, tool_name, created_at) " +
+                "VALUES ('binding-1', 'profile-1', NULL, 'read_url', 1)"
+        )
+
+        database.platformDao().deletePlatform(platform.copy(id = platformId.toInt()))
+
+        database.openHelper.writableDatabase.query("SELECT COUNT(*) FROM agent_tool_bindings").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(0, cursor.getInt(0))
+        }
+        assertEquals(emptyList<PlatformV2>(), database.platformDao().getPlatforms())
+    }
+
+    private suspend fun persistTurn(
+        chatRoom: ChatRoomV2,
+        question: String,
+        runId: String,
+        createdAt: Long
+    ) = database.agentPersistenceDao().persistAgentTurn(
+        PersistAgentTurnRequest(
+            chatRoom = chatRoom,
+            userMessage = MessageV2(
+                chatId = chatRoom.id,
+                content = question,
+                platformType = null,
+                createdAt = createdAt
+            ),
+            runs = listOf(
+                AgentRunDraft(
+                    runId = runId,
+                    profileUid = "profile-1",
+                    providerSnapshot = "OPENAI",
+                    modelSnapshot = "gpt-5",
+                    createdAt = createdAt + 1
+                )
+            ),
+            chatPlatformModels = mapOf("profile-1" to "gpt-5")
+        )
+    )
+
+    private fun newChat() = ChatRoomV2(
+        title = "Chat",
+        enabledPlatform = listOf("profile-1"),
+        createdAt = 99L,
+        updatedAt = 99L
+    )
+}

--- a/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2MigrationInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2MigrationInstrumentedTest.kt
@@ -1,0 +1,283 @@
+package dev.chungjungsoo.gptmobile.data.database
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.io.IOException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ChatDatabaseV2MigrationInstrumentedTest {
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        ChatDatabaseV2::class.java
+    )
+
+    @Test
+    @Throws(IOException::class)
+    fun migrateBrokenVersion2To7_repairsMissingColumnsAndPreservesLegacyRows() {
+        helper.createDatabase(BROKEN_VERSION_2_DATABASE, 1).apply {
+            execSQL(
+                "INSERT INTO chats_v2 (chat_id, title, enabled_platform, created_at, updated_at) " +
+                    "VALUES (1, 'Legacy chat', 'profile-1', 10, 11)"
+            )
+            execSQL(
+                """
+                INSERT INTO platform_v2 (
+                    platform_id, uid, name, enabled, api_url, token, model,
+                    temperature, top_p, system_prompt, stream, timeout
+                ) VALUES (
+                    1, 'profile-1', 'Anthropic', 1, 'https://api.anthropic.com/',
+                    'legacy-secret', 'claude', NULL, NULL, 'Legacy prompt', 1, 30
+                )
+                """.trimIndent()
+            )
+            execSQL(
+                """
+                INSERT INTO messages_v2 (
+                    message_id, chat_id, content, files, linked_message_id, platform_type, created_at
+                ) VALUES (1, 1, 'Legacy question', '/tmp/legacy.png', 0, NULL, 12)
+                """.trimIndent()
+            )
+            execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS chat_platform_model_v2 (
+                    chat_id INTEGER NOT NULL,
+                    platform_uid TEXT NOT NULL,
+                    model TEXT NOT NULL,
+                    updated_at INTEGER NOT NULL,
+                    PRIMARY KEY(chat_id, platform_uid),
+                    FOREIGN KEY(chat_id) REFERENCES chats_v2(chat_id) ON UPDATE NO ACTION ON DELETE CASCADE
+                )
+                """.trimIndent()
+            )
+            execSQL(
+                "INSERT INTO chat_platform_model_v2 (chat_id, platform_uid, model, updated_at) " +
+                    "VALUES (1, 'profile-1', 'claude', 11)"
+            )
+            version = 2
+            close()
+        }
+
+        val database = helper.runMigrationsAndValidate(
+            BROKEN_VERSION_2_DATABASE,
+            7,
+            true,
+            ChatDatabaseV2Migrations.MIGRATION_2_3,
+            ChatDatabaseV2Migrations.MIGRATION_3_4,
+            ChatDatabaseV2Migrations.MIGRATION_4_5,
+            ChatDatabaseV2Migrations.MIGRATION_5_6,
+            ChatDatabaseV2Migrations.MIGRATION_6_7
+        )
+
+        database.query(
+            "SELECT thoughts, content, attachments, revisions, active_revision_index, current_run_id " +
+                "FROM messages_v2 WHERE message_id = 1"
+        ).use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("", cursor.getString(0))
+            assertEquals("Legacy question", cursor.getString(1))
+            assertTrue(cursor.getString(2).contains("legacy.png"))
+            assertEquals("[]", cursor.getString(3))
+            assertEquals(-1, cursor.getInt(4))
+            assertTrue(cursor.isNull(5))
+        }
+        database.query(
+            "SELECT compatible_type, reasoning, token, secret_ref, system_prompt FROM platform_v2 WHERE platform_id = 1"
+        ).use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("ANTHROPIC", cursor.getString(0))
+            assertEquals(0, cursor.getInt(1))
+            assertEquals("legacy-secret", cursor.getString(2))
+            assertTrue(cursor.isNull(3))
+            assertEquals("Legacy prompt", cursor.getString(4))
+        }
+        database.close()
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate6To7_preservesExistingRowsAndStartsWithNoToolsOrRuns() {
+        helper.createDatabase(TEST_DATABASE, 6).apply {
+            execSQL(
+                """
+                INSERT INTO chats_v2 (chat_id, title, enabled_platform, created_at, updated_at)
+                VALUES (7, 'Existing chat', 'profile-1', 100, 101)
+                """.trimIndent()
+            )
+            execSQL(
+                """
+                INSERT INTO platform_v2 (
+                    platform_id, uid, name, compatible_type, enabled, api_url, token, model,
+                    temperature, top_p, system_prompt, stream, reasoning, timeout,
+                    harassment_safety_threshold, hate_speech_safety_threshold,
+                    sexually_explicit_safety_threshold, dangerous_content_safety_threshold
+                ) VALUES (
+                    3, 'profile-1', 'OpenAI', 'OPENAI', 1, 'https://api.openai.com/v1/',
+                    'legacy-secret', 'gpt-5', NULL, NULL, 'Keep this prompt', 1, 0, 30,
+                    'BLOCK_NONE', 'BLOCK_NONE', 'BLOCK_NONE', 'BLOCK_NONE'
+                )
+                """.trimIndent()
+            )
+            execSQL(
+                """
+                INSERT INTO messages_v2 (
+                    message_id, chat_id, thoughts, content, attachments, revisions,
+                    active_revision_index, linked_message_id, platform_type, created_at
+                ) VALUES (11, 7, '', 'Old question', '', '[]', -1, 0, NULL, 102)
+                """.trimIndent()
+            )
+            close()
+        }
+
+        val database = helper.runMigrationsAndValidate(
+            TEST_DATABASE,
+            7,
+            true,
+            ChatDatabaseV2Migrations.MIGRATION_6_7
+        )
+
+        database.query("SELECT title, enabled_platform FROM chats_v2 WHERE chat_id = 7").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("Existing chat", cursor.getString(0))
+            assertEquals("profile-1", cursor.getString(1))
+        }
+        database.query("SELECT token, secret_ref, system_prompt FROM platform_v2 WHERE platform_id = 3").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("legacy-secret", cursor.getString(0))
+            assertTrue(cursor.isNull(1))
+            assertEquals("Keep this prompt", cursor.getString(2))
+        }
+        database.query("SELECT current_run_id FROM messages_v2 WHERE message_id = 11").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertTrue(cursor.isNull(0))
+        }
+        listOf("tool_connections", "agent_tool_bindings", "agent_runs", "tool_events").forEach { table ->
+            database.query("SELECT COUNT(*) FROM $table").use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals(0, cursor.getInt(0))
+            }
+        }
+        database.close()
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate6To7_preservesDuplicateLegacyProfileUids() {
+        helper.createDatabase(DUPLICATE_PROFILE_DATABASE, 6).apply {
+            repeat(2) { index ->
+                execSQL(
+                    """
+                    INSERT INTO platform_v2 (
+                        platform_id, uid, name, compatible_type, enabled, api_url, token, model,
+                        temperature, top_p, system_prompt, stream, reasoning, timeout,
+                        harassment_safety_threshold, hate_speech_safety_threshold,
+                        sexually_explicit_safety_threshold, dangerous_content_safety_threshold
+                    ) VALUES (
+                        ${index + 1}, 'duplicate-profile', 'Profile ${index + 1}', 'OPENAI', 1,
+                        'https://api.openai.com/v1/', 'secret-$index', 'gpt-5', NULL, NULL, NULL,
+                        1, 0, 30, 'BLOCK_NONE', 'BLOCK_NONE', 'BLOCK_NONE', 'BLOCK_NONE'
+                    )
+                    """.trimIndent()
+                )
+            }
+            close()
+        }
+
+        val database = helper.runMigrationsAndValidate(
+            DUPLICATE_PROFILE_DATABASE,
+            7,
+            true,
+            ChatDatabaseV2Migrations.MIGRATION_6_7
+        )
+
+        database.query("SELECT COUNT(*) FROM platform_v2 WHERE uid = 'duplicate-profile'").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(2, cursor.getInt(0))
+        }
+        database.close()
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate6To7_cascadesConnectionBindingsAndRunHistoryAtTheirOwners() {
+        helper.createDatabase(CASCADE_DATABASE, 6).close()
+        val database = helper.runMigrationsAndValidate(
+            CASCADE_DATABASE,
+            7,
+            true,
+            ChatDatabaseV2Migrations.MIGRATION_6_7
+        )
+        database.execSQL("PRAGMA foreign_keys = ON")
+        database.execSQL(
+            "INSERT INTO chats_v2 (chat_id, title, enabled_platform, created_at, updated_at) VALUES (1, 'Chat', 'profile-1', 1, 1)"
+        )
+        database.execSQL(
+            """
+            INSERT INTO platform_v2 (
+                platform_id, uid, name, compatible_type, enabled, api_url, token, secret_ref,
+                model, temperature, top_p, system_prompt, stream, reasoning, timeout,
+                harassment_safety_threshold, hate_speech_safety_threshold,
+                sexually_explicit_safety_threshold, dangerous_content_safety_threshold
+            ) VALUES (
+                1, 'profile-1', 'OpenAI', 'OPENAI', 1, 'https://api.openai.com/v1/', NULL, NULL,
+                'gpt-5', NULL, NULL, NULL, 1, 0, 30,
+                'BLOCK_NONE', 'BLOCK_NONE', 'BLOCK_NONE', 'BLOCK_NONE'
+            )
+            """.trimIndent()
+        )
+        database.execSQL(
+            "INSERT INTO messages_v2 (message_id, chat_id, thoughts, content, attachments, revisions, active_revision_index, linked_message_id, platform_type, created_at, current_run_id) VALUES (1, 1, '', 'Q', '', '[]', -1, 0, NULL, 1, NULL)"
+        )
+        database.execSQL(
+            "INSERT INTO messages_v2 (message_id, chat_id, thoughts, content, attachments, revisions, active_revision_index, linked_message_id, platform_type, created_at, current_run_id) VALUES (2, 1, '', '', '', '[]', -1, 0, 'profile-1', 1, 'run-1')"
+        )
+        database.execSQL(
+            "INSERT INTO tool_connections (connection_uid, name, alias, type, endpoint_url, auth_type, secret_ref, oauth_client_id, allow_cleartext, created_at, updated_at) VALUES ('connection-1', 'Fixture', 'fixture', 'MCP', 'https://example.test/mcp', 'NONE', NULL, NULL, 0, 1, 1)"
+        )
+        database.execSQL(
+            "INSERT INTO agent_tool_bindings (binding_uid, profile_uid, connection_uid, tool_name, created_at) VALUES ('binding-1', 'profile-1', 'connection-1', 'lookup', 1)"
+        )
+        database.execSQL(
+            "INSERT INTO agent_tool_bindings (binding_uid, profile_uid, connection_uid, tool_name, created_at) VALUES ('binding-2', 'profile-1', NULL, 'read_url', 1)"
+        )
+        database.execSQL(
+            "INSERT INTO agent_runs (run_id, chat_id, user_message_id, assistant_message_id, profile_uid, provider_snapshot, model_snapshot, status, created_at, started_at, completed_at, terminal_error) VALUES ('run-1', 1, 1, 2, 'profile-1', 'OPENAI', 'gpt-5', 'COMPLETED', 1, 1, 2, NULL)"
+        )
+        database.execSQL(
+            "INSERT INTO tool_events (event_id, run_id, sequence, call_id, connection_uid_snapshot, connection_name_snapshot, tool_name, model_tool_name, arguments, result, result_type, status, is_error, started_at, completed_at, error) VALUES ('event-1', 'run-1', 0, 'call-1', 'connection-1', 'Fixture', 'lookup', 'fixture__lookup', '{}', 'ok', 'TEXT', 'COMPLETED', 0, 1, 2, NULL)"
+        )
+
+        database.execSQL("DELETE FROM tool_connections WHERE connection_uid = 'connection-1'")
+        assertCount(database, "agent_tool_bindings", 1)
+        assertCount(database, "tool_events", 1)
+
+        database.execSQL("DELETE FROM chats_v2 WHERE chat_id = 1")
+        assertCount(database, "agent_runs", 0)
+        assertCount(database, "tool_events", 0)
+        database.close()
+    }
+
+    private fun assertCount(
+        database: androidx.sqlite.db.SupportSQLiteDatabase,
+        table: String,
+        expected: Int
+    ) {
+        database.query("SELECT COUNT(*) FROM $table").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(expected, cursor.getInt(0))
+        }
+    }
+
+    private companion object {
+        const val TEST_DATABASE = "agent-migration-test"
+        const val DUPLICATE_PROFILE_DATABASE = "agent-migration-duplicate-profile-test"
+        const val CASCADE_DATABASE = "agent-migration-cascade-test"
+        const val BROKEN_VERSION_2_DATABASE = "agent-migration-broken-v2-test"
+    }
+}

--- a/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2MigrationInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2MigrationInstrumentedTest.kt
@@ -163,6 +163,20 @@ class ChatDatabaseV2MigrationInstrumentedTest {
                 assertEquals(0, cursor.getInt(0))
             }
         }
+        database.execSQL(
+            "INSERT INTO agent_tool_bindings (binding_uid, profile_uid, connection_uid, tool_name, created_at) " +
+                "VALUES ('binding-1', 'profile-1', NULL, 'read_url', 1)"
+        )
+        var duplicateRejected = false
+        try {
+            database.execSQL(
+                "INSERT INTO agent_tool_bindings (binding_uid, profile_uid, connection_uid, tool_name, created_at) " +
+                    "VALUES ('binding-2', 'profile-1', NULL, 'read_url', 2)"
+            )
+        } catch (_: android.database.sqlite.SQLiteConstraintException) {
+            duplicateRejected = true
+        }
+        assertTrue(duplicateRejected)
         database.close()
     }
 

--- a/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/security/SecretVaultInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/security/SecretVaultInstrumentedTest.kt
@@ -1,0 +1,91 @@
+package dev.chungjungsoo.gptmobile.data.security
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.io.File
+import java.security.KeyStore
+import java.util.UUID
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SecretVaultInstrumentedTest {
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+    private val suffix = UUID.randomUUID().toString()
+    private val keyAlias = "gpt-mobile-test-$suffix"
+    private val directoryName = "secret-vault-test-$suffix"
+    private val vault = AndroidSecretVault(context, keyAlias, directoryName)
+
+    @After
+    fun cleanUp() {
+        File(context.noBackupFilesDir, directoryName).deleteRecursively()
+        KeyStore.getInstance("AndroidKeyStore").apply { load(null) }.deleteEntry(keyAlias)
+    }
+
+    @Test
+    fun roundTripOverwriteAndDelete() = runBlocking {
+        val secretRef = "profile_123"
+        val first = "first-secret".encodeToByteArray()
+        val second = "replacement-secret".encodeToByteArray()
+
+        vault.put(secretRef, first)
+
+        assertArrayEquals(first, vault.read(secretRef))
+        assertTrue(File(context.noBackupFilesDir, "$directoryName/$secretRef.vault").isFile)
+        assertFalse(File(context.filesDir, "$directoryName/$secretRef.vault").exists())
+
+        vault.put(secretRef, second)
+        assertArrayEquals(second, vault.read(secretRef))
+
+        vault.delete(secretRef)
+        assertNull(vault.read(secretRef))
+    }
+
+    @Test
+    fun rejectsUnsafeReferencesAndOversizedSecrets() = runBlocking {
+        assertFails<IllegalArgumentException> { vault.put("../secret", byteArrayOf(1)) }
+        assertFails<IllegalArgumentException> { vault.read("") }
+        assertFails<IllegalArgumentException> {
+            vault.put("profile_oversized", ByteArray(AndroidSecretVault.MAX_SECRET_BYTES + 1))
+        }
+    }
+
+    @Test
+    fun rejectsMalformedRecords() = runBlocking {
+        val secretRef = "profile_corrupt"
+        val record = File(context.noBackupFilesDir, "$directoryName/$secretRef.vault")
+        record.parentFile?.mkdirs()
+        record.writeBytes(byteArrayOf(1, 2, 3, 4))
+
+        assertFails<SecretVaultException> { vault.read(secretRef) }
+    }
+
+    @Test
+    fun rejectsRecordMovedToAnotherReference() = runBlocking {
+        val firstRef = "profile_first"
+        val secondRef = "profile_second"
+        vault.put(firstRef, "first-secret".encodeToByteArray())
+        vault.put(secondRef, "second-secret".encodeToByteArray())
+
+        val directory = File(context.noBackupFilesDir, directoryName)
+        File(directory, "$secondRef.vault").copyTo(File(directory, "$firstRef.vault"), overwrite = true)
+
+        assertFails<SecretVaultException> { vault.read(firstRef) }
+    }
+
+    private suspend inline fun <reified T : Throwable> assertFails(crossinline block: suspend () -> Unit) {
+        var thrown: Throwable? = null
+        try {
+            block()
+        } catch (error: Throwable) {
+            thrown = error
+        }
+        assertTrue("Expected ${T::class.java.simpleName}, got ${thrown?.javaClass?.simpleName}", thrown is T)
+    }
+}

--- a/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/security/SecretVaultInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/security/SecretVaultInstrumentedTest.kt
@@ -79,6 +79,16 @@ class SecretVaultInstrumentedTest {
         assertFails<SecretVaultException> { vault.read(firstRef) }
     }
 
+    @Test
+    fun missingKeystoreKey_discardsIrrecoverableRecord() = runBlocking {
+        val secretRef = "profile_missing_key"
+        vault.put(secretRef, "secret".encodeToByteArray())
+        KeyStore.getInstance("AndroidKeyStore").apply { load(null) }.deleteEntry(keyAlias)
+
+        assertNull(vault.read(secretRef))
+        assertFalse(File(context.noBackupFilesDir, "$directoryName/$secretRef.vault").exists())
+    }
+
     private suspend inline fun <reified T : Throwable> assertFails(crossinline block: suspend () -> Unit) {
         var thrown: Throwable? = null
         try {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,9 +12,11 @@
     <application
         android:name=".presentation.GPTMobileApp"
         android:allowBackup="true"
+        android:backupAgent=".data.backup.SanitizedChatBackupAgent"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="@xml/backup_rules"
+        android:fullBackupOnly="true"
         android:icon="@mipmap/ic_gpt_mobile"
         android:label="@string/app_name"
         android:supportsRtl="true"

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/backup/SanitizedChatBackup.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/backup/SanitizedChatBackup.kt
@@ -1,0 +1,78 @@
+package dev.chungjungsoo.gptmobile.data.backup
+
+import android.app.backup.BackupAgent
+import android.app.backup.BackupDataInput
+import android.app.backup.BackupDataOutput
+import android.app.backup.FullBackupDataOutput
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.os.ParcelFileDescriptor
+import android.util.AtomicFile
+import java.io.File
+
+class SanitizedChatBackupAgent : BackupAgent() {
+    override fun onBackup(
+        oldState: ParcelFileDescriptor,
+        data: BackupDataOutput,
+        newState: ParcelFileDescriptor
+    ) = Unit
+
+    override fun onRestore(data: BackupDataInput, appVersionCode: Int, newState: ParcelFileDescriptor) = Unit
+
+    override fun onFullBackup(data: FullBackupDataOutput) {
+        super.onFullBackup(data)
+        val source = getDatabasePath(DATABASE_NAME)
+        if (!source.exists()) return
+
+        val backup = SanitizedChatBackup.stagedFile(this)
+        try {
+            SanitizedChatBackup.createSanitizedCopy(source, backup)
+            fullBackupFile(backup, data)
+        } finally {
+            backup.delete()
+        }
+    }
+
+    private companion object {
+        const val DATABASE_NAME = "chat_v2"
+    }
+}
+
+object SanitizedChatBackup {
+    private const val DATABASE_NAME = "chat_v2"
+    private const val STAGED_PATH = "backup/chat_v2"
+
+    fun restoreIfPresent(context: Context) {
+        val staged = stagedFile(context)
+        if (!staged.isFile) return
+
+        val database = context.getDatabasePath(DATABASE_NAME)
+        database.parentFile?.mkdirs()
+        val atomicFile = AtomicFile(database)
+        val output = atomicFile.startWrite()
+        try {
+            staged.inputStream().use { input -> input.copyTo(output) }
+            atomicFile.finishWrite(output)
+            File("${database.path}-wal").delete()
+            File("${database.path}-shm").delete()
+            staged.delete()
+        } catch (error: Exception) {
+            atomicFile.failWrite(output)
+            throw error
+        }
+    }
+
+    internal fun createSanitizedCopy(source: File, destination: File) {
+        destination.parentFile?.mkdirs()
+        destination.delete()
+        SQLiteDatabase.openDatabase(source.path, null, SQLiteDatabase.OPEN_READWRITE).use { database ->
+            val escapedDestination = destination.path.replace("'", "''")
+            database.execSQL("VACUUM INTO '$escapedDestination'")
+        }
+        SQLiteDatabase.openDatabase(destination.path, null, SQLiteDatabase.OPEN_READWRITE).use { database ->
+            database.execSQL("UPDATE platform_v2 SET token = NULL")
+        }
+    }
+
+    internal fun stagedFile(context: Context): File = File(context.filesDir, STAGED_PATH)
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/backup/SanitizedChatBackup.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/backup/SanitizedChatBackup.kt
@@ -20,6 +20,7 @@ class SanitizedChatBackupAgent : BackupAgent() {
     override fun onRestore(data: BackupDataInput, appVersionCode: Int, newState: ParcelFileDescriptor) = Unit
 
     override fun onFullBackup(data: FullBackupDataOutput) {
+        if (!SanitizedChatBackup.deleteStagedFile(this)) return
         super.onFullBackup(data)
         val source = getDatabasePath(DATABASE_NAME)
         if (!source.exists()) return
@@ -72,6 +73,11 @@ object SanitizedChatBackup {
         SQLiteDatabase.openDatabase(destination.path, null, SQLiteDatabase.OPEN_READWRITE).use { database ->
             database.execSQL("UPDATE platform_v2 SET token = NULL")
         }
+    }
+
+    internal fun deleteStagedFile(context: Context): Boolean {
+        val staged = stagedFile(context)
+        return !staged.exists() || staged.delete()
     }
 
     internal fun stagedFile(context: Context): File = File(context.filesDir, STAGED_PATH)

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2.kt
@@ -3,10 +3,14 @@ package dev.chungjungsoo.gptmobile.data.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import dev.chungjungsoo.gptmobile.data.database.dao.AgentPersistenceDao
+import dev.chungjungsoo.gptmobile.data.database.dao.AgentRunDao
 import dev.chungjungsoo.gptmobile.data.database.dao.ChatPlatformModelV2Dao
 import dev.chungjungsoo.gptmobile.data.database.dao.ChatRoomV2Dao
 import dev.chungjungsoo.gptmobile.data.database.dao.MessageV2Dao
 import dev.chungjungsoo.gptmobile.data.database.dao.PlatformV2Dao
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRun
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentToolBinding
 import dev.chungjungsoo.gptmobile.data.database.entity.AssistantRevisionListConverter
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatAttachmentListConverter
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatPlatformModelV2
@@ -14,10 +18,21 @@ import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoomV2
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
 import dev.chungjungsoo.gptmobile.data.database.entity.StringListConverter
+import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnection
+import dev.chungjungsoo.gptmobile.data.database.entity.ToolEvent
 
 @Database(
-    entities = [ChatRoomV2::class, MessageV2::class, PlatformV2::class, ChatPlatformModelV2::class],
-    version = 6,
+    entities = [
+        ChatRoomV2::class,
+        MessageV2::class,
+        PlatformV2::class,
+        ChatPlatformModelV2::class,
+        ToolConnection::class,
+        AgentToolBinding::class,
+        AgentRun::class,
+        ToolEvent::class
+    ],
+    version = 7,
     exportSchema = true
 )
 @TypeConverters(
@@ -31,4 +46,6 @@ abstract class ChatDatabaseV2 : RoomDatabase() {
     abstract fun chatRoomDao(): ChatRoomV2Dao
     abstract fun messageDao(): MessageV2Dao
     abstract fun chatPlatformModelDao(): ChatPlatformModelV2Dao
+    abstract fun agentRunDao(): AgentRunDao
+    abstract fun agentPersistenceDao(): AgentPersistenceDao
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2Migrations.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2Migrations.kt
@@ -1,5 +1,6 @@
 package dev.chungjungsoo.gptmobile.data.database
 
+import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import dev.chungjungsoo.gptmobile.data.ModelConstants
@@ -12,6 +13,12 @@ import dev.chungjungsoo.gptmobile.data.model.ClientType
 import java.io.File
 
 object ChatDatabaseV2Migrations {
+
+    val AGENT_TOOL_BINDING_CALLBACK = object : RoomDatabase.Callback() {
+        override fun onOpen(db: SupportSQLiteDatabase) {
+            installAgentToolBindingConstraints(db)
+        }
+    }
 
     val MIGRATION_1_2 = object : Migration(1, 2) {
         override fun migrate(db: SupportSQLiteDatabase) {
@@ -278,6 +285,7 @@ object ChatDatabaseV2Migrations {
             db.execSQL("CREATE INDEX IF NOT EXISTS `index_agent_tool_bindings_profile_uid` ON `agent_tool_bindings` (`profile_uid`)")
             db.execSQL("CREATE INDEX IF NOT EXISTS `index_agent_tool_bindings_connection_uid` ON `agent_tool_bindings` (`connection_uid`)")
             db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_agent_tool_bindings_profile_uid_connection_uid_tool_name` ON `agent_tool_bindings` (`profile_uid`, `connection_uid`, `tool_name`)")
+            installAgentToolBindingConstraints(db)
             db.execSQL(
                 """
                 CREATE TABLE IF NOT EXISTS `agent_runs` (
@@ -331,6 +339,40 @@ object ChatDatabaseV2Migrations {
             db.execSQL("CREATE INDEX IF NOT EXISTS `index_tool_events_run_id` ON `tool_events` (`run_id`)")
             db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_tool_events_run_id_sequence` ON `tool_events` (`run_id`, `sequence`)")
         }
+    }
+
+    private fun installAgentToolBindingConstraints(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TRIGGER IF NOT EXISTS `agent_tool_bindings_builtin_insert_unique`
+            BEFORE INSERT ON `agent_tool_bindings`
+            WHEN NEW.`connection_uid` IS NULL AND EXISTS (
+                SELECT 1 FROM `agent_tool_bindings`
+                WHERE `profile_uid` = NEW.`profile_uid`
+                  AND `connection_uid` IS NULL
+                  AND `tool_name` = NEW.`tool_name`
+            )
+            BEGIN
+                SELECT RAISE(ABORT, 'duplicate built-in tool binding');
+            END
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            CREATE TRIGGER IF NOT EXISTS `agent_tool_bindings_builtin_update_unique`
+            BEFORE UPDATE ON `agent_tool_bindings`
+            WHEN NEW.`connection_uid` IS NULL AND EXISTS (
+                SELECT 1 FROM `agent_tool_bindings`
+                WHERE `profile_uid` = NEW.`profile_uid`
+                  AND `connection_uid` IS NULL
+                  AND `tool_name` = NEW.`tool_name`
+                  AND `binding_uid` != OLD.`binding_uid`
+            )
+            BEGIN
+                SELECT RAISE(ABORT, 'duplicate built-in tool binding');
+            END
+            """.trimIndent()
+        )
     }
 
     internal fun legacyFilesToAttachmentsJson(filesValue: String): String {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2Migrations.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2Migrations.kt
@@ -15,6 +15,8 @@ object ChatDatabaseV2Migrations {
 
     val MIGRATION_1_2 = object : Migration(1, 2) {
         override fun migrate(db: SupportSQLiteDatabase) {
+            ensureLegacyMessageColumns(db)
+            ensureLegacyPlatformColumns(db)
             db.execSQL(
                 """
                 CREATE TABLE IF NOT EXISTS `chat_platform_model_v2` (
@@ -66,6 +68,9 @@ object ChatDatabaseV2Migrations {
 
     val MIGRATION_2_3 = object : Migration(2, 3) {
         override fun migrate(db: SupportSQLiteDatabase) {
+            // Early v2 builds advanced the DB version without adding these schema-v2 columns.
+            ensureLegacyMessageColumns(db)
+            ensureLegacyPlatformColumns(db)
             db.execSQL(
                 """
                 CREATE TABLE IF NOT EXISTS `messages_v2_new` (
@@ -234,6 +239,100 @@ object ChatDatabaseV2Migrations {
         }
     }
 
+    val MIGRATION_6_7 = object : Migration(6, 7) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE `messages_v2` ADD COLUMN `current_run_id` TEXT")
+            db.execSQL("ALTER TABLE `platform_v2` ADD COLUMN `secret_ref` TEXT")
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `tool_connections` (
+                    `connection_uid` TEXT NOT NULL,
+                    `name` TEXT NOT NULL,
+                    `alias` TEXT NOT NULL,
+                    `type` TEXT NOT NULL,
+                    `endpoint_url` TEXT,
+                    `auth_type` TEXT NOT NULL,
+                    `secret_ref` TEXT,
+                    `oauth_client_id` TEXT,
+                    `allow_cleartext` INTEGER NOT NULL,
+                    `created_at` INTEGER NOT NULL,
+                    `updated_at` INTEGER NOT NULL,
+                    PRIMARY KEY(`connection_uid`)
+                )
+                """.trimIndent()
+            )
+            db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_tool_connections_alias` ON `tool_connections` (`alias`)")
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `agent_tool_bindings` (
+                    `binding_uid` TEXT NOT NULL,
+                    `profile_uid` TEXT NOT NULL,
+                    `connection_uid` TEXT,
+                    `tool_name` TEXT NOT NULL,
+                    `created_at` INTEGER NOT NULL,
+                    PRIMARY KEY(`binding_uid`),
+                    FOREIGN KEY(`connection_uid`) REFERENCES `tool_connections`(`connection_uid`) ON UPDATE NO ACTION ON DELETE CASCADE
+                )
+                """.trimIndent()
+            )
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_agent_tool_bindings_profile_uid` ON `agent_tool_bindings` (`profile_uid`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_agent_tool_bindings_connection_uid` ON `agent_tool_bindings` (`connection_uid`)")
+            db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_agent_tool_bindings_profile_uid_connection_uid_tool_name` ON `agent_tool_bindings` (`profile_uid`, `connection_uid`, `tool_name`)")
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `agent_runs` (
+                    `run_id` TEXT NOT NULL,
+                    `chat_id` INTEGER NOT NULL,
+                    `user_message_id` INTEGER NOT NULL,
+                    `assistant_message_id` INTEGER NOT NULL,
+                    `profile_uid` TEXT NOT NULL,
+                    `provider_snapshot` TEXT NOT NULL,
+                    `model_snapshot` TEXT NOT NULL,
+                    `status` TEXT NOT NULL,
+                    `created_at` INTEGER NOT NULL,
+                    `started_at` INTEGER,
+                    `completed_at` INTEGER,
+                    `terminal_error` TEXT,
+                    PRIMARY KEY(`run_id`),
+                    FOREIGN KEY(`chat_id`) REFERENCES `chats_v2`(`chat_id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+                    FOREIGN KEY(`user_message_id`) REFERENCES `messages_v2`(`message_id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+                    FOREIGN KEY(`assistant_message_id`) REFERENCES `messages_v2`(`message_id`) ON UPDATE NO ACTION ON DELETE CASCADE
+                )
+                """.trimIndent()
+            )
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_agent_runs_chat_id` ON `agent_runs` (`chat_id`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_agent_runs_user_message_id` ON `agent_runs` (`user_message_id`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_agent_runs_assistant_message_id` ON `agent_runs` (`assistant_message_id`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_agent_runs_status` ON `agent_runs` (`status`)")
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `tool_events` (
+                    `event_id` TEXT NOT NULL,
+                    `run_id` TEXT NOT NULL,
+                    `sequence` INTEGER NOT NULL,
+                    `call_id` TEXT NOT NULL,
+                    `connection_uid_snapshot` TEXT,
+                    `connection_name_snapshot` TEXT,
+                    `tool_name` TEXT NOT NULL,
+                    `model_tool_name` TEXT NOT NULL,
+                    `arguments` TEXT NOT NULL,
+                    `result` TEXT,
+                    `result_type` TEXT,
+                    `status` TEXT NOT NULL,
+                    `is_error` INTEGER NOT NULL,
+                    `started_at` INTEGER,
+                    `completed_at` INTEGER,
+                    `error` TEXT,
+                    PRIMARY KEY(`event_id`),
+                    FOREIGN KEY(`run_id`) REFERENCES `agent_runs`(`run_id`) ON UPDATE NO ACTION ON DELETE CASCADE
+                )
+                """.trimIndent()
+            )
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_tool_events_run_id` ON `tool_events` (`run_id`)")
+            db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_tool_events_run_id_sequence` ON `tool_events` (`run_id`, `sequence`)")
+        }
+    }
+
     internal fun legacyFilesToAttachmentsJson(filesValue: String): String {
         val attachments = filesValue
             .split(",")
@@ -250,6 +349,75 @@ object ChatDatabaseV2Migrations {
             }
 
         return ChatAttachmentListConverter().fromList(attachments)
+    }
+
+    internal fun ensureLegacyMessageColumns(db: SupportSQLiteDatabase) {
+        if (!db.hasColumn("messages_v2", "thoughts")) {
+            db.execSQL("ALTER TABLE `messages_v2` ADD COLUMN `thoughts` TEXT NOT NULL DEFAULT ''")
+        }
+        if (!db.hasColumn("messages_v2", "revisions")) {
+            db.execSQL("ALTER TABLE `messages_v2` ADD COLUMN `revisions` TEXT NOT NULL DEFAULT ''")
+        }
+    }
+
+    internal fun ensureLegacyPlatformColumns(db: SupportSQLiteDatabase) {
+        val hasCompatibleType = db.hasColumn("platform_v2", "compatible_type")
+        val hasReasoning = db.hasColumn("platform_v2", "reasoning")
+        if (hasCompatibleType && hasReasoning) return
+
+        val compatibleType = if (hasCompatibleType) {
+            "`compatible_type`"
+        } else {
+            """
+            CASE
+                WHEN LOWER(`name`) LIKE '%anthropic%' OR LOWER(`api_url`) LIKE '%anthropic%' THEN 'ANTHROPIC'
+                WHEN LOWER(`name`) LIKE '%gemini%' OR LOWER(`name`) LIKE '%google%' OR LOWER(`api_url`) LIKE '%googleapis%' THEN 'GOOGLE'
+                WHEN LOWER(`name`) LIKE '%groq%' OR LOWER(`api_url`) LIKE '%groq%' THEN 'GROQ'
+                WHEN LOWER(`name`) LIKE '%ollama%' THEN 'OLLAMA'
+                WHEN LOWER(`name`) LIKE '%openrouter%' OR LOWER(`api_url`) LIKE '%openrouter%' THEN 'OPENROUTER'
+                WHEN LOWER(`name`) LIKE '%openai%' OR LOWER(`api_url`) LIKE '%openai%' THEN 'OPENAI'
+                ELSE 'CUSTOM'
+            END
+            """.trimIndent()
+        }
+        val reasoning = if (hasReasoning) "`reasoning`" else "0"
+
+        db.execSQL("ALTER TABLE `platform_v2` RENAME TO `platform_v2_legacy`")
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `platform_v2` (
+                `platform_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                `uid` TEXT NOT NULL,
+                `name` TEXT NOT NULL,
+                `compatible_type` TEXT NOT NULL,
+                `enabled` INTEGER NOT NULL,
+                `api_url` TEXT NOT NULL,
+                `token` TEXT,
+                `model` TEXT NOT NULL,
+                `temperature` REAL,
+                `top_p` REAL,
+                `system_prompt` TEXT,
+                `stream` INTEGER NOT NULL,
+                `reasoning` INTEGER NOT NULL,
+                `timeout` INTEGER NOT NULL
+            )
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            INSERT INTO `platform_v2` (
+                `platform_id`, `uid`, `name`, `compatible_type`, `enabled`, `api_url`,
+                `token`, `model`, `temperature`, `top_p`, `system_prompt`, `stream`,
+                `reasoning`, `timeout`
+            )
+            SELECT
+                `platform_id`, `uid`, `name`, $compatibleType, `enabled`, `api_url`,
+                `token`, `model`, `temperature`, `top_p`, `system_prompt`, `stream`,
+                $reasoning, `timeout`
+            FROM `platform_v2_legacy`
+            """.trimIndent()
+        )
+        db.execSQL("DROP TABLE `platform_v2_legacy`")
     }
 
     internal fun legacyRevisionsToStructuredJson(
@@ -315,4 +483,10 @@ object ChatDatabaseV2Migrations {
     private fun String.hasV1Segment(): Boolean = trimEnd('/')
         .split("/")
         .any { segment -> segment.substringBefore("?").substringBefore("#") == "v1" }
+}
+
+private fun SupportSQLiteDatabase.hasColumn(table: String, column: String): Boolean = query("PRAGMA table_info(`$table`)").use { cursor ->
+    val nameIndex = cursor.getColumnIndexOrThrow("name")
+    generateSequence { if (cursor.moveToNext()) cursor.getString(nameIndex) else null }
+        .any { it == column }
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/dao/AgentPersistenceDao.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/dao/AgentPersistenceDao.kt
@@ -1,0 +1,242 @@
+package dev.chungjungsoo.gptmobile.data.database.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Update
+import androidx.room.Upsert
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRun
+import dev.chungjungsoo.gptmobile.data.database.entity.ChatPlatformModelV2
+import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoomV2
+import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
+import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentRetryRequest
+import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentRetryResult
+import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentTurnRequest
+import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentTurnResult
+import dev.chungjungsoo.gptmobile.data.database.entity.ToolEvent
+import dev.chungjungsoo.gptmobile.data.database.entity.snapshotLatestAssistantRevision
+import java.util.UUID
+
+@Dao
+interface AgentPersistenceDao {
+    @Insert
+    suspend fun insertChatRoom(chatRoom: ChatRoomV2): Long
+
+    @Update
+    suspend fun updateChatRoom(chatRoom: ChatRoomV2)
+
+    @Insert
+    suspend fun insertMessage(message: MessageV2): Long
+
+    @Insert
+    suspend fun insertRun(run: AgentRun)
+
+    @Insert
+    suspend fun insertToolEvent(event: ToolEvent)
+
+    @Delete
+    suspend fun deleteMessages(messages: List<MessageV2>)
+
+    @Upsert
+    suspend fun upsertModels(models: List<ChatPlatformModelV2>)
+
+    @Query("SELECT * FROM chats_v2 WHERE chat_id = :chatId")
+    suspend fun getChatRoom(chatId: Int): ChatRoomV2?
+
+    @Query("SELECT * FROM messages_v2 WHERE chat_id = :chatId ORDER BY created_at, message_id")
+    suspend fun getMessages(chatId: Int): List<MessageV2>
+
+    @Query("SELECT * FROM chat_platform_model_v2 WHERE chat_id = :chatId")
+    suspend fun getModels(chatId: Int): List<ChatPlatformModelV2>
+
+    @Query("SELECT * FROM agent_runs WHERE chat_id = :chatId AND status = 'COMPLETED' ORDER BY created_at, run_id")
+    suspend fun getCompletedRuns(chatId: Int): List<AgentRun>
+
+    @Query("SELECT * FROM tool_events WHERE run_id IN (:runIds) ORDER BY run_id, sequence")
+    suspend fun getToolEvents(runIds: List<String>): List<ToolEvent>
+
+    @Transaction
+    suspend fun persistAgentTurn(request: PersistAgentTurnRequest): PersistAgentTurnResult {
+        val chatRoom = if (request.chatRoom.id == 0) {
+            request.chatRoom.copy(id = insertChatRoom(request.chatRoom).toInt())
+        } else {
+            updateChatRoom(request.chatRoom)
+            request.chatRoom
+        }
+        val userMessage = request.userMessage.copy(chatId = chatRoom.id).let { message ->
+            if (message.id == 0) {
+                message.copy(id = insertMessage(message).toInt())
+            } else {
+                updateMessage(message)
+                message
+            }
+        }
+        val assistantMessages = request.runs.map { draft ->
+            MessageV2(
+                chatId = chatRoom.id,
+                content = "",
+                linkedMessageId = userMessage.id,
+                platformType = draft.profileUid,
+                currentRunId = draft.runId,
+                createdAt = draft.createdAt
+            ).let { it.copy(id = insertMessage(it).toInt()) }
+        }
+        val runs = request.runs.zip(assistantMessages) { draft, assistantMessage ->
+            AgentRun(
+                runId = draft.runId,
+                chatId = chatRoom.id,
+                userMessageId = userMessage.id,
+                assistantMessageId = assistantMessage.id,
+                profileUid = draft.profileUid,
+                providerSnapshot = draft.providerSnapshot,
+                modelSnapshot = draft.modelSnapshot,
+                createdAt = draft.createdAt
+            ).also { insertRun(it) }
+        }
+        upsertModels(
+            request.chatPlatformModels.map { (profileUid, model) ->
+                ChatPlatformModelV2(chatId = chatRoom.id, platformUid = profileUid, model = model)
+            }
+        )
+        return PersistAgentTurnResult(chatRoom, userMessage, assistantMessages, runs)
+    }
+
+    @Transaction
+    suspend fun saveChatSnapshot(
+        chatRoom: ChatRoomV2,
+        messages: List<MessageV2>,
+        chatPlatformModels: Map<String, String>
+    ) {
+        require(chatRoom.id > 0)
+        updateChatRoom(chatRoom)
+
+        val incomingIds = messages.asSequence().map(MessageV2::id).filter { it > 0 }.toSet()
+        val removedMessages = getMessages(chatRoom.id).filter { it.id !in incomingIds }
+        if (removedMessages.isNotEmpty()) deleteMessages(removedMessages)
+
+        messages.forEach { message ->
+            val persisted = message.copy(chatId = chatRoom.id)
+            if (persisted.id == 0) {
+                insertMessage(persisted)
+            } else {
+                updateMessage(persisted)
+            }
+        }
+        upsertModels(
+            chatPlatformModels.map { (profileUid, model) ->
+                ChatPlatformModelV2(chatId = chatRoom.id, platformUid = profileUid, model = model)
+            }
+        )
+    }
+
+    @Transaction
+    suspend fun persistAgentRetry(request: PersistAgentRetryRequest): PersistAgentRetryResult {
+        require(request.userMessage.id > 0 && request.assistantMessage.id > 0)
+        require(request.userMessage.chatId == request.assistantMessage.chatId)
+
+        val previousRevision = request.assistantMessage.snapshotLatestAssistantRevision(request.run.createdAt)
+        val assistantMessage = request.assistantMessage.copy(
+            content = "",
+            thoughts = "",
+            revisions = previousRevision
+                ?.let { listOf(it) + request.assistantMessage.revisions }
+                ?: request.assistantMessage.revisions,
+            currentRunId = request.run.runId,
+            createdAt = request.run.createdAt
+        )
+        updateMessage(assistantMessage)
+
+        val run = AgentRun(
+            runId = request.run.runId,
+            chatId = request.userMessage.chatId,
+            userMessageId = request.userMessage.id,
+            assistantMessageId = assistantMessage.id,
+            profileUid = request.run.profileUid,
+            providerSnapshot = request.run.providerSnapshot,
+            modelSnapshot = request.run.modelSnapshot,
+            createdAt = request.run.createdAt
+        )
+        insertRun(run)
+        return PersistAgentRetryResult(assistantMessage, run)
+    }
+
+    @Transaction
+    suspend fun duplicateChatWithHistory(
+        sourceChatId: Int,
+        title: String,
+        timestamp: Long
+    ): ChatRoomV2 {
+        val sourceChat = requireNotNull(getChatRoom(sourceChatId))
+        val sourceMessages = getMessages(sourceChatId)
+        val completedRuns = getCompletedRuns(sourceChatId)
+        val sourceEvents = if (completedRuns.isEmpty()) {
+            emptyList()
+        } else {
+            getToolEvents(completedRuns.map { it.runId })
+        }
+
+        val duplicate = sourceChat.copy(
+            id = 0,
+            title = title,
+            createdAt = timestamp,
+            updatedAt = timestamp
+        ).let { it.copy(id = insertChatRoom(it).toInt()) }
+
+        val messageIdMap = sourceMessages.associate { source ->
+            val insertedId = insertMessage(
+                source.copy(
+                    id = 0,
+                    chatId = duplicate.id,
+                    linkedMessageId = 0,
+                    currentRunId = null
+                )
+            ).toInt()
+            source.id to insertedId
+        }
+        val runIdMap = completedRuns.associate { it.runId to UUID.randomUUID().toString() }
+
+        sourceMessages.forEach { source ->
+            updateMessage(
+                source.copy(
+                    id = messageIdMap.getValue(source.id),
+                    chatId = duplicate.id,
+                    linkedMessageId = messageIdMap[source.linkedMessageId] ?: 0,
+                    currentRunId = source.currentRunId?.let(runIdMap::get),
+                    revisions = source.revisions.map { revision ->
+                        revision.copy(runId = revision.runId?.let(runIdMap::get))
+                    }
+                )
+            )
+        }
+
+        completedRuns.forEach { source ->
+            insertRun(
+                source.copy(
+                    runId = runIdMap.getValue(source.runId),
+                    chatId = duplicate.id,
+                    userMessageId = messageIdMap.getValue(source.userMessageId),
+                    assistantMessageId = messageIdMap.getValue(source.assistantMessageId)
+                )
+            )
+        }
+        sourceEvents.forEach { source ->
+            insertToolEvent(
+                source.copy(
+                    eventId = UUID.randomUUID().toString(),
+                    runId = runIdMap.getValue(source.runId)
+                )
+            )
+        }
+        upsertModels(
+            getModels(sourceChatId).map { model ->
+                model.copy(chatId = duplicate.id, updatedAt = timestamp)
+            }
+        )
+        return duplicate
+    }
+
+    @Update
+    suspend fun updateMessage(message: MessageV2)
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/dao/AgentPersistenceDao.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/dao/AgentPersistenceDao.kt
@@ -7,6 +7,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Update
 import androidx.room.Upsert
+import dev.chungjungsoo.gptmobile.data.database.entity.ACTIVE_REVISION_LATEST
 import dev.chungjungsoo.gptmobile.data.database.entity.AgentRun
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatPlatformModelV2
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoomV2
@@ -140,9 +141,11 @@ interface AgentPersistenceDao {
         val assistantMessage = request.assistantMessage.copy(
             content = "",
             thoughts = "",
+            attachments = emptyList(),
             revisions = previousRevision
                 ?.let { listOf(it) + request.assistantMessage.revisions }
                 ?: request.assistantMessage.revisions,
+            activeRevisionIndex = ACTIVE_REVISION_LATEST,
             currentRunId = request.run.runId,
             createdAt = request.run.createdAt
         )
@@ -161,6 +164,31 @@ interface AgentPersistenceDao {
         insertRun(run)
         return PersistAgentRetryResult(assistantMessage, run)
     }
+
+    @Transaction
+    suspend fun finishAgentRun(
+        assistantMessage: MessageV2,
+        runId: String,
+        status: String,
+        startedAt: Long?,
+        completedAt: Long?,
+        terminalError: String?
+    ) {
+        updateMessage(assistantMessage)
+        updateRunStatus(runId, status, startedAt, completedAt, terminalError)
+    }
+
+    @Query(
+        "UPDATE agent_runs SET status = :status, started_at = :startedAt, " +
+            "completed_at = :completedAt, terminal_error = :terminalError WHERE run_id = :runId"
+    )
+    suspend fun updateRunStatus(
+        runId: String,
+        status: String,
+        startedAt: Long?,
+        completedAt: Long?,
+        terminalError: String?
+    )
 
     @Transaction
     suspend fun duplicateChatWithHistory(

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/dao/AgentRunDao.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/dao/AgentRunDao.kt
@@ -1,0 +1,36 @@
+package dev.chungjungsoo.gptmobile.data.database.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRun
+
+@Dao
+interface AgentRunDao {
+    @Upsert
+    suspend fun upsert(run: AgentRun)
+
+    @Query("SELECT * FROM agent_runs WHERE run_id = :runId")
+    suspend fun getById(runId: String): AgentRun?
+
+    @Query("SELECT * FROM agent_runs WHERE chat_id = :chatId ORDER BY created_at, run_id")
+    suspend fun getByChatId(chatId: Int): List<AgentRun>
+
+    @Query(
+        "UPDATE agent_runs SET status = :status, started_at = :startedAt, " +
+            "completed_at = :completedAt, terminal_error = :terminalError WHERE run_id = :runId"
+    )
+    suspend fun updateStatus(
+        runId: String,
+        status: String,
+        startedAt: Long?,
+        completedAt: Long?,
+        terminalError: String?
+    )
+
+    @Query(
+        "UPDATE agent_runs SET status = 'INTERRUPTED', completed_at = :completedAt " +
+            "WHERE status IN ('QUEUED', 'RUNNING')"
+    )
+    suspend fun interruptActiveRuns(completedAt: Long): Int
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/dao/PlatformV2Dao.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/dao/PlatformV2Dao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Update
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
 
@@ -22,6 +23,15 @@ interface PlatformV2Dao {
     @Update
     suspend fun editPlatform(platform: PlatformV2)
 
+    @Transaction
+    suspend fun deletePlatform(platform: PlatformV2) {
+        deleteBindingsByProfileUid(platform.uid)
+        deletePlatformRow(platform)
+    }
+
+    @Query("DELETE FROM agent_tool_bindings WHERE profile_uid = :profileUid")
+    suspend fun deleteBindingsByProfileUid(profileUid: String)
+
     @Delete
-    suspend fun deletePlatform(platform: PlatformV2)
+    suspend fun deletePlatformRow(platform: PlatformV2)
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/AgentRun.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/AgentRun.kt
@@ -1,0 +1,117 @@
+package dev.chungjungsoo.gptmobile.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "agent_runs",
+    foreignKeys = [
+        ForeignKey(
+            entity = ChatRoomV2::class,
+            parentColumns = ["chat_id"],
+            childColumns = ["chat_id"],
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = MessageV2::class,
+            parentColumns = ["message_id"],
+            childColumns = ["user_message_id"],
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = MessageV2::class,
+            parentColumns = ["message_id"],
+            childColumns = ["assistant_message_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(value = ["chat_id"]),
+        Index(value = ["user_message_id"]),
+        Index(value = ["assistant_message_id"]),
+        Index(value = ["status"])
+    ]
+)
+data class AgentRun(
+    @PrimaryKey
+    @ColumnInfo(name = "run_id")
+    val runId: String,
+
+    @ColumnInfo(name = "chat_id")
+    val chatId: Int,
+
+    @ColumnInfo(name = "user_message_id")
+    val userMessageId: Int,
+
+    @ColumnInfo(name = "assistant_message_id")
+    val assistantMessageId: Int,
+
+    @ColumnInfo(name = "profile_uid")
+    val profileUid: String,
+
+    @ColumnInfo(name = "provider_snapshot")
+    val providerSnapshot: String,
+
+    @ColumnInfo(name = "model_snapshot")
+    val modelSnapshot: String,
+
+    @ColumnInfo(name = "status")
+    val status: String = AgentRunStatus.QUEUED,
+
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long = System.currentTimeMillis() / 1000,
+
+    @ColumnInfo(name = "started_at")
+    val startedAt: Long? = null,
+
+    @ColumnInfo(name = "completed_at")
+    val completedAt: Long? = null,
+
+    @ColumnInfo(name = "terminal_error")
+    val terminalError: String? = null
+)
+
+data class AgentRunDraft(
+    val runId: String,
+    val profileUid: String,
+    val providerSnapshot: String,
+    val modelSnapshot: String,
+    val createdAt: Long = System.currentTimeMillis() / 1000
+)
+
+data class PersistAgentTurnRequest(
+    val chatRoom: ChatRoomV2,
+    val userMessage: MessageV2,
+    val runs: List<AgentRunDraft>,
+    val chatPlatformModels: Map<String, String>
+)
+
+data class PersistAgentTurnResult(
+    val chatRoom: ChatRoomV2,
+    val userMessage: MessageV2,
+    val assistantMessages: List<MessageV2>,
+    val runs: List<AgentRun>
+)
+
+data class PersistAgentRetryRequest(
+    val userMessage: MessageV2,
+    val assistantMessage: MessageV2,
+    val run: AgentRunDraft
+)
+
+data class PersistAgentRetryResult(
+    val assistantMessage: MessageV2,
+    val run: AgentRun
+)
+
+object AgentRunStatus {
+    const val QUEUED = "QUEUED"
+    const val RUNNING = "RUNNING"
+    const val COMPLETED = "COMPLETED"
+    const val FAILED = "FAILED"
+    const val CANCELED = "CANCELED"
+    const val INTERRUPTED = "INTERRUPTED"
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/AgentToolBinding.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/AgentToolBinding.kt
@@ -1,0 +1,45 @@
+package dev.chungjungsoo.gptmobile.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "agent_tool_bindings",
+    foreignKeys = [
+        ForeignKey(
+            entity = ToolConnection::class,
+            parentColumns = ["connection_uid"],
+            childColumns = ["connection_uid"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(value = ["profile_uid"]),
+        Index(value = ["connection_uid"]),
+        Index(value = ["profile_uid", "connection_uid", "tool_name"], unique = true)
+    ]
+)
+data class AgentToolBinding(
+    @PrimaryKey
+    @ColumnInfo(name = "binding_uid")
+    val bindingUid: String,
+
+    @ColumnInfo(name = "profile_uid")
+    val profileUid: String,
+
+    @ColumnInfo(name = "connection_uid")
+    val connectionUid: String?,
+
+    @ColumnInfo(name = "tool_name")
+    val toolName: String,
+
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long = System.currentTimeMillis() / 1000
+)
+
+object BuiltInAgentTool {
+    const val READ_URL = "read_url"
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/MessageV2.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/MessageV2.kt
@@ -49,6 +49,9 @@ data class MessageV2(
     @ColumnInfo(name = "platform_type")
     val platformType: String?,
 
+    @ColumnInfo(name = "current_run_id")
+    val currentRunId: String? = null,
+
     @ColumnInfo(name = "created_at")
     val createdAt: Long = System.currentTimeMillis() / 1000
 )
@@ -57,7 +60,8 @@ data class MessageV2(
 data class AssistantRevision(
     val content: String,
     val thoughts: String = "",
-    val createdAt: Long
+    val createdAt: Long,
+    val runId: String? = null
 )
 
 const val ACTIVE_REVISION_LATEST = -1
@@ -89,6 +93,7 @@ fun MessageV2.snapshotLatestAssistantRevision(timestamp: Long = System.currentTi
     return AssistantRevision(
         content = content,
         thoughts = thoughts,
-        createdAt = timestamp
+        createdAt = timestamp,
+        runId = currentRunId
     )
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/PlatformV2.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/PlatformV2.kt
@@ -31,6 +31,9 @@ data class PlatformV2(
     @ColumnInfo(name = "token")
     val token: String? = null,
 
+    @ColumnInfo(name = "secret_ref")
+    val secretRef: String? = null,
+
     @ColumnInfo(name = "model")
     val model: String,
 

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/ToolConnection.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/ToolConnection.kt
@@ -1,0 +1,59 @@
+package dev.chungjungsoo.gptmobile.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "tool_connections",
+    indices = [Index(value = ["alias"], unique = true)]
+)
+data class ToolConnection(
+    @PrimaryKey
+    @ColumnInfo(name = "connection_uid")
+    val connectionUid: String,
+
+    @ColumnInfo(name = "name")
+    val name: String,
+
+    @ColumnInfo(name = "alias")
+    val alias: String,
+
+    @ColumnInfo(name = "type")
+    val type: String,
+
+    @ColumnInfo(name = "endpoint_url")
+    val endpointUrl: String?,
+
+    @ColumnInfo(name = "auth_type")
+    val authType: String,
+
+    @ColumnInfo(name = "secret_ref")
+    val secretRef: String?,
+
+    @ColumnInfo(name = "oauth_client_id")
+    val oauthClientId: String?,
+
+    @ColumnInfo(name = "allow_cleartext")
+    val allowCleartext: Boolean = false,
+
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long = System.currentTimeMillis() / 1000,
+
+    @ColumnInfo(name = "updated_at")
+    val updatedAt: Long = System.currentTimeMillis() / 1000
+)
+
+object ToolConnectionType {
+    const val MCP = "MCP"
+    const val FIRECRAWL = "FIRECRAWL"
+    const val PERPLEXITY = "PERPLEXITY"
+    const val EXA = "EXA"
+}
+
+object ToolConnectionAuthType {
+    const val NONE = "NONE"
+    const val BEARER = "BEARER"
+    const val OAUTH = "OAUTH"
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/ToolEvent.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/ToolEvent.kt
@@ -1,0 +1,88 @@
+package dev.chungjungsoo.gptmobile.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "tool_events",
+    foreignKeys = [
+        ForeignKey(
+            entity = AgentRun::class,
+            parentColumns = ["run_id"],
+            childColumns = ["run_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(value = ["run_id"]),
+        Index(value = ["run_id", "sequence"], unique = true)
+    ]
+)
+data class ToolEvent(
+    @PrimaryKey
+    @ColumnInfo(name = "event_id")
+    val eventId: String,
+
+    @ColumnInfo(name = "run_id")
+    val runId: String,
+
+    @ColumnInfo(name = "sequence")
+    val sequence: Int,
+
+    @ColumnInfo(name = "call_id")
+    val callId: String,
+
+    @ColumnInfo(name = "connection_uid_snapshot")
+    val connectionUidSnapshot: String?,
+
+    @ColumnInfo(name = "connection_name_snapshot")
+    val connectionNameSnapshot: String?,
+
+    @ColumnInfo(name = "tool_name")
+    val toolName: String,
+
+    @ColumnInfo(name = "model_tool_name")
+    val modelToolName: String,
+
+    @ColumnInfo(name = "arguments")
+    val arguments: String,
+
+    @ColumnInfo(name = "result")
+    val result: String?,
+
+    @ColumnInfo(name = "result_type")
+    val resultType: String?,
+
+    @ColumnInfo(name = "status")
+    val status: String,
+
+    @ColumnInfo(name = "is_error")
+    val isError: Boolean = false,
+
+    @ColumnInfo(name = "started_at")
+    val startedAt: Long? = null,
+
+    @ColumnInfo(name = "completed_at")
+    val completedAt: Long? = null,
+
+    @ColumnInfo(name = "error")
+    val error: String? = null
+)
+
+object ToolEventStatus {
+    const val PENDING = "PENDING"
+    const val RUNNING = "RUNNING"
+    const val COMPLETED = "COMPLETED"
+    const val FAILED = "FAILED"
+    const val CANCELED = "CANCELED"
+}
+
+object ToolEventResultType {
+    const val TEXT = "TEXT"
+    const val JSON = "JSON"
+    const val RESOURCE_LINKS = "RESOURCE_LINKS"
+    const val UNSUPPORTED = "UNSUPPORTED"
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/datastore/SettingDataSource.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/datastore/SettingDataSource.kt
@@ -10,6 +10,7 @@ interface SettingDataSource {
     suspend fun updateStatus(apiType: ApiType, status: Boolean)
     suspend fun updateAPIUrl(apiType: ApiType, url: String)
     suspend fun updateToken(apiType: ApiType, token: String)
+    suspend fun clearToken(apiType: ApiType)
     suspend fun updateModel(apiType: ApiType, model: String)
     suspend fun updateTemperature(apiType: ApiType, temperature: Float)
     suspend fun updateTopP(apiType: ApiType, topP: Float)

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/datastore/SettingDataSourceImpl.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/datastore/SettingDataSourceImpl.kt
@@ -99,6 +99,12 @@ class SettingDataSourceImpl @Inject constructor(
         }
     }
 
+    override suspend fun clearToken(apiType: ApiType) {
+        dataStore.edit { pref ->
+            pref.remove(apiTokenMap[apiType]!!)
+        }
+    }
+
     override suspend fun updateModel(apiType: ApiType, model: String) {
         dataStore.edit { pref ->
             pref[apiModelMap[apiType]!!] = model

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepository.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepository.kt
@@ -4,6 +4,10 @@ import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoom
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoomV2
 import dev.chungjungsoo.gptmobile.data.database.entity.Message
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
+import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentRetryRequest
+import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentRetryResult
+import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentTurnRequest
+import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentTurnResult
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
 import dev.chungjungsoo.gptmobile.data.dto.ApiState
 import kotlinx.coroutines.flow.Flow
@@ -18,6 +22,16 @@ interface ChatRepository {
     suspend fun fetchMessagesV2(chatId: Int): List<MessageV2>
     suspend fun fetchChatPlatformModels(chatId: Int): Map<String, String>
     suspend fun saveChatPlatformModels(chatId: Int, models: Map<String, String>)
+    suspend fun persistAgentTurn(request: PersistAgentTurnRequest): PersistAgentTurnResult
+    suspend fun persistAgentRetry(request: PersistAgentRetryRequest): PersistAgentRetryResult
+    suspend fun updateAgentRunStatus(
+        runId: String,
+        status: String,
+        startedAt: Long?,
+        completedAt: Long?,
+        terminalError: String?
+    )
+    suspend fun interruptActiveAgentRuns(completedAt: Long): Int
     suspend fun migrateToChatRoomV2MessageV2()
     fun generateDefaultChatTitle(messages: List<MessageV2>): String?
     suspend fun updateChatTitle(chatRoom: ChatRoomV2, title: String)

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepository.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepository.kt
@@ -31,6 +31,14 @@ interface ChatRepository {
         completedAt: Long?,
         terminalError: String?
     )
+    suspend fun finishAgentRun(
+        assistantMessage: MessageV2,
+        runId: String,
+        status: String,
+        startedAt: Long?,
+        completedAt: Long?,
+        terminalError: String?
+    )
     suspend fun interruptActiveAgentRuns(completedAt: Long): Int
     suspend fun migrateToChatRoomV2MessageV2()
     fun generateDefaultChatTitle(messages: List<MessageV2>): String?

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImpl.kt
@@ -839,6 +839,22 @@ class ChatRepositoryImpl @Inject constructor(
         agentRunDao.updateStatus(runId, status, startedAt, completedAt, terminalError)
     }
 
+    override suspend fun finishAgentRun(
+        assistantMessage: MessageV2,
+        runId: String,
+        status: String,
+        startedAt: Long?,
+        completedAt: Long?,
+        terminalError: String?
+    ) = agentPersistenceDao.finishAgentRun(
+        assistantMessage,
+        runId,
+        status,
+        startedAt,
+        completedAt,
+        terminalError
+    )
+
     override suspend fun interruptActiveAgentRuns(completedAt: Long): Int = agentRunDao.interruptActiveRuns(completedAt)
 
     override suspend fun migrateToChatRoomV2MessageV2() {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImpl.kt
@@ -5,6 +5,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.chungjungsoo.gptmobile.data.context.ContextBuilder
 import dev.chungjungsoo.gptmobile.data.context.ConversationTurn
 import dev.chungjungsoo.gptmobile.data.context.ProviderContextPolicy
+import dev.chungjungsoo.gptmobile.data.database.dao.AgentPersistenceDao
+import dev.chungjungsoo.gptmobile.data.database.dao.AgentRunDao
 import dev.chungjungsoo.gptmobile.data.database.dao.ChatPlatformModelV2Dao
 import dev.chungjungsoo.gptmobile.data.database.dao.ChatRoomDao
 import dev.chungjungsoo.gptmobile.data.database.dao.ChatRoomV2Dao
@@ -15,6 +17,10 @@ import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoom
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoomV2
 import dev.chungjungsoo.gptmobile.data.database.entity.Message
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
+import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentRetryRequest
+import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentRetryResult
+import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentTurnRequest
+import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentTurnResult
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
 import dev.chungjungsoo.gptmobile.data.database.entity.effectiveContent
 import dev.chungjungsoo.gptmobile.data.dto.ApiState
@@ -76,6 +82,8 @@ class ChatRepositoryImpl @Inject constructor(
     private val chatRoomV2Dao: ChatRoomV2Dao,
     private val messageV2Dao: MessageV2Dao,
     private val chatPlatformModelV2Dao: ChatPlatformModelV2Dao,
+    private val agentPersistenceDao: AgentPersistenceDao,
+    private val agentRunDao: AgentRunDao,
     private val settingRepository: SettingRepository,
     private val openAIAPI: OpenAIAPI,
     private val groqAPI: GroqAPI,
@@ -817,6 +825,22 @@ class ChatRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun persistAgentTurn(request: PersistAgentTurnRequest): PersistAgentTurnResult = agentPersistenceDao.persistAgentTurn(request)
+
+    override suspend fun persistAgentRetry(request: PersistAgentRetryRequest): PersistAgentRetryResult = agentPersistenceDao.persistAgentRetry(request)
+
+    override suspend fun updateAgentRunStatus(
+        runId: String,
+        status: String,
+        startedAt: Long?,
+        completedAt: Long?,
+        terminalError: String?
+    ) {
+        agentRunDao.updateStatus(runId, status, startedAt, completedAt, terminalError)
+    }
+
+    override suspend fun interruptActiveAgentRuns(completedAt: Long): Int = agentRunDao.interruptActiveRuns(completedAt)
+
     override suspend fun migrateToChatRoomV2MessageV2() {
         val leftOverChatRoomV2s = chatRoomV2Dao.getChatRooms()
         leftOverChatRoomV2s.forEach { chatPlatformModelV2Dao.deleteByChatId(it.id) }
@@ -902,26 +926,10 @@ class ChatRepositoryImpl @Inject constructor(
             return savedChatRoom.copy(title = updatedMessages[0].content.replace('\n', ' ').take(50))
         }
 
-        val savedMessages = fetchMessagesV2(chatRoom.id)
-        val updatedMessages = messages.map { it.copy(chatId = chatRoom.id) }
-
-        val shouldBeDeleted = savedMessages.filter { m ->
-            updatedMessages.firstOrNull { it.id == m.id } == null
-        }
-        val shouldBeUpdated = updatedMessages.filter { m ->
-            savedMessages.firstOrNull { it.id == m.id && it != m } != null
-        }
-        val shouldBeAdded = updatedMessages.filter { m ->
-            savedMessages.firstOrNull { it.id == m.id } == null
-        }
-
-        chatRoomV2Dao.editChatRoom(chatRoom)
-        messageV2Dao.deleteMessages(*shouldBeDeleted.toTypedArray())
-        messageV2Dao.editMessages(*shouldBeUpdated.toTypedArray())
-        messageV2Dao.addMessages(*shouldBeAdded.toTypedArray())
-        saveChatPlatformModels(
-            chatId = chatRoom.id,
-            models = chatPlatformModels.filterKeys { it in chatRoom.enabledPlatform }
+        agentPersistenceDao.saveChatSnapshot(
+            chatRoom = chatRoom,
+            messages = messages,
+            chatPlatformModels = chatPlatformModels.filterKeys { it in chatRoom.enabledPlatform }
         )
 
         return chatRoom
@@ -929,32 +937,10 @@ class ChatRepositoryImpl @Inject constructor(
 
     override suspend fun duplicateChatV2(chatRoom: ChatRoomV2): ChatRoomV2 {
         val duplicatedTitle = "${chatRoom.title} (copy)".take(50)
-        val duplicatedChatId = chatRoomV2Dao.addChatRoom(
-            ChatRoomV2(
-                title = duplicatedTitle,
-                enabledPlatform = chatRoom.enabledPlatform
-            )
-        ).toInt()
-
-        val messages = fetchMessagesV2(chatRoom.id).map { message ->
-            message.copy(
-                id = 0,
-                chatId = duplicatedChatId,
-                linkedMessageId = 0
-            )
-        }
-        if (messages.isNotEmpty()) {
-            messageV2Dao.addMessages(*messages.toTypedArray())
-        }
-
-        val chatPlatformModels = fetchChatPlatformModels(chatRoom.id)
-        saveChatPlatformModels(duplicatedChatId, chatPlatformModels)
-
-        return chatRoom.copy(
-            id = duplicatedChatId,
+        return agentPersistenceDao.duplicateChatWithHistory(
+            sourceChatId = chatRoom.id,
             title = duplicatedTitle,
-            createdAt = System.currentTimeMillis() / 1000,
-            updatedAt = System.currentTimeMillis() / 1000
+            timestamp = System.currentTimeMillis() / 1000
         )
     }
 

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/SettingRepository.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/SettingRepository.kt
@@ -9,6 +9,7 @@ interface SettingRepository {
     suspend fun fetchPlatformV2s(): List<PlatformV2>
     suspend fun fetchThemes(): ThemeSetting
     suspend fun migrateToPlatformV2()
+    suspend fun migrateSecrets(): List<SecretMigrationError>
     suspend fun updatePlatforms(platforms: List<Platform>)
     suspend fun updateThemes(themeSetting: ThemeSetting)
 
@@ -18,3 +19,5 @@ interface SettingRepository {
     suspend fun deletePlatformV2(platform: PlatformV2)
     suspend fun getPlatformV2ById(id: Int): PlatformV2?
 }
+
+data class SecretMigrationError(val source: String, val message: String)

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/SettingRepositoryImpl.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/SettingRepositoryImpl.kt
@@ -11,12 +11,14 @@ import dev.chungjungsoo.gptmobile.data.model.ApiType
 import dev.chungjungsoo.gptmobile.data.model.ClientType
 import dev.chungjungsoo.gptmobile.data.model.DynamicTheme
 import dev.chungjungsoo.gptmobile.data.model.ThemeMode
+import dev.chungjungsoo.gptmobile.data.security.SecretVault
 import javax.inject.Inject
 
 class SettingRepositoryImpl @Inject constructor(
     private val settingDataSource: SettingDataSource,
     private val platformV2Dao: PlatformV2Dao,
-    private val chatPlatformModelV2Dao: ChatPlatformModelV2Dao
+    private val chatPlatformModelV2Dao: ChatPlatformModelV2Dao,
+    private val secretVault: SecretVault
 ) : SettingRepository {
 
     override suspend fun fetchPlatforms(): List<Platform> = ApiType.entries.map { apiType ->
@@ -28,7 +30,7 @@ class SettingRepositoryImpl @Inject constructor(
             ApiType.GROQ -> settingDataSource.getAPIUrl(apiType) ?: ModelConstants.GROQ_API_URL
             ApiType.OLLAMA -> settingDataSource.getAPIUrl(apiType) ?: ""
         }
-        val token = settingDataSource.getToken(apiType)
+        val token = resolveLegacyToken(apiType)
         val model = settingDataSource.getModel(apiType)
         val temperature = settingDataSource.getTemperature(apiType)
         val topP = settingDataSource.getTopP(apiType)
@@ -52,7 +54,9 @@ class SettingRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun fetchPlatformV2s(): List<PlatformV2> = platformV2Dao.getPlatforms()
+    override suspend fun fetchPlatformV2s(): List<PlatformV2> = platformV2Dao.getPlatforms().map { platform ->
+        resolvePlatformToken(platform)
+    }
 
     override suspend fun fetchThemes(): ThemeSetting = ThemeSetting(
         dynamicTheme = settingDataSource.getDynamicTheme() ?: DynamicTheme.OFF,
@@ -61,12 +65,12 @@ class SettingRepositoryImpl @Inject constructor(
 
     override suspend fun migrateToPlatformV2() {
         val leftOverPlatformV2s = fetchPlatformV2s()
-        leftOverPlatformV2s.forEach { platformV2Dao.deletePlatform(it) }
+        leftOverPlatformV2s.forEach { deletePlatformV2(it) }
 
         val platforms = fetchPlatforms()
 
         platforms.forEach { platform ->
-            platformV2Dao.addPlatform(
+            addPlatformV2(
                 PlatformV2(
                     name = when (platform.name) {
                         ApiType.OPENAI -> "OpenAI"
@@ -96,12 +100,45 @@ class SettingRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun migrateSecrets(): List<SecretMigrationError> = buildList {
+        platformV2Dao.getPlatforms().forEach { platform ->
+            val plaintext = platform.token ?: return@forEach
+            val source = "profile:${platform.uid}"
+            try {
+                val secretRef = platform.secretRef ?: migratedProfileSecretRef(platform)
+                storeVerified(secretRef, plaintext)
+                platformV2Dao.editPlatform(platform.copy(token = null, secretRef = secretRef))
+            } catch (error: Exception) {
+                add(SecretMigrationError(source, error.message ?: "Credential migration failed."))
+            }
+        }
+
+        ApiType.entries.forEach { apiType ->
+            val plaintext = settingDataSource.getToken(apiType) ?: return@forEach
+            val source = "legacy:${apiType.name}"
+            try {
+                storeVerified(legacySecretRef(apiType), plaintext)
+                settingDataSource.clearToken(apiType)
+            } catch (error: Exception) {
+                add(SecretMigrationError(source, error.message ?: "Credential migration failed."))
+            }
+        }
+    }
+
     override suspend fun updatePlatforms(platforms: List<Platform>) {
         platforms.forEach { platform ->
             settingDataSource.updateStatus(platform.name, platform.enabled)
             settingDataSource.updateAPIUrl(platform.name, platform.apiUrl)
 
-            platform.token?.let { settingDataSource.updateToken(platform.name, it) }
+            platform.token?.let { token ->
+                if (token.isBlank()) {
+                    secretVault.delete(legacySecretRef(platform.name))
+                    settingDataSource.clearToken(platform.name)
+                } else {
+                    storeVerified(legacySecretRef(platform.name), token)
+                    settingDataSource.clearToken(platform.name)
+                }
+            }
             platform.model?.let { settingDataSource.updateModel(platform.name, it) }
             platform.temperature?.let { settingDataSource.updateTemperature(platform.name, it) }
             platform.topP?.let { settingDataSource.updateTopP(platform.name, it) }
@@ -115,17 +152,78 @@ class SettingRepositoryImpl @Inject constructor(
     }
 
     override suspend fun addPlatformV2(platform: PlatformV2) {
-        platformV2Dao.addPlatform(platform)
+        platformV2Dao.addPlatform(securePlatform(platform))
     }
 
     override suspend fun updatePlatformV2(platform: PlatformV2) {
-        platformV2Dao.editPlatform(platform)
+        val previousSecretRef = platform.secretRef
+            ?: platform.id.takeIf { it > 0 }?.let { platformV2Dao.getPlatform(it)?.secretRef }
+        val securedPlatform = securePlatform(platform)
+        platformV2Dao.editPlatform(securedPlatform)
+        if (securedPlatform.secretRef == null) {
+            previousSecretRef?.let { secretVault.delete(it) }
+        }
     }
 
     override suspend fun deletePlatformV2(platform: PlatformV2) {
+        val secretRef = platform.secretRef
+            ?: platform.id.takeIf { it > 0 }?.let { platformV2Dao.getPlatform(it)?.secretRef }
         chatPlatformModelV2Dao.deleteByPlatformUid(platform.uid)
         platformV2Dao.deletePlatform(platform)
+        secretRef?.let { secretVault.delete(it) }
     }
 
-    override suspend fun getPlatformV2ById(id: Int): PlatformV2? = platformV2Dao.getPlatform(id)
+    override suspend fun getPlatformV2ById(id: Int): PlatformV2? = platformV2Dao.getPlatform(id)?.let { platform ->
+        resolvePlatformToken(platform)
+    }
+
+    private suspend fun securePlatform(platform: PlatformV2): PlatformV2 {
+        val secret = platform.token
+        if (secret == null) {
+            return platform.copy(token = null, secretRef = null)
+        }
+
+        val secretRef = platform.secretRef ?: profileSecretRef(platform.uid)
+        storeVerified(secretRef, secret)
+        return platform.copy(token = null, secretRef = secretRef)
+    }
+
+    private suspend fun resolvePlatformToken(platform: PlatformV2): PlatformV2 {
+        if (platform.token != null) return platform
+        val secretRef = platform.secretRef ?: return platform
+        return platform.copy(token = readSecret(secretRef))
+    }
+
+    private suspend fun resolveLegacyToken(apiType: ApiType): String? = settingDataSource.getToken(apiType)
+        ?: readSecret(legacySecretRef(apiType))
+
+    private suspend fun readSecret(secretRef: String): String? {
+        val bytes = secretVault.read(secretRef) ?: return null
+        return try {
+            bytes.decodeToString()
+        } finally {
+            bytes.fill(0)
+        }
+    }
+
+    private suspend fun storeVerified(secretRef: String, secret: String) {
+        val bytes = secret.encodeToByteArray()
+        try {
+            secretVault.put(secretRef, bytes)
+            val verified = secretVault.read(secretRef)
+            try {
+                check(verified != null && verified.contentEquals(bytes)) { "Credential verification failed." }
+            } finally {
+                verified?.fill(0)
+            }
+        } finally {
+            bytes.fill(0)
+        }
+    }
+
+    private fun profileSecretRef(uid: String): String = "profile_$uid"
+
+    private fun migratedProfileSecretRef(platform: PlatformV2): String = platform.id.takeIf { it > 0 }?.let { "room_profile_$it" } ?: profileSecretRef(platform.uid)
+
+    private fun legacySecretRef(apiType: ApiType): String = "legacy_${apiType.name.lowercase()}"
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/SettingRepositoryImpl.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/SettingRepositoryImpl.kt
@@ -160,7 +160,7 @@ class SettingRepositoryImpl @Inject constructor(
             ?: platform.id.takeIf { it > 0 }?.let { platformV2Dao.getPlatform(it)?.secretRef }
         val securedPlatform = securePlatform(platform)
         platformV2Dao.editPlatform(securedPlatform)
-        if (securedPlatform.secretRef == null) {
+        if (previousSecretRef != securedPlatform.secretRef) {
             previousSecretRef?.let { secretVault.delete(it) }
         }
     }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/security/SecretVault.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/security/SecretVault.kt
@@ -2,6 +2,7 @@ package dev.chungjungsoo.gptmobile.data.security
 
 import android.content.Context
 import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyPermanentlyInvalidatedException
 import android.security.keystore.KeyProperties
 import android.util.AtomicFile
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -85,7 +86,16 @@ class AndroidSecretVault private constructor(
                     val (iv, ciphertext) = decodeRecord(record)
                     try {
                         val cipher = Cipher.getInstance(CIPHER_TRANSFORMATION)
-                        cipher.init(Cipher.DECRYPT_MODE, getOrCreateKey(), GCMParameterSpec(GCM_TAG_BITS, iv))
+                        val key = getExistingKey() ?: run {
+                            atomicFile.delete()
+                            return@withLock null
+                        }
+                        try {
+                            cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
+                        } catch (_: KeyPermanentlyInvalidatedException) {
+                            atomicFile.delete()
+                            return@withLock null
+                        }
                         cipher.bindTo(secretRef)
                         cipher.doFinal(ciphertext).also { plaintext ->
                             if (plaintext.size > MAX_SECRET_BYTES) {
@@ -131,6 +141,10 @@ class AndroidSecretVault private constructor(
             generateKey()
         }
     }
+
+    private fun getExistingKey(): SecretKey? = KeyStore.getInstance(KEYSTORE_PROVIDER)
+        .apply { load(null) }
+        .getKey(keyAlias, null) as? SecretKey
 
     private fun writeRecord(secretRef: String, iv: ByteArray, ciphertext: ByteArray) {
         if (iv.size !in MIN_IV_BYTES..MAX_IV_BYTES || ciphertext.size !in MIN_CIPHERTEXT_BYTES..MAX_CIPHERTEXT_BYTES) {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/security/SecretVault.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/security/SecretVault.kt
@@ -1,0 +1,217 @@
+package dev.chungjungsoo.gptmobile.data.security
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.AtomicFile
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import java.io.FileNotFoundException
+import java.nio.ByteBuffer
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+interface SecretVault {
+    suspend fun put(secretRef: String, secret: ByteArray)
+    suspend fun read(secretRef: String): ByteArray?
+    suspend fun delete(secretRef: String)
+}
+
+class SecretVaultException(message: String, cause: Throwable? = null) : Exception(message, cause)
+
+class AndroidSecretVault private constructor(
+    private val directory: File,
+    private val keyAlias: String
+) : SecretVault {
+    @Inject
+    constructor(@ApplicationContext context: Context) : this(
+        directory = File(context.noBackupFilesDir, DEFAULT_DIRECTORY_NAME),
+        keyAlias = DEFAULT_KEY_ALIAS
+    )
+
+    internal constructor(context: Context, keyAlias: String, directoryName: String) : this(
+        directory = File(context.noBackupFilesDir, directoryName),
+        keyAlias = keyAlias
+    )
+
+    private val mutex = Mutex()
+
+    override suspend fun put(secretRef: String, secret: ByteArray) = withContext(Dispatchers.IO) {
+        requireValidReference(secretRef)
+        require(secret.size <= MAX_SECRET_BYTES) { "Secret exceeds the vault size limit." }
+
+        mutex.withLock {
+            try {
+                val cipher = Cipher.getInstance(CIPHER_TRANSFORMATION)
+                cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey())
+                cipher.bindTo(secretRef)
+                val ciphertext = cipher.doFinal(secret)
+                val iv = cipher.iv
+                try {
+                    writeRecord(secretRef, iv, ciphertext)
+                } finally {
+                    iv.fill(0)
+                    ciphertext.fill(0)
+                }
+            } catch (error: SecretVaultException) {
+                throw error
+            } catch (error: Exception) {
+                throw SecretVaultException("Unable to store the credential.", error)
+            }
+        }
+    }
+
+    override suspend fun read(secretRef: String): ByteArray? = withContext(Dispatchers.IO) {
+        requireValidReference(secretRef)
+
+        mutex.withLock {
+            val atomicFile = AtomicFile(recordFile(secretRef))
+
+            try {
+                val record = try {
+                    atomicFile.openRead().use { input -> input.readBytes() }
+                } catch (_: FileNotFoundException) {
+                    return@withLock null
+                }
+                try {
+                    val (iv, ciphertext) = decodeRecord(record)
+                    try {
+                        val cipher = Cipher.getInstance(CIPHER_TRANSFORMATION)
+                        cipher.init(Cipher.DECRYPT_MODE, getOrCreateKey(), GCMParameterSpec(GCM_TAG_BITS, iv))
+                        cipher.bindTo(secretRef)
+                        cipher.doFinal(ciphertext).also { plaintext ->
+                            if (plaintext.size > MAX_SECRET_BYTES) {
+                                plaintext.fill(0)
+                                throw SecretVaultException("Credential record is invalid.")
+                            }
+                        }
+                    } finally {
+                        iv.fill(0)
+                        ciphertext.fill(0)
+                    }
+                } finally {
+                    record.fill(0)
+                }
+            } catch (error: SecretVaultException) {
+                throw error
+            } catch (error: Exception) {
+                throw SecretVaultException("Unable to read the credential.", error)
+            }
+        }
+    }
+
+    override suspend fun delete(secretRef: String) = withContext(Dispatchers.IO) {
+        requireValidReference(secretRef)
+        mutex.withLock { AtomicFile(recordFile(secretRef)).delete() }
+    }
+
+    private fun getOrCreateKey(): SecretKey {
+        val keyStore = KeyStore.getInstance(KEYSTORE_PROVIDER).apply { load(null) }
+        (keyStore.getKey(keyAlias, null) as? SecretKey)?.let { return it }
+
+        return KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE_PROVIDER).run {
+            init(
+                KeyGenParameterSpec.Builder(
+                    keyAlias,
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+                )
+                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .setRandomizedEncryptionRequired(true)
+                    .build()
+            )
+            generateKey()
+        }
+    }
+
+    private fun writeRecord(secretRef: String, iv: ByteArray, ciphertext: ByteArray) {
+        if (iv.size !in MIN_IV_BYTES..MAX_IV_BYTES || ciphertext.size !in MIN_CIPHERTEXT_BYTES..MAX_CIPHERTEXT_BYTES) {
+            throw SecretVaultException("Credential record is invalid.")
+        }
+
+        val record = ByteBuffer.allocate(HEADER_BYTES + iv.size + ciphertext.size)
+            .put(MAGIC)
+            .put(RECORD_VERSION)
+            .put(iv.size.toByte())
+            .putInt(ciphertext.size)
+            .put(iv)
+            .put(ciphertext)
+            .array()
+        val atomicFile = AtomicFile(recordFile(secretRef))
+        directory.mkdirs()
+        val output = atomicFile.startWrite()
+        try {
+            output.write(record)
+            atomicFile.finishWrite(output)
+        } catch (error: Exception) {
+            atomicFile.failWrite(output)
+            throw error
+        } finally {
+            record.fill(0)
+        }
+    }
+
+    private fun decodeRecord(record: ByteArray): Pair<ByteArray, ByteArray> {
+        if (record.size !in MIN_RECORD_BYTES..MAX_RECORD_BYTES) {
+            throw SecretVaultException("Credential record is invalid.")
+        }
+        val buffer = ByteBuffer.wrap(record)
+        val magic = ByteArray(MAGIC.size).also(buffer::get)
+        if (!magic.contentEquals(MAGIC) || buffer.get() != RECORD_VERSION) {
+            throw SecretVaultException("Credential record is invalid.")
+        }
+        val ivSize = buffer.get().toInt() and 0xff
+        val ciphertextSize = buffer.int
+        if (ivSize !in MIN_IV_BYTES..MAX_IV_BYTES ||
+            ciphertextSize !in MIN_CIPHERTEXT_BYTES..MAX_CIPHERTEXT_BYTES ||
+            buffer.remaining() != ivSize + ciphertextSize
+        ) {
+            throw SecretVaultException("Credential record is invalid.")
+        }
+        val iv = ByteArray(ivSize).also(buffer::get)
+        val ciphertext = ByteArray(ciphertextSize).also(buffer::get)
+        return iv to ciphertext
+    }
+
+    private fun recordFile(secretRef: String): File = File(directory, "$secretRef.vault")
+
+    private fun Cipher.bindTo(secretRef: String) {
+        val reference = secretRef.encodeToByteArray()
+        try {
+            updateAAD(reference)
+        } finally {
+            reference.fill(0)
+        }
+    }
+
+    private fun requireValidReference(secretRef: String) {
+        require(SECRET_REF_PATTERN.matches(secretRef)) { "Invalid credential reference." }
+    }
+
+    companion object {
+        internal const val MAX_SECRET_BYTES = 64 * 1024
+        private const val DEFAULT_DIRECTORY_NAME = "secret-vault"
+        private const val DEFAULT_KEY_ALIAS = "gpt-mobile-secret-vault-v1"
+        private const val KEYSTORE_PROVIDER = "AndroidKeyStore"
+        private const val CIPHER_TRANSFORMATION = "AES/GCM/NoPadding"
+        private const val GCM_TAG_BITS = 128
+        private const val MIN_IV_BYTES = 12
+        private const val MAX_IV_BYTES = 32
+        private const val MIN_CIPHERTEXT_BYTES = GCM_TAG_BITS / 8
+        private const val MAX_CIPHERTEXT_BYTES = MAX_SECRET_BYTES + GCM_TAG_BITS / 8
+        private const val HEADER_BYTES = 10
+        private const val MIN_RECORD_BYTES = HEADER_BYTES + MIN_IV_BYTES + MIN_CIPHERTEXT_BYTES
+        private const val MAX_RECORD_BYTES = HEADER_BYTES + MAX_IV_BYTES + MAX_CIPHERTEXT_BYTES
+        private const val RECORD_VERSION: Byte = 1
+        private val MAGIC = byteArrayOf(0x47, 0x50, 0x54, 0x56)
+        private val SECRET_REF_PATTERN = Regex("[A-Za-z0-9_-]{1,128}")
+    }
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/di/ChatRepositoryModule.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/di/ChatRepositoryModule.kt
@@ -7,6 +7,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dev.chungjungsoo.gptmobile.data.context.ContextBuilder
+import dev.chungjungsoo.gptmobile.data.database.dao.AgentPersistenceDao
+import dev.chungjungsoo.gptmobile.data.database.dao.AgentRunDao
 import dev.chungjungsoo.gptmobile.data.database.dao.ChatPlatformModelV2Dao
 import dev.chungjungsoo.gptmobile.data.database.dao.ChatRoomDao
 import dev.chungjungsoo.gptmobile.data.database.dao.ChatRoomV2Dao
@@ -34,6 +36,8 @@ object ChatRepositoryModule {
         chatRoomV2Dao: ChatRoomV2Dao,
         messageV2Dao: MessageV2Dao,
         chatPlatformModelV2Dao: ChatPlatformModelV2Dao,
+        agentPersistenceDao: AgentPersistenceDao,
+        agentRunDao: AgentRunDao,
         settingRepository: SettingRepository,
         openAIAPI: OpenAIAPI,
         groqAPI: GroqAPI,
@@ -48,6 +52,8 @@ object ChatRepositoryModule {
         chatRoomV2Dao,
         messageV2Dao,
         chatPlatformModelV2Dao,
+        agentPersistenceDao,
+        agentRunDao,
         settingRepository,
         openAIAPI,
         groqAPI,

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/di/DatabaseModule.kt
@@ -71,5 +71,5 @@ object DatabaseModule {
         ChatDatabaseV2Migrations.MIGRATION_4_5,
         ChatDatabaseV2Migrations.MIGRATION_5_6,
         ChatDatabaseV2Migrations.MIGRATION_6_7
-    ).build()
+    ).addCallback(ChatDatabaseV2Migrations.AGENT_TOOL_BINDING_CALLBACK).build()
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/di/DatabaseModule.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/di/DatabaseModule.kt
@@ -10,6 +10,8 @@ import dagger.hilt.components.SingletonComponent
 import dev.chungjungsoo.gptmobile.data.database.ChatDatabase
 import dev.chungjungsoo.gptmobile.data.database.ChatDatabaseV2
 import dev.chungjungsoo.gptmobile.data.database.ChatDatabaseV2Migrations
+import dev.chungjungsoo.gptmobile.data.database.dao.AgentPersistenceDao
+import dev.chungjungsoo.gptmobile.data.database.dao.AgentRunDao
 import dev.chungjungsoo.gptmobile.data.database.dao.ChatPlatformModelV2Dao
 import dev.chungjungsoo.gptmobile.data.database.dao.ChatRoomDao
 import dev.chungjungsoo.gptmobile.data.database.dao.ChatRoomV2Dao
@@ -23,6 +25,12 @@ import javax.inject.Singleton
 object DatabaseModule {
     private const val DB_NAME = "chat"
     private const val DB_NAME_V2 = "chat_v2"
+
+    @Provides
+    fun provideAgentRunDao(chatDatabaseV2: ChatDatabaseV2): AgentRunDao = chatDatabaseV2.agentRunDao()
+
+    @Provides
+    fun provideAgentPersistenceDao(chatDatabaseV2: ChatDatabaseV2): AgentPersistenceDao = chatDatabaseV2.agentPersistenceDao()
 
     @Provides
     fun provideChatPlatformModelV2Dao(chatDatabaseV2: ChatDatabaseV2): ChatPlatformModelV2Dao = chatDatabaseV2.chatPlatformModelDao()
@@ -61,6 +69,7 @@ object DatabaseModule {
         ChatDatabaseV2Migrations.MIGRATION_2_3,
         ChatDatabaseV2Migrations.MIGRATION_3_4,
         ChatDatabaseV2Migrations.MIGRATION_4_5,
-        ChatDatabaseV2Migrations.MIGRATION_5_6
+        ChatDatabaseV2Migrations.MIGRATION_5_6,
+        ChatDatabaseV2Migrations.MIGRATION_6_7
     ).build()
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/di/SettingRepositoryModule.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/di/SettingRepositoryModule.kt
@@ -9,6 +9,8 @@ import dev.chungjungsoo.gptmobile.data.database.dao.PlatformV2Dao
 import dev.chungjungsoo.gptmobile.data.datastore.SettingDataSource
 import dev.chungjungsoo.gptmobile.data.repository.SettingRepository
 import dev.chungjungsoo.gptmobile.data.repository.SettingRepositoryImpl
+import dev.chungjungsoo.gptmobile.data.security.AndroidSecretVault
+import dev.chungjungsoo.gptmobile.data.security.SecretVault
 import javax.inject.Singleton
 
 @Module
@@ -17,9 +19,14 @@ object SettingRepositoryModule {
 
     @Provides
     @Singleton
+    fun provideSecretVault(androidSecretVault: AndroidSecretVault): SecretVault = androidSecretVault
+
+    @Provides
+    @Singleton
     fun provideSettingRepository(
         settingDataSource: SettingDataSource,
         platformV2Dao: PlatformV2Dao,
-        chatPlatformModelV2Dao: ChatPlatformModelV2Dao
-    ): SettingRepository = SettingRepositoryImpl(settingDataSource, platformV2Dao, chatPlatformModelV2Dao)
+        chatPlatformModelV2Dao: ChatPlatformModelV2Dao,
+        secretVault: SecretVault
+    ): SettingRepository = SettingRepositoryImpl(settingDataSource, platformV2Dao, chatPlatformModelV2Dao, secretVault)
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileApp.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileApp.kt
@@ -2,9 +2,19 @@ package dev.chungjungsoo.gptmobile.presentation
 
 import android.app.Application
 import android.content.Context
+import android.widget.Toast
 import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.chungjungsoo.gptmobile.R
+import dev.chungjungsoo.gptmobile.data.database.dao.AgentRunDao
+import dev.chungjungsoo.gptmobile.data.repository.SecretMigrationError
+import dev.chungjungsoo.gptmobile.data.repository.SettingRepository
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @HiltAndroidApp
 class GPTMobileApp : Application() {
@@ -12,4 +22,37 @@ class GPTMobileApp : Application() {
     @Inject
     @ApplicationContext
     lateinit var context: Context
+
+    @Inject
+    lateinit var agentRunDao: AgentRunDao
+
+    @Inject
+    lateinit var settingRepository: SettingRepository
+
+    @Volatile
+    var secretMigrationErrors: List<SecretMigrationError> = emptyList()
+        private set
+
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onCreate() {
+        super.onCreate()
+        applicationScope.launch {
+            secretMigrationErrors = try {
+                settingRepository.migrateSecrets()
+            } catch (error: Exception) {
+                listOf(SecretMigrationError("startup", error.message ?: "Credential migration failed."))
+            }
+            if (secretMigrationErrors.isNotEmpty()) {
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(
+                        this@GPTMobileApp,
+                        R.string.credential_migration_warning,
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+            }
+            agentRunDao.interruptActiveRuns(System.currentTimeMillis() / 1000)
+        }
+    }
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileApp.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileApp.kt
@@ -2,10 +2,12 @@ package dev.chungjungsoo.gptmobile.presentation
 
 import android.app.Application
 import android.content.Context
+import android.util.Log
 import android.widget.Toast
 import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.chungjungsoo.gptmobile.R
+import dev.chungjungsoo.gptmobile.data.backup.SanitizedChatBackup
 import dev.chungjungsoo.gptmobile.data.database.dao.AgentRunDao
 import dev.chungjungsoo.gptmobile.data.repository.SecretMigrationError
 import dev.chungjungsoo.gptmobile.data.repository.SettingRepository
@@ -36,7 +38,15 @@ class GPTMobileApp : Application() {
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onCreate() {
+        SanitizedChatBackup.restoreIfPresent(this)
         super.onCreate()
+        applicationScope.launch {
+            runCatching {
+                agentRunDao.interruptActiveRuns(System.currentTimeMillis() / 1000)
+            }.onFailure { error ->
+                Log.e(TAG, "Unable to mark active agent runs as interrupted.", error)
+            }
+        }
         applicationScope.launch {
             secretMigrationErrors = try {
                 settingRepository.migrateSecrets()
@@ -52,7 +62,10 @@ class GPTMobileApp : Application() {
                     ).show()
                 }
             }
-            agentRunDao.interruptActiveRuns(System.currentTimeMillis() / 1000)
         }
+    }
+
+    private companion object {
+        const val TAG = "GPTMobileApp"
     }
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileApp.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileApp.kt
@@ -54,12 +54,16 @@ class GPTMobileApp : Application() {
                 listOf(SecretMigrationError("startup", error.message ?: "Credential migration failed."))
             }
             if (secretMigrationErrors.isNotEmpty()) {
-                withContext(Dispatchers.Main) {
-                    Toast.makeText(
-                        this@GPTMobileApp,
-                        R.string.credential_migration_warning,
-                        Toast.LENGTH_LONG
-                    ).show()
+                runCatching {
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(
+                            this@GPTMobileApp,
+                            R.string.credential_migration_warning,
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
+                }.onFailure { error ->
+                    Log.e(TAG, "Unable to show credential migration warning.", error)
                 }
             }
         }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModel.kt
@@ -10,8 +10,12 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.chungjungsoo.gptmobile.data.database.entity.ACTIVE_REVISION_LATEST
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRunDraft
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRunStatus
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoomV2
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
+import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentRetryRequest
+import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentTurnRequest
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
 import dev.chungjungsoo.gptmobile.data.database.entity.effectiveContent
 import dev.chungjungsoo.gptmobile.data.database.entity.effectiveThoughts
@@ -21,12 +25,17 @@ import dev.chungjungsoo.gptmobile.data.database.entity.snapshotLatestAssistantRe
 import dev.chungjungsoo.gptmobile.data.repository.AttachmentUploadCoordinator
 import dev.chungjungsoo.gptmobile.data.repository.ChatRepository
 import dev.chungjungsoo.gptmobile.data.repository.SettingRepository
+import dev.chungjungsoo.gptmobile.util.ApiStateFlowOutcome
 import dev.chungjungsoo.gptmobile.util.AttachmentPayloadCache
 import dev.chungjungsoo.gptmobile.util.FileUtils
+import dev.chungjungsoo.gptmobile.util.buildAssistantErrorContent
 import dev.chungjungsoo.gptmobile.util.getPlatformName
 import dev.chungjungsoo.gptmobile.util.handleStates
+import java.util.UUID
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -251,41 +260,48 @@ class ChatViewModel @Inject constructor(
     fun retryChat(turnIndex: Int, platformIndex: Int) {
         if (turnIndex !in _groupedMessages.value.assistantMessages.indices) return
         if (platformIndex >= enabledPlatformsInChat.size || platformIndex < 0) return
-        val platform = _enabledPlatformsInApp.value.firstOrNull { it.uid == enabledPlatformsInChat[platformIndex] } ?: return
+        val platform = _platformsInApp.value.firstOrNull { it.uid == enabledPlatformsInChat[platformIndex] } ?: return
         val platformWithChatModel = resolvePlatformModel(platform)
-        val revisionToAppendOnSuccess = _groupedMessages.value.assistantMessages
+        val currentAssistantMessage = _groupedMessages.value.assistantMessages
             .getOrNull(turnIndex)
             ?.getOrNull(platformIndex)
-            ?.snapshotLatestAssistantRevision(currentTimeStamp)
+            ?: return
+        val userMessage = _groupedMessages.value.userMessages.getOrNull(turnIndex) ?: return
+        val runId = UUID.randomUUID().toString()
         _loadingStates.update { it.toMutableList().apply { this[platformIndex] = LoadingState.Loading } }
-        _groupedMessages.update {
-            updateAssistantSlot(
-                groupedMessages = it,
-                turnIndex = turnIndex,
-                platformIndex = platformIndex
-            ) { currentMessage ->
-                createRetryAssistantMessage(
-                    currentMessage = currentMessage,
-                    chatId = chatRoomId,
-                    platformUid = platformWithChatModel.uid
-                )
-            }
-        }
 
         viewModelScope.launch {
-            val retryContext = groupedMessagesThroughTurn(_groupedMessages.value, turnIndex)
-            chatRepository.completeChat(
-                retryContext.userMessages,
-                retryContext.assistantMessages,
-                platformWithChatModel
-            ).handleStates(
-                messageFlow = _groupedMessages,
-                turnIndex = turnIndex,
-                platformIdx = platformIndex,
-                onLoadingComplete = {
-                    _loadingStates.update { it.toMutableList().apply { this[platformIndex] = LoadingState.Idle } }
+            persistBeforeProvider(
+                persist = {
+                    chatRepository.persistAgentRetry(
+                        PersistAgentRetryRequest(
+                            userMessage = userMessage,
+                            assistantMessage = currentAssistantMessage,
+                            run = AgentRunDraft(
+                                runId = runId,
+                                profileUid = platformWithChatModel.uid,
+                                providerSnapshot = platformWithChatModel.compatibleType.name,
+                                modelSnapshot = platformWithChatModel.model,
+                                createdAt = currentTimeStamp
+                            )
+                        )
+                    )
                 },
-                revisionToAppendOnSuccess = revisionToAppendOnSuccess
+                startProvider = { persisted ->
+                    _groupedMessages.update { groupedMessages ->
+                        updateAssistantSlot(groupedMessages, turnIndex, platformIndex) { persisted.assistantMessage }
+                    }
+                    launchProviderRun(
+                        runId = runId,
+                        turnIndex = turnIndex,
+                        platformIndex = platformIndex,
+                        platform = platformWithChatModel,
+                        contextMessages = groupedMessagesThroughTurn(_groupedMessages.value, turnIndex)
+                    )
+                },
+                onFailure = { error ->
+                    showPersistenceFailure(turnIndex, listOf(platformIndex), error)
+                }
             )
         }
     }
@@ -415,7 +431,7 @@ class ChatViewModel @Inject constructor(
         }
 
         // Start new conversation from the edited question
-        completeChat()
+        completeChat(persistSnapshotFirst = true)
         return true
     }
 
@@ -522,28 +538,197 @@ class ChatViewModel @Inject constructor(
         return Pair(fileName, chatHistoryMarkdown)
     }
 
-    private fun completeChat() {
+    private fun completeChat(persistSnapshotFirst: Boolean = false) {
         // Update all the platform loading states to Loading
         _loadingStates.update { List(enabledPlatformsInChat.size) { LoadingState.Loading } }
         val turnIndex = _groupedMessages.value.assistantMessages.lastIndex
 
-        // Send chat completion requests
-        enabledPlatformsInChat.forEachIndexed { idx, platformUid ->
-            val platform = _enabledPlatformsInApp.value.firstOrNull { it.uid == platformUid } ?: return@forEachIndexed
-            val platformWithChatModel = resolvePlatformModel(platform)
-            viewModelScope.launch {
-                chatRepository.completeChat(
-                    _groupedMessages.value.userMessages,
-                    _groupedMessages.value.assistantMessages,
-                    platformWithChatModel
+        viewModelScope.launch {
+            val platforms = resolveSelectedPlatforms(enabledPlatformsInChat, _platformsInApp.value)
+                .map { IndexedValue(it.index, resolvePlatformModel(it.value)) }
+            val unavailableIndexes = enabledPlatformsInChat.indices - platforms.mapTo(mutableSetOf()) { it.index }
+            _loadingStates.update { states ->
+                states.toMutableList().apply {
+                    unavailableIndexes.forEach { this[it] = LoadingState.Idle }
+                }
+            }
+            if (platforms.isEmpty()) {
+                _loadingStates.update { List(enabledPlatformsInChat.size) { LoadingState.Idle } }
+                return@launch
+            }
+            val timestamp = currentTimeStamp
+            val userMessage = _groupedMessages.value.userMessages.getOrNull(turnIndex)
+            if (userMessage == null) {
+                _loadingStates.update { List(enabledPlatformsInChat.size) { LoadingState.Idle } }
+                return@launch
+            }
+            val runs = platforms.map { (_, platform) ->
+                AgentRunDraft(
+                    runId = UUID.randomUUID().toString(),
+                    profileUid = platform.uid,
+                    providerSnapshot = platform.compatibleType.name,
+                    modelSnapshot = platform.model,
+                    createdAt = timestamp
+                )
+            }
+            val chatRoom = _chatRoom.value.copy(
+                title = if (_chatRoom.value.id == 0) {
+                    userMessage.content.replace('\n', ' ').take(50)
+                } else {
+                    _chatRoom.value.title
+                },
+                updatedAt = timestamp
+            )
+            persistBeforeProvider(
+                persist = {
+                    if (persistSnapshotFirst && _chatRoom.value.id > 0) {
+                        chatRepository.saveChat(
+                            chatRoom = _chatRoom.value,
+                            messages = persistableMessages(_groupedMessages.value),
+                            chatPlatformModels = _chatPlatformModels.value
+                        )
+                    }
+                    chatRepository.persistAgentTurn(
+                        PersistAgentTurnRequest(
+                            chatRoom = chatRoom,
+                            userMessage = userMessage,
+                            runs = runs,
+                            chatPlatformModels = _chatPlatformModels.value.filterKeys { it in chatRoom.enabledPlatform }
+                        )
+                    )
+                },
+                startProvider = { persisted ->
+                    _chatRoom.update { persisted.chatRoom }
+                    _groupedMessages.update { groupedMessages ->
+                        groupedMessages.copy(
+                            userMessages = groupedMessages.userMessages.toMutableList().apply {
+                                this[turnIndex] = persisted.userMessage
+                            },
+                            assistantMessages = groupedMessages.assistantMessages.toMutableList().apply {
+                                this[turnIndex] = mergePersistedAssistantRow(
+                                    currentRow = this[turnIndex],
+                                    selectedProfileUids = enabledPlatformsInChat,
+                                    persistedMessages = persisted.assistantMessages,
+                                    chatId = persisted.chatRoom.id
+                                )
+                            }
+                        )
+                    }
+                    val contextMessages = _groupedMessages.value
+                    platforms.forEachIndexed { runIndex, (platformIndex, platform) ->
+                        launchProviderRun(
+                            runId = runs[runIndex].runId,
+                            turnIndex = turnIndex,
+                            platformIndex = platformIndex,
+                            platform = platform,
+                            contextMessages = contextMessages
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    showPersistenceFailure(turnIndex, platforms.map { it.index }, error)
+                }
+            )
+        }
+    }
+
+    private fun launchProviderRun(
+        runId: String,
+        turnIndex: Int,
+        platformIndex: Int,
+        platform: PlatformV2,
+        contextMessages: GroupedMessages
+    ) {
+        viewModelScope.launch {
+            val startedAt = currentTimeStamp
+            try {
+                chatRepository.updateAgentRunStatus(
+                    runId,
+                    AgentRunStatus.RUNNING,
+                    startedAt,
+                    null,
+                    null
+                )
+                val outcome = chatRepository.completeChat(
+                    contextMessages.userMessages,
+                    contextMessages.assistantMessages,
+                    platform
                 ).handleStates(
                     messageFlow = _groupedMessages,
                     turnIndex = turnIndex,
-                    platformIdx = idx,
-                    onLoadingComplete = {
-                        _loadingStates.update { it.toMutableList().apply { this[idx] = LoadingState.Idle } }
-                    }
+                    platformIdx = platformIndex,
+                    onLoadingComplete = {}
                 )
+                val terminal = outcome.toAgentRunTerminalUpdate()
+                chatRepository.updateAgentRunStatus(
+                    runId,
+                    terminal.status,
+                    startedAt,
+                    currentTimeStamp,
+                    terminal.error
+                )
+            } catch (error: CancellationException) {
+                withContext(NonCancellable) {
+                    runCatching {
+                        chatRepository.updateAgentRunStatus(
+                            runId,
+                            AgentRunStatus.CANCELED,
+                            startedAt,
+                            currentTimeStamp,
+                            null
+                        )
+                    }
+                    runCatching {
+                        chatRepository.saveChat(
+                            chatRoom = _chatRoom.value,
+                            messages = persistableMessages(_groupedMessages.value),
+                            chatPlatformModels = _chatPlatformModels.value
+                        )
+                    }
+                }
+                throw error
+            } catch (error: Throwable) {
+                val message = error.message ?: "Unknown provider error."
+                _groupedMessages.update { groupedMessages ->
+                    updateAssistantSlot(groupedMessages, turnIndex, platformIndex) { assistantMessage ->
+                        assistantMessage.copy(
+                            content = buildAssistantErrorContent(assistantMessage.content, message),
+                            createdAt = currentTimeStamp
+                        )
+                    }
+                }
+                chatRepository.updateAgentRunStatus(
+                    runId,
+                    AgentRunStatus.FAILED,
+                    startedAt,
+                    currentTimeStamp,
+                    message
+                )
+            } finally {
+                _loadingStates.update { states ->
+                    states.toMutableList().apply { this[platformIndex] = LoadingState.Idle }
+                }
+            }
+        }
+    }
+
+    private fun showPersistenceFailure(turnIndex: Int, platformIndexes: List<Int>, error: Throwable) {
+        val message = error.message ?: "Failed to save this turn."
+        _groupedMessages.update { groupedMessages ->
+            platformIndexes.fold(groupedMessages) { current, platformIndex ->
+                updateAssistantSlot(current, turnIndex, platformIndex) { assistantMessage ->
+                    assistantMessage.copy(
+                        content = buildAssistantErrorContent(assistantMessage.content, message),
+                        createdAt = currentTimeStamp
+                    )
+                }
+            }
+        }
+        _loadingStates.update { states ->
+            states.toMutableList().apply {
+                platformIndexes.forEach { index ->
+                    if (index in indices) this[index] = LoadingState.Idle
+                }
             }
         }
     }
@@ -934,13 +1119,68 @@ internal fun groupedMessagesThroughTurn(
     assistantMessages = groupedMessages.assistantMessages.take(turnIndex + 1)
 )
 
+internal data class AgentRunTerminalUpdate(val status: String, val error: String?)
+
+internal fun resolveSelectedPlatforms(
+    selectedProfileUids: List<String>,
+    configuredPlatforms: List<PlatformV2>
+): List<IndexedValue<PlatformV2>> {
+    val platformsByUid = configuredPlatforms.associateBy(PlatformV2::uid)
+    return selectedProfileUids.mapIndexedNotNull { index, uid ->
+        platformsByUid[uid]?.let { IndexedValue(index, it) }
+    }
+}
+
+internal suspend fun <T> persistBeforeProvider(
+    persist: suspend () -> T,
+    startProvider: suspend (T) -> Unit,
+    onFailure: suspend (Throwable) -> Unit
+) {
+    val persisted = try {
+        persist()
+    } catch (error: CancellationException) {
+        throw error
+    } catch (error: Throwable) {
+        onFailure(error)
+        return
+    }
+    startProvider(persisted)
+}
+
+internal fun mergePersistedAssistantRow(
+    currentRow: List<MessageV2>,
+    selectedProfileUids: List<String>,
+    persistedMessages: List<MessageV2>,
+    chatId: Int
+): List<MessageV2> {
+    val currentByProfile = currentRow.associateBy { it.platformType }
+    val persistedByProfile = persistedMessages.associateBy { it.platformType }
+    return selectedProfileUids.map { profileUid ->
+        persistedByProfile[profileUid]
+            ?: currentByProfile[profileUid]
+            ?: createEmptyAssistantMessage(chatId, profileUid)
+    }
+}
+
+internal fun ApiStateFlowOutcome.toAgentRunTerminalUpdate(): AgentRunTerminalUpdate = when (this) {
+    ApiStateFlowOutcome.Completed -> AgentRunTerminalUpdate(AgentRunStatus.COMPLETED, null)
+
+    is ApiStateFlowOutcome.Failed -> AgentRunTerminalUpdate(AgentRunStatus.FAILED, message)
+
+    ApiStateFlowOutcome.Incomplete -> AgentRunTerminalUpdate(
+        AgentRunStatus.FAILED,
+        "Provider stream ended without completion."
+    )
+}
+
 internal fun persistableMessages(groupedMessages: ChatViewModel.GroupedMessages): List<MessageV2> {
     val merged = groupedMessages.userMessages + groupedMessages.assistantMessages.flatten()
     return merged
         .filter {
             it.effectiveContent().isNotBlank() ||
                 it.effectiveThoughts().isNotBlank() ||
-                it.attachments.isNotEmpty()
+                it.attachments.isNotEmpty() ||
+                it.currentRunId != null
         }
         .sortedBy { it.createdAt }
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModel.kt
@@ -660,12 +660,13 @@ class ChatViewModel @Inject constructor(
                     onLoadingComplete = {}
                 )
                 val terminal = outcome.toAgentRunTerminalUpdate()
-                chatRepository.updateAgentRunStatus(
-                    runId,
-                    terminal.status,
-                    startedAt,
-                    currentTimeStamp,
-                    terminal.error
+                chatRepository.finishAgentRun(
+                    assistantMessage = _groupedMessages.value.assistantMessages[turnIndex][platformIndex],
+                    runId = runId,
+                    status = terminal.status,
+                    startedAt = startedAt,
+                    completedAt = currentTimeStamp,
+                    terminalError = terminal.error
                 )
             } catch (error: CancellationException) {
                 withContext(NonCancellable) {
@@ -697,13 +698,16 @@ class ChatViewModel @Inject constructor(
                         )
                     }
                 }
-                chatRepository.updateAgentRunStatus(
-                    runId,
-                    AgentRunStatus.FAILED,
-                    startedAt,
-                    currentTimeStamp,
-                    message
-                )
+                runCatching {
+                    chatRepository.finishAgentRun(
+                        assistantMessage = _groupedMessages.value.assistantMessages[turnIndex][platformIndex],
+                        runId = runId,
+                        status = AgentRunStatus.FAILED,
+                        startedAt = startedAt,
+                        completedAt = currentTimeStamp,
+                        terminalError = message
+                    )
+                }
             } finally {
                 _loadingStates.update { states ->
                     states.toMutableList().apply { this[platformIndex] = LoadingState.Idle }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensions.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensions.kt
@@ -11,6 +11,12 @@ import kotlinx.coroutines.flow.update
 
 private const val STREAM_PUBLISH_INTERVAL_MILLIS = 50L
 
+sealed interface ApiStateFlowOutcome {
+    data object Completed : ApiStateFlowOutcome
+    data class Failed(val message: String) : ApiStateFlowOutcome
+    data object Incomplete : ApiStateFlowOutcome
+}
+
 suspend fun Flow<ApiState>.handleStates(
     messageFlow: MutableStateFlow<ChatViewModel.GroupedMessages>,
     turnIndex: Int,
@@ -19,7 +25,7 @@ suspend fun Flow<ApiState>.handleStates(
     nanoTimeProvider: () -> Long = System::nanoTime,
     currentTimeProvider: () -> Long = { System.currentTimeMillis() / 1000 },
     revisionToAppendOnSuccess: AssistantRevision? = null
-) {
+): ApiStateFlowOutcome {
     val buffer = StreamingMessageBuffer(nanoTimeProvider = nanoTimeProvider)
     var isCompletedSuccessfully = false
     var terminalError: String? = null
@@ -67,6 +73,12 @@ suspend fun Flow<ApiState>.handleStates(
             )
         }
         onLoadingComplete()
+    }
+
+    return when {
+        terminalError != null -> ApiStateFlowOutcome.Failed(terminalError)
+        isCompletedSuccessfully -> ApiStateFlowOutcome.Completed
+        else -> ApiStateFlowOutcome.Incomplete
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,7 +98,7 @@
     <string name="google_brand_text" translatable="false">Powered by Gemini</string>
     <string name="token_not_set">Token not set</string>
     <string name="token_set">Token is set as %s*****</string>
-    <string name="credential_migration_warning">Some API keys could not be secured. Reopen provider settings to recover them.</string>
+    <string name="credential_migration_warning">Some API keys could not be secured. Reopen platform settings to recover them.</string>
     <string name="not_set">Not set</string>
     <string name="close">Close</string>
     <string name="delete">Delete</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="google_brand_text" translatable="false">Powered by Gemini</string>
     <string name="token_not_set">Token not set</string>
     <string name="token_set">Token is set as %s*****</string>
+    <string name="credential_migration_warning">Some API keys could not be secured. Reopen provider settings to recover them.</string>
     <string name="not_set">Not set</string>
     <string name="close">Close</string>
     <string name="delete">Delete</string>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older that API 31
-   See https://developer.android.com/about/versions/12/backup-restore
--->
+<?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <exclude domain="file" path="datastore/token.preferences_pb" />
 </full-backup-content>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
     <exclude domain="file" path="datastore/token.preferences_pb" />
+    <exclude domain="database" path="chat_v2" />
+    <exclude domain="database" path="chat_v2-wal" />
+    <exclude domain="database" path="chat_v2-shm" />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
--->
+<?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude domain="file" path="datastore/token.preferences_pb" />
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="file" path="datastore/token.preferences_pb" />
     </device-transfer>
-    -->
 </data-extraction-rules>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -2,8 +2,14 @@
 <data-extraction-rules>
     <cloud-backup>
         <exclude domain="file" path="datastore/token.preferences_pb" />
+        <exclude domain="database" path="chat_v2" />
+        <exclude domain="database" path="chat_v2-wal" />
+        <exclude domain="database" path="chat_v2-shm" />
     </cloud-backup>
     <device-transfer>
         <exclude domain="file" path="datastore/token.preferences_pb" />
+        <exclude domain="database" path="chat_v2" />
+        <exclude domain="database" path="chat_v2-wal" />
+        <exclude domain="database" path="chat_v2-shm" />
     </device-transfer>
 </data-extraction-rules>

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2MigrationsTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/database/ChatDatabaseV2MigrationsTest.kt
@@ -7,6 +7,7 @@ import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
 import dev.chungjungsoo.gptmobile.data.model.ClientType
 import dev.chungjungsoo.gptmobile.data.model.GeminiSafetySettings
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -103,6 +104,34 @@ class ChatDatabaseV2MigrationsTest {
         val revisions = AssistantRevisionListConverter().fromString("[")
 
         assertTrue(revisions.isEmpty())
+    }
+
+    @Test
+    fun `assistant revision serialization preserves run linkage`() {
+        val converter = AssistantRevisionListConverter()
+        val encoded = converter.fromList(
+            listOf(
+                dev.chungjungsoo.gptmobile.data.database.entity.AssistantRevision(
+                    content = "Answer",
+                    thoughts = "Reasoning",
+                    createdAt = 1234L,
+                    runId = "run-123"
+                )
+            )
+        )
+
+        val decoded = converter.fromString(encoded)
+
+        assertEquals("run-123", decoded.single().runId)
+    }
+
+    @Test
+    fun `legacy assistant revision json decodes without run linkage`() {
+        val decoded = AssistantRevisionListConverter().fromString(
+            """[{"content":"Old answer","thoughts":"","createdAt":1234}]"""
+        )
+
+        assertNull(decoded.single().runId)
     }
 
     @Test

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImplTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImplTest.kt
@@ -333,6 +333,8 @@ class ChatRepositoryImplTest {
         chatRoomV2Dao = proxy(),
         messageV2Dao = proxy(),
         chatPlatformModelV2Dao = proxy(),
+        agentPersistenceDao = proxy(),
+        agentRunDao = proxy(),
         settingRepository = proxy(),
         openAIAPI = openAIAPI,
         groqAPI = groqAPI,

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/SettingRepositorySecretMigrationTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/SettingRepositorySecretMigrationTest.kt
@@ -1,0 +1,284 @@
+package dev.chungjungsoo.gptmobile.data.repository
+
+import dev.chungjungsoo.gptmobile.data.database.dao.ChatPlatformModelV2Dao
+import dev.chungjungsoo.gptmobile.data.database.dao.PlatformV2Dao
+import dev.chungjungsoo.gptmobile.data.database.entity.ChatPlatformModelV2
+import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
+import dev.chungjungsoo.gptmobile.data.datastore.SettingDataSource
+import dev.chungjungsoo.gptmobile.data.model.ApiType
+import dev.chungjungsoo.gptmobile.data.model.ClientType
+import dev.chungjungsoo.gptmobile.data.model.DynamicTheme
+import dev.chungjungsoo.gptmobile.data.model.ThemeMode
+import dev.chungjungsoo.gptmobile.data.security.SecretVault
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class SettingRepositorySecretMigrationTest {
+    @Test
+    fun `profile CRUD stores only a verified vault reference and resolves transient tokens`() = runBlocking {
+        val dao = FakePlatformV2Dao()
+        val vault = FakeSecretVault()
+        val repository = createRepository(dao, vault)
+        val platform = testPlatform(token = "profile-secret")
+
+        repository.addPlatformV2(platform)
+
+        assertEquals("profile-secret", vault.values.getValue("profile_profile-1").decodeToString())
+        assertNull(dao.platforms.single().token)
+        assertEquals("profile_profile-1", dao.platforms.single().secretRef)
+        assertEquals("profile-secret", repository.fetchPlatformV2s().single().token)
+
+        val fetched = repository.fetchPlatformV2s().single()
+        repository.updatePlatformV2(fetched.copy(name = "Renamed"))
+        assertNull(dao.platforms.single().token)
+        assertEquals("Renamed", dao.platforms.single().name)
+
+        repository.deletePlatformV2(fetched)
+        assertTrue(dao.platforms.isEmpty())
+        assertNull(vault.values["profile_profile-1"])
+    }
+
+    @Test
+    fun `resolved vault bytes are wiped after creating the transient token`() = runBlocking {
+        val dao = FakePlatformV2Dao(
+            mutableListOf(testPlatform(token = null).copy(secretRef = "profile_profile-1"))
+        )
+        val vault = FakeSecretVault().apply {
+            values["profile_profile-1"] = "profile-secret".encodeToByteArray()
+        }
+        val repository = createRepository(dao, vault)
+
+        assertEquals("profile-secret", repository.fetchPlatformV2s().single().token)
+        assertTrue(vault.lastReadBytes?.all { it == 0.toByte() } == true)
+    }
+
+    @Test
+    fun `room plaintext migration clears token only after byte verification`() = runBlocking {
+        val dao = FakePlatformV2Dao(mutableListOf(testPlatform(token = "legacy-room-secret")))
+        val vault = FakeSecretVault()
+        val repository = createRepository(dao, vault)
+
+        val errors = repository.migrateSecrets()
+
+        assertTrue(errors.isEmpty())
+        assertNull(dao.platforms.single().token)
+        assertEquals("profile_profile-1", dao.platforms.single().secretRef)
+        assertEquals("legacy-room-secret", vault.values.getValue("profile_profile-1").decodeToString())
+    }
+
+    @Test
+    fun `room plaintext migration keeps duplicate profile uid credentials distinct`() = runBlocking {
+        val dao = FakePlatformV2Dao(
+            mutableListOf(
+                testPlatform(token = "first-secret").copy(id = 1),
+                testPlatform(token = "second-secret").copy(id = 2)
+            )
+        )
+        val vault = FakeSecretVault()
+        val repository = createRepository(dao, vault)
+
+        val errors = repository.migrateSecrets()
+
+        assertTrue(errors.isEmpty())
+        assertEquals(listOf("first-secret", "second-secret"), repository.fetchPlatformV2s().map { it.token })
+        assertEquals(2, dao.platforms.mapNotNull { it.secretRef }.distinct().size)
+    }
+
+    @Test
+    fun `explicitly clearing a profile token removes its vault record and reference`() = runBlocking {
+        val dao = FakePlatformV2Dao()
+        val vault = FakeSecretVault()
+        val repository = createRepository(dao, vault)
+        repository.addPlatformV2(testPlatform(token = "profile-secret"))
+
+        repository.updatePlatformV2(repository.fetchPlatformV2s().single().copy(token = null))
+
+        assertNull(dao.platforms.single().token)
+        assertNull(dao.platforms.single().secretRef)
+        assertNull(vault.values["profile_profile-1"])
+    }
+
+    @Test
+    fun `failed profile clear keeps the existing vault credential`() = runBlocking {
+        val dao = FakePlatformV2Dao()
+        val vault = FakeSecretVault()
+        val repository = createRepository(dao, vault)
+        repository.addPlatformV2(testPlatform(token = "profile-secret"))
+        dao.failEdits = true
+
+        try {
+            repository.updatePlatformV2(repository.fetchPlatformV2s().single().copy(token = null))
+            fail("Expected the database update to fail")
+        } catch (_: IllegalStateException) {
+            // Expected.
+        }
+
+        assertEquals("profile-secret", vault.values.getValue("profile_profile-1").decodeToString())
+        assertEquals("profile_profile-1", dao.platforms.single().secretRef)
+    }
+
+    @Test
+    fun `room plaintext migration failure is recoverable and retains plaintext`() = runBlocking {
+        val original = testPlatform(token = "keep-me")
+        val dao = FakePlatformV2Dao(mutableListOf(original))
+        val vault = FakeSecretVault(readOverride = "different".encodeToByteArray())
+        val repository = createRepository(dao, vault)
+
+        val errors = repository.migrateSecrets()
+
+        assertEquals(1, errors.size)
+        assertEquals("profile:profile-1", errors.single().source)
+        assertEquals(original, dao.platforms.single())
+    }
+
+    @Test
+    fun `legacy datastore migration clears token only after verification and remains readable`() = runBlocking {
+        val dataSource = FakeSettingDataSource(mutableMapOf(ApiType.OPENAI to "legacy-datastore-secret"))
+        val vault = FakeSecretVault()
+        val repository = createRepository(FakePlatformV2Dao(), vault, dataSource)
+
+        val errors = repository.migrateSecrets()
+
+        assertTrue(errors.isEmpty())
+        assertNull(dataSource.tokens[ApiType.OPENAI])
+        assertEquals("legacy-datastore-secret", repository.fetchPlatforms().first { it.name == ApiType.OPENAI }.token)
+    }
+
+    @Test
+    fun `legacy datastore verification failure retains plaintext`() = runBlocking {
+        val dataSource = FakeSettingDataSource(mutableMapOf(ApiType.OPENAI to "keep-legacy"))
+        val vault = FakeSecretVault(readOverride = "different".encodeToByteArray())
+        val repository = createRepository(FakePlatformV2Dao(), vault, dataSource)
+
+        val errors = repository.migrateSecrets()
+
+        assertEquals(1, errors.size)
+        assertEquals("legacy:OPENAI", errors.single().source)
+        assertEquals("keep-legacy", dataSource.tokens[ApiType.OPENAI])
+    }
+
+    @Test
+    fun `legacy profile conversion deletes replaced vault credentials`() = runBlocking {
+        val oldSecretRef = "room_profile_1"
+        val dao = FakePlatformV2Dao(
+            mutableListOf(testPlatform(token = null).copy(id = 1, secretRef = oldSecretRef))
+        )
+        val vault = FakeSecretVault().apply {
+            values[oldSecretRef] = "old-secret".encodeToByteArray()
+        }
+        val repository = createRepository(dao, vault)
+
+        repository.migrateToPlatformV2()
+
+        assertNull(vault.values[oldSecretRef])
+    }
+
+    private fun createRepository(
+        dao: FakePlatformV2Dao,
+        vault: FakeSecretVault,
+        dataSource: FakeSettingDataSource = FakeSettingDataSource()
+    ) = SettingRepositoryImpl(
+        settingDataSource = dataSource,
+        platformV2Dao = dao,
+        chatPlatformModelV2Dao = FakeChatPlatformModelV2Dao(),
+        secretVault = vault
+    )
+
+    private fun testPlatform(token: String?) = PlatformV2(
+        uid = "profile-1",
+        name = "OpenAI",
+        compatibleType = ClientType.OPENAI,
+        enabled = true,
+        apiUrl = "https://api.openai.com/v1/",
+        token = token,
+        model = "gpt-5"
+    )
+}
+
+private class FakeSecretVault(
+    private val readOverride: ByteArray? = null
+) : SecretVault {
+    val values = mutableMapOf<String, ByteArray>()
+    var lastReadBytes: ByteArray? = null
+
+    override suspend fun put(secretRef: String, secret: ByteArray) {
+        values[secretRef] = secret.copyOf()
+    }
+
+    override suspend fun read(secretRef: String): ByteArray? = (readOverride ?: values[secretRef])?.copyOf()?.also {
+        lastReadBytes = it
+    }
+
+    override suspend fun delete(secretRef: String) {
+        values.remove(secretRef)
+    }
+}
+
+private class FakePlatformV2Dao(
+    val platforms: MutableList<PlatformV2> = mutableListOf()
+) : PlatformV2Dao {
+    var failEdits = false
+
+    override suspend fun getPlatforms(): List<PlatformV2> = platforms.toList()
+
+    override suspend fun getPlatform(id: Int): PlatformV2? = platforms.firstOrNull { it.id == id }
+
+    override suspend fun addPlatform(platform: PlatformV2): Long {
+        val persisted = if (platform.id == 0) platform.copy(id = (platforms.maxOfOrNull { it.id } ?: 0) + 1) else platform
+        platforms += persisted
+        return persisted.id.toLong()
+    }
+
+    override suspend fun editPlatform(platform: PlatformV2) {
+        check(!failEdits) { "Database update failed." }
+        val index = platforms.indexOfFirst { it.id == platform.id }
+        if (index >= 0) platforms[index] = platform
+    }
+
+    override suspend fun deleteBindingsByProfileUid(profileUid: String) = Unit
+
+    override suspend fun deletePlatformRow(platform: PlatformV2) {
+        platforms.removeAll { it.id == platform.id }
+    }
+}
+
+private class FakeChatPlatformModelV2Dao : ChatPlatformModelV2Dao {
+    override suspend fun getByChatId(chatId: Int): List<ChatPlatformModelV2> = emptyList()
+    override suspend fun upsertAll(vararg models: ChatPlatformModelV2) = Unit
+    override suspend fun deleteByChatId(chatId: Int) = Unit
+    override suspend fun deleteByPlatformUid(platformUid: String) = Unit
+}
+
+private class FakeSettingDataSource(
+    val tokens: MutableMap<ApiType, String> = mutableMapOf()
+) : SettingDataSource {
+    override suspend fun updateDynamicTheme(theme: DynamicTheme) = Unit
+    override suspend fun updateThemeMode(themeMode: ThemeMode) = Unit
+    override suspend fun updateStatus(apiType: ApiType, status: Boolean) = Unit
+    override suspend fun updateAPIUrl(apiType: ApiType, url: String) = Unit
+    override suspend fun updateToken(apiType: ApiType, token: String) {
+        tokens[apiType] = token
+    }
+
+    override suspend fun clearToken(apiType: ApiType) {
+        tokens.remove(apiType)
+    }
+
+    override suspend fun updateModel(apiType: ApiType, model: String) = Unit
+    override suspend fun updateTemperature(apiType: ApiType, temperature: Float) = Unit
+    override suspend fun updateTopP(apiType: ApiType, topP: Float) = Unit
+    override suspend fun updateSystemPrompt(apiType: ApiType, prompt: String) = Unit
+    override suspend fun getDynamicTheme(): DynamicTheme? = null
+    override suspend fun getThemeMode(): ThemeMode? = null
+    override suspend fun getStatus(apiType: ApiType): Boolean? = false
+    override suspend fun getAPIUrl(apiType: ApiType): String? = null
+    override suspend fun getToken(apiType: ApiType): String? = tokens[apiType]
+    override suspend fun getModel(apiType: ApiType): String? = null
+    override suspend fun getTemperature(apiType: ApiType): Float? = null
+    override suspend fun getTopP(apiType: ApiType): Float? = null
+    override suspend fun getSystemPrompt(apiType: ApiType): String? = null
+}

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/SettingRepositorySecretMigrationTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/SettingRepositorySecretMigrationTest.kt
@@ -177,6 +177,25 @@ class SettingRepositorySecretMigrationTest {
         assertNull(vault.values[oldSecretRef])
     }
 
+    @Test
+    fun `replacing a migrated profile credential deletes its old vault record`() = runBlocking {
+        val oldSecretRef = "room_profile_1"
+        val dao = FakePlatformV2Dao(
+            mutableListOf(testPlatform(token = null).copy(id = 1, secretRef = oldSecretRef))
+        )
+        val vault = FakeSecretVault().apply {
+            values[oldSecretRef] = "old-secret".encodeToByteArray()
+        }
+        val repository = createRepository(dao, vault)
+
+        repository.updatePlatformV2(
+            dao.platforms.single().copy(token = "replacement-secret", secretRef = null)
+        )
+
+        assertNull(vault.values[oldSecretRef])
+        assertEquals("replacement-secret", vault.values.getValue("profile_profile-1").decodeToString())
+    }
+
     private fun createRepository(
         dao: FakePlatformV2Dao,
         vault: FakeSecretVault,

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/SettingRepositorySecretMigrationTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/SettingRepositorySecretMigrationTest.kt
@@ -192,6 +192,8 @@ class SettingRepositorySecretMigrationTest {
             dao.platforms.single().copy(token = "replacement-secret", secretRef = null)
         )
 
+        assertNull(dao.platforms.single().token)
+        assertEquals("profile_profile-1", dao.platforms.single().secretRef)
         assertNull(vault.values[oldSecretRef])
         assertEquals("replacement-secret", vault.values.getValue("profile_profile-1").decodeToString())
     }

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModelRetryTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModelRetryTest.kt
@@ -1,19 +1,126 @@
 package dev.chungjungsoo.gptmobile.presentation.ui.chat
 
 import dev.chungjungsoo.gptmobile.data.database.entity.ACTIVE_REVISION_LATEST
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRunStatus
 import dev.chungjungsoo.gptmobile.data.database.entity.AssistantRevision
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
+import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
 import dev.chungjungsoo.gptmobile.data.database.entity.effectiveContent
 import dev.chungjungsoo.gptmobile.data.database.entity.effectiveThoughts
 import dev.chungjungsoo.gptmobile.data.database.entity.resetActiveRevision
 import dev.chungjungsoo.gptmobile.data.database.entity.selectRevision
+import dev.chungjungsoo.gptmobile.data.database.entity.snapshotLatestAssistantRevision
 import dev.chungjungsoo.gptmobile.data.model.ChatAttachment
+import dev.chungjungsoo.gptmobile.data.model.ClientType
 import dev.chungjungsoo.gptmobile.data.repository.hasSendableAssistantPayload
+import dev.chungjungsoo.gptmobile.util.ApiStateFlowOutcome
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ChatViewModelRetryTest {
+
+    @Test
+    fun `selected profiles resolve from all configured profiles without losing slot indexes`() {
+        val configured = listOf(
+            PlatformV2(
+                uid = "profile-2",
+                name = "Disabled but selected",
+                compatibleType = ClientType.OPENAI,
+                enabled = false,
+                apiUrl = "https://example.com",
+                model = "model"
+            )
+        )
+
+        val resolved = resolveSelectedPlatforms(
+            selectedProfileUids = listOf("missing-profile", "profile-2"),
+            configuredPlatforms = configured
+        )
+
+        assertEquals(listOf(1), resolved.map { it.index })
+        assertEquals(listOf("profile-2"), resolved.map { it.value.uid })
+    }
+
+    @Test
+    fun `persist before provider waits for persistence and skips provider on failure`() = runBlocking {
+        val persistenceGate = CompletableDeferred<String>()
+        var providerValue: String? = null
+        var failure: Throwable? = null
+
+        val successJob = launch {
+            persistBeforeProvider(
+                persist = { persistenceGate.await() },
+                startProvider = { providerValue = it },
+                onFailure = { failure = it }
+            )
+        }
+
+        assertFalse(successJob.isCompleted)
+        assertEquals(null, providerValue)
+        persistenceGate.complete("persisted")
+        successJob.join()
+        assertEquals("persisted", providerValue)
+        assertEquals(null, failure)
+
+        providerValue = null
+        persistBeforeProvider(
+            persist = { throw IllegalStateException("database unavailable") },
+            startProvider = { providerValue = it },
+            onFailure = { failure = it }
+        )
+
+        assertEquals(null, providerValue)
+        assertEquals("database unavailable", failure?.message)
+    }
+
+    @Test
+    fun `persisted assistant rows retain unavailable profile slots`() {
+        val currentRow = listOf(
+            MessageV2(chatId = 7, content = "Profile unavailable", platformType = "missing-profile"),
+            MessageV2(chatId = 7, content = "", platformType = "profile-2")
+        )
+        val persisted = listOf(
+            MessageV2(
+                id = 12,
+                chatId = 7,
+                content = "",
+                platformType = "profile-2",
+                currentRunId = "run-2"
+            )
+        )
+
+        val merged = mergePersistedAssistantRow(
+            currentRow = currentRow,
+            selectedProfileUids = listOf("missing-profile", "profile-2"),
+            persistedMessages = persisted,
+            chatId = 7
+        )
+
+        assertEquals(listOf("missing-profile", "profile-2"), merged.map { it.platformType })
+        assertEquals("Profile unavailable", merged[0].content)
+        assertEquals("run-2", merged[1].currentRunId)
+    }
+
+    @Test
+    fun `agent run terminal updates preserve provider failure details`() {
+        assertEquals(
+            AgentRunTerminalUpdate(AgentRunStatus.COMPLETED, null),
+            ApiStateFlowOutcome.Completed.toAgentRunTerminalUpdate()
+        )
+        assertEquals(
+            AgentRunTerminalUpdate(AgentRunStatus.FAILED, "provider failed"),
+            ApiStateFlowOutcome.Failed("provider failed").toAgentRunTerminalUpdate()
+        )
+        assertEquals(
+            AgentRunTerminalUpdate(AgentRunStatus.FAILED, "Provider stream ended without completion."),
+            ApiStateFlowOutcome.Incomplete.toAgentRunTerminalUpdate()
+        )
+    }
 
     @Test
     fun `normalizeAssistantRow pads sparse rows and preserves overflow messages`() {
@@ -95,6 +202,20 @@ class ChatViewModelRetryTest {
         assertEquals("", retryMessage.thoughts)
         assertEquals(listOf(AssistantRevision(content = "Older answer", createdAt = 100L)), retryMessage.revisions)
         assertEquals(ACTIVE_REVISION_LATEST, retryMessage.activeRevisionIndex)
+    }
+
+    @Test
+    fun `assistant revision preserves the run that produced the answer`() {
+        val assistantMessage = MessageV2(
+            chatId = 7,
+            content = "Answer",
+            platformType = "platform-1",
+            currentRunId = "run-123"
+        )
+
+        val revision = assistantMessage.snapshotLatestAssistantRevision(timestamp = 100L)
+
+        assertEquals("run-123", revision?.runId)
     }
 
     @Test
@@ -195,6 +316,30 @@ class ChatViewModelRetryTest {
         assertEquals("Question", messages[0].content)
         assertEquals("Internal reasoning", messages[1].thoughts)
         assertEquals(1, messages[2].attachments.size)
+    }
+
+    @Test
+    fun `persistable messages keep blank assistant placeholders linked to runs`() {
+        val groupedMessages = ChatViewModel.GroupedMessages(
+            userMessages = listOf(
+                MessageV2(chatId = 7, content = "Question", platformType = null, createdAt = 1L)
+            ),
+            assistantMessages = listOf(
+                listOf(
+                    MessageV2(
+                        chatId = 7,
+                        content = "",
+                        platformType = "platform-1",
+                        currentRunId = "run-123",
+                        createdAt = 2L
+                    )
+                )
+            )
+        )
+
+        val messages = persistableMessages(groupedMessages)
+
+        assertEquals(listOf(null, "run-123"), messages.map { it.currentRunId })
     }
 
     @Test

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensionsTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensionsTest.kt
@@ -34,7 +34,7 @@ class ApiStateFlowExtensionsTest {
             )
         )
 
-        flowOf(
+        val outcome = flowOf(
             ApiState.Success("Partial answer"),
             ApiState.Error("Request timed out.")
         ).handleStates(
@@ -47,6 +47,7 @@ class ApiStateFlowExtensionsTest {
         val assistantContent = messageFlow.value.assistantMessages.last().first().content
         assertTrue(assistantContent.contains("Partial answer"))
         assertTrue(assistantContent.contains("[Response stopped: Request timed out.]"))
+        assertEquals(ApiStateFlowOutcome.Failed("Request timed out."), outcome)
     }
 
     @Test
@@ -177,7 +178,7 @@ class ApiStateFlowExtensionsTest {
             )
         )
 
-        flowOf(ApiState.Done).handleStates(
+        val outcome = flowOf(ApiState.Done).handleStates(
             messageFlow = messageFlow,
             turnIndex = 0,
             platformIdx = 1,
@@ -189,6 +190,28 @@ class ApiStateFlowExtensionsTest {
         assertEquals(1234L, messageFlow.value.assistantMessages[0][1].createdAt)
         assertEquals(untouchedTimestamp, messageFlow.value.assistantMessages[1][0].createdAt)
         assertEquals(untouchedTimestamp, messageFlow.value.assistantMessages[1][1].createdAt)
+        assertEquals(ApiStateFlowOutcome.Completed, outcome)
+    }
+
+    @Test
+    fun `handleStates reports incomplete when stream ends without terminal state`() = runBlocking {
+        val messageFlow = MutableStateFlow(
+            ChatViewModel.GroupedMessages(
+                userMessages = listOf(MessageV2(content = "Hello", platformType = null)),
+                assistantMessages = listOf(
+                    listOf(MessageV2(content = "", platformType = "platform-1"))
+                )
+            )
+        )
+
+        val outcome = flowOf(ApiState.Success("Partial answer")).handleStates(
+            messageFlow = messageFlow,
+            turnIndex = 0,
+            platformIdx = 0,
+            onLoadingComplete = {}
+        )
+
+        assertEquals(ApiStateFlowOutcome.Incomplete, outcome)
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,7 @@ splashscreen = { group = "androidx.core", name = "core-splashscreen", version.re
 room = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 androidx-lifecycle-runtime-compose-android = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose-android", version.ref = "lifecycleRuntime" }
 
 [plugins]


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent agent run tracking, retries, interruptions, tool events, and chat-history duplication.
  * Added encrypted API credential storage, migration, clearing, and warnings for credentials needing attention.
  * Added sanitized chat backups that exclude plaintext credentials and support safer restoration.
  * Added support for tool connections and profile-specific tool bindings.
  * Added database migration support while preserving existing chat data.

* **Bug Fixes**
  * Improved cleanup of related tool data when platforms are deleted.
  * Added backup exclusions for stored tokens and database files.

* **Tests**
  * Expanded coverage for database migration, chat execution, backups, credential security, and streaming states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->