### PR TITLE
feat: add streamable HTTP MCP connections

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,6 +107,13 @@ dependencies {
     implementation(libs.ktor.client.okhttp)
     implementation(libs.ktor.logging)
     implementation(libs.ktor.serialization)
+    implementation(libs.mcp.kotlin.sdk.client) {
+        // The SDK bytecode targets Kotlin 2.1, but its 2.4 stdlib confuses Hilt's 2.3 metadata reader.
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
+    }
+
+    // OAuth browser flow
+    implementation(libs.androidx.browser)
 
     // License page UI
     implementation(libs.auto.license.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,17 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="oauth"
+                    android:pathPrefix="/mcp/"
+                    android:scheme="dev.chungjungsoo.gptmobile" />
+            </intent-filter>
         </activity>
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/AgentContracts.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/AgentContracts.kt
@@ -21,7 +21,8 @@ data class AgentToolDefinition(
 data class AgentToolResult(
     val callId: String,
     val content: ToolResultContent,
-    val isError: Boolean
+    val isError: Boolean,
+    val traceContent: ToolResultContent? = null
 )
 
 sealed interface ToolResultContent {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/AgentToolResolver.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/AgentToolResolver.kt
@@ -7,10 +7,13 @@ import dev.chungjungsoo.gptmobile.data.agent.ToolResultContent
 import dev.chungjungsoo.gptmobile.data.database.dao.AgentToolBindingWithConnection
 import dev.chungjungsoo.gptmobile.data.database.entity.BuiltInAgentTool
 import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnection
+import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnectionAuthType
 import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnectionType
 import dev.chungjungsoo.gptmobile.data.network.NetworkClient
 import dev.chungjungsoo.gptmobile.data.repository.ToolConnectionRepository
 import dev.chungjungsoo.gptmobile.data.security.SecretVault
+import io.modelcontextprotocol.kotlin.sdk.client.StreamableHttpError
+import io.modelcontextprotocol.kotlin.sdk.types.Tool
 import java.nio.charset.StandardCharsets
 import javax.inject.Inject
 import kotlinx.serialization.json.JsonObject
@@ -26,17 +29,42 @@ data class ResolvedAgentTool(
 class AgentToolResolver @Inject constructor(
     private val toolConnectionRepository: ToolConnectionRepository,
     private val secretVault: SecretVault,
-    private val networkClient: NetworkClient
+    private val networkClient: NetworkClient,
+    private val mcpClientManager: McpClientManager,
+    private val mcpOAuthCoordinator: McpOAuthCoordinator
 ) {
+    suspend fun discoverMcpTools(connection: ToolConnection): List<Tool> {
+        val config = mcpConfig(connection)
+        return try {
+            mcpClientManager.listTools(config)
+        } catch (error: Exception) {
+            if (connection.authType != ToolConnectionAuthType.OAUTH || !error.isUnauthorized()) throw error
+            mcpClientManager.listTools(
+                mcpConfig(
+                    connection,
+                    forceOAuthRefresh = true,
+                    rejectedAuthorizationHeader = config.authorizationHeader
+                )
+            )
+        }
+    }
+
     suspend fun resolve(profileUid: String): List<ResolvedAgentTool> {
         val resolved = mutableListOf(
             CurrentDateTool().resolved(null, null, BuiltInAgentTool.CURRENT_DATE)
         )
-        toolConnectionRepository.listBindingsWithConnections(profileUid)
+        val bindings = toolConnectionRepository.listBindingsWithConnections(profileUid)
             .sortedWith(compareBy<AgentToolBindingWithConnection> { it.binding.toolName }.thenBy { it.binding.connectionUid ?: "" }.thenBy { it.binding.bindingUid })
+        bindings
+            .filterNot { it.connection?.type == ToolConnectionType.MCP }
             .forEach { binding ->
                 resolveBinding(binding)?.let { resolved += it }
             }
+        bindings.filter { it.connection?.type == ToolConnectionType.MCP }
+            .groupBy { requireNotNull(it.connection).connectionUid }
+            .toSortedMap()
+            .values
+            .forEach { mcpBindings -> resolved += resolveMcpTools(requireNotNull(mcpBindings.first().connection), mcpBindings) }
         return resolved.distinctBy { it.modelToolName }
             .sortedBy { it.modelToolName }
     }
@@ -86,6 +114,70 @@ class AgentToolResolver @Inject constructor(
         return tool.resolved(actualConnection.connectionUid, actualConnection.name, WEB_SEARCH_TOOL)
     }
 
+    private suspend fun resolveMcpTools(
+        connection: ToolConnection,
+        bindings: List<AgentToolBindingWithConnection>
+    ): List<ResolvedAgentTool> {
+        val selectedNames = bindings.map { it.binding.toolName }.toSet()
+        val remoteTools = discoverMcpTools(connection)
+        val config = mcpConfig(connection)
+        return remoteTools
+            .filter { it.name in selectedNames }
+            .map { remoteTool ->
+                val tool = McpAgentTool(
+                    definition = mcpToolDefinition(connection.alias, remoteTool),
+                    config = config,
+                    remoteToolName = remoteTool.name,
+                    clientManager = mcpClientManager
+                )
+                ResolvedAgentTool(
+                    tool = tool,
+                    connectionUid = connection.connectionUid,
+                    connectionName = connection.name,
+                    realToolName = remoteTool.name,
+                    modelToolName = tool.definition.name
+                )
+            }
+    }
+
+    private suspend fun mcpConfig(
+        connection: ToolConnection,
+        forceOAuthRefresh: Boolean = false,
+        rejectedAuthorizationHeader: String? = null
+    ): McpConnectionConfig {
+        val authorization = when (connection.authType) {
+            ToolConnectionAuthType.NONE -> null
+
+            ToolConnectionAuthType.BEARER -> readBearerHeader(connection)
+
+            ToolConnectionAuthType.OAUTH -> mcpOAuthCoordinator.authorizationHeader(
+                connection,
+                forceOAuthRefresh,
+                rejectedAuthorizationHeader
+            )
+
+            else -> throw IllegalArgumentException("Unsupported MCP authentication type.")
+        }
+        return McpConnectionConfig(
+            connectionUid = connection.connectionUid,
+            endpointUrl = connection.endpointUrl ?: throw IllegalArgumentException("MCP endpoint is required."),
+            allowCleartext = connection.allowCleartext,
+            authorizationHeader = authorization
+        )
+    }
+
+    private suspend fun readBearerHeader(connection: ToolConnection): String {
+        val secretRef = connection.secretRef ?: throw IllegalArgumentException("MCP bearer credential is missing.")
+        val bytes = secretVault.read(secretRef) ?: throw IllegalArgumentException("MCP bearer credential is missing.")
+        return try {
+            val token = bytes.decodeToString()
+            require(token.isNotBlank()) { "MCP bearer credential is missing." }
+            "Bearer $token"
+        } finally {
+            bytes.fill(0)
+        }
+    }
+
     private fun AgentTool.resolved(
         connectionUid: String?,
         connectionName: String?,
@@ -107,6 +199,18 @@ class AgentToolResolver @Inject constructor(
         )
     }
 }
+
+private class McpAgentTool(
+    override val definition: AgentToolDefinition,
+    private val config: McpConnectionConfig,
+    private val remoteToolName: String,
+    private val clientManager: McpClientManager
+) : AgentTool {
+    override suspend fun execute(callId: String, arguments: JsonObject): AgentToolResult = mapMcpToolResult(callId, clientManager.callTool(config, remoteToolName, arguments))
+}
+
+private fun Throwable.isUnauthorized(): Boolean = generateSequence(this) { it.cause }
+    .any { error -> error is StreamableHttpError && error.code == 401 }
 
 private data class SearchProvider(
     val provider: WebSearchProvider,

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/AgentToolResolver.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/AgentToolResolver.kt
@@ -16,6 +16,7 @@ import io.modelcontextprotocol.kotlin.sdk.client.StreamableHttpError
 import io.modelcontextprotocol.kotlin.sdk.types.Tool
 import java.nio.charset.StandardCharsets
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.JsonObject
 
 data class ResolvedAgentTool(
@@ -64,7 +65,14 @@ class AgentToolResolver @Inject constructor(
             .groupBy { requireNotNull(it.connection).connectionUid }
             .toSortedMap()
             .values
-            .forEach { mcpBindings -> resolved += resolveMcpTools(requireNotNull(mcpBindings.first().connection), mcpBindings) }
+            .forEach { mcpBindings ->
+                try {
+                    resolved += resolveMcpTools(requireNotNull(mcpBindings.first().connection), mcpBindings)
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (_: Exception) {
+                }
+            }
         return resolved.distinctBy { it.modelToolName }
             .sortedBy { it.modelToolName }
     }
@@ -120,13 +128,13 @@ class AgentToolResolver @Inject constructor(
     ): List<ResolvedAgentTool> {
         val selectedNames = bindings.map { it.binding.toolName }.toSet()
         val remoteTools = discoverMcpTools(connection)
-        val config = mcpConfig(connection)
         return remoteTools
             .filter { it.name in selectedNames }
             .map { remoteTool ->
                 val tool = McpAgentTool(
                     definition = mcpToolDefinition(connection.alias, remoteTool),
-                    config = config,
+                    authType = connection.authType,
+                    config = { forceRefresh, rejectedHeader -> mcpConfig(connection, forceRefresh, rejectedHeader) },
                     remoteToolName = remoteTool.name,
                     clientManager = mcpClientManager
                 )
@@ -202,11 +210,25 @@ class AgentToolResolver @Inject constructor(
 
 private class McpAgentTool(
     override val definition: AgentToolDefinition,
-    private val config: McpConnectionConfig,
+    private val authType: String,
+    private val config: suspend (Boolean, String?) -> McpConnectionConfig,
     private val remoteToolName: String,
     private val clientManager: McpClientManager
 ) : AgentTool {
-    override suspend fun execute(callId: String, arguments: JsonObject): AgentToolResult = mapMcpToolResult(callId, clientManager.callTool(config, remoteToolName, arguments))
+    override suspend fun execute(callId: String, arguments: JsonObject): AgentToolResult {
+        val initialConfig = config(false, null)
+        val result = try {
+            clientManager.callTool(initialConfig, remoteToolName, arguments)
+        } catch (error: Exception) {
+            if (authType != ToolConnectionAuthType.OAUTH || !error.isUnauthorized()) throw error
+            clientManager.callTool(
+                config(true, initialConfig.authorizationHeader),
+                remoteToolName,
+                arguments
+            )
+        }
+        return mapMcpToolResult(callId, result)
+    }
 }
 
 private fun Throwable.isUnauthorized(): Boolean = generateSequence(this) { it.cause }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/AgentToolResolver.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/AgentToolResolver.kt
@@ -178,8 +178,9 @@ class AgentToolResolver @Inject constructor(
         val secretRef = connection.secretRef ?: throw IllegalArgumentException("MCP bearer credential is missing.")
         val bytes = secretVault.read(secretRef) ?: throw IllegalArgumentException("MCP bearer credential is missing.")
         return try {
-            val token = bytes.decodeToString()
-            require(token.isNotBlank()) { "MCP bearer credential is missing." }
+            val token = bytes.decodeToString().trim()
+            require(token.isNotEmpty()) { "MCP bearer credential is missing." }
+            require('\r' !in token && '\n' !in token) { "MCP bearer credential is invalid." }
             "Bearer $token"
         } finally {
             bytes.fill(0)
@@ -219,6 +220,8 @@ private class McpAgentTool(
         val initialConfig = config(false, null)
         val result = try {
             clientManager.callTool(initialConfig, remoteToolName, arguments)
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: Exception) {
             if (authType != ToolConnectionAuthType.OAUTH || !error.isUnauthorized()) throw error
             clientManager.callTool(

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpClientManager.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpClientManager.kt
@@ -1,0 +1,165 @@
+package dev.chungjungsoo.gptmobile.data.agent.tool
+
+import dev.chungjungsoo.gptmobile.data.network.NetworkClient
+import io.ktor.client.HttpClient
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.modelcontextprotocol.kotlin.sdk.client.Client
+import io.modelcontextprotocol.kotlin.sdk.client.StreamableHttpClientTransport
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ListToolsRequest
+import io.modelcontextprotocol.kotlin.sdk.types.PaginatedRequestParams
+import io.modelcontextprotocol.kotlin.sdk.types.Tool
+import java.net.URI
+import java.security.MessageDigest
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.serialization.json.JsonObject
+
+class McpConnectionConfig(
+    val connectionUid: String,
+    val endpointUrl: String,
+    val allowCleartext: Boolean,
+    val authorizationHeader: String? = null
+)
+
+@Singleton
+class McpClientManager internal constructor(
+    private val httpClient: HttpClient
+) {
+    @Inject
+    constructor(networkClient: NetworkClient) : this(networkClient())
+
+    private val mutex = Mutex()
+
+    // ponytail: one global lock serializes session setup only; use per-connection locks if startup contention becomes measurable.
+    private val sessions = mutableMapOf<String, Session>()
+
+    suspend fun listTools(config: McpConnectionConfig): List<Tool> = withSession(config) { client ->
+        val tools = mutableListOf<Tool>()
+        val seenCursors = mutableSetOf<String>()
+        var pageCount = 0
+        var cursor: String? = null
+        do {
+            check(++pageCount <= MAX_TOOL_PAGES) { "MCP server returned too many tool pages." }
+            val page = client.listTools(
+                request = if (cursor == null) ListToolsRequest() else ListToolsRequest(PaginatedRequestParams(cursor))
+            )
+            tools += page.tools
+            check(tools.size <= MAX_DISCOVERED_TOOLS) { "MCP server returned too many tools." }
+            cursor = page.nextCursor
+            check(cursor == null || seenCursors.add(cursor)) { "MCP server returned a repeated tools cursor." }
+        } while (cursor != null)
+        tools
+    }
+
+    suspend fun callTool(
+        config: McpConnectionConfig,
+        toolName: String,
+        arguments: JsonObject
+    ): CallToolResult = withSession(config) { client ->
+        client.callTool(toolName, arguments)
+    }
+
+    suspend fun close(connectionUid: String) {
+        val session = takeSession(connectionUid) ?: return
+        runCatching { session.client.close() }
+    }
+
+    suspend fun closeAll() {
+        mutex.lock()
+        val active = try {
+            sessions.values.toList().also { sessions.clear() }
+        } finally {
+            mutex.unlock()
+        }
+        active.forEach { session -> runCatching { session.client.close() } }
+    }
+
+    private suspend fun <T> withSession(config: McpConnectionConfig, block: suspend (Client) -> T): T {
+        val session = session(config)
+        return try {
+            block(session.client)
+        } catch (error: Exception) {
+            invalidate(config.connectionUid, session)
+            throw error
+        }
+    }
+
+    private suspend fun session(config: McpConnectionConfig): Session {
+        val key = config.validatedKey()
+        mutex.lock()
+        try {
+            sessions[config.connectionUid]?.takeIf { it.key == key }?.let { return it }
+            sessions.remove(config.connectionUid)?.let { previous -> runCatching { previous.client.close() } }
+
+            val transport = StreamableHttpClientTransport(httpClient, config.endpointUrl) {
+                config.authorizationHeader?.let { header(HttpHeaders.Authorization, it) }
+            }
+            val client = Client(Implementation(name = CLIENT_NAME, version = CLIENT_VERSION))
+            try {
+                client.connect(transport)
+            } catch (error: Exception) {
+                runCatching { client.close() }
+                throw error
+            }
+            return Session(key, client).also { sessions[config.connectionUid] = it }
+        } finally {
+            mutex.unlock()
+        }
+    }
+
+    private suspend fun invalidate(connectionUid: String, expected: Session) {
+        mutex.lock()
+        val removed = try {
+            if (sessions[connectionUid] === expected) sessions.remove(connectionUid) else null
+        } finally {
+            mutex.unlock()
+        }
+        removed?.let { runCatching { it.client.close() } }
+    }
+
+    private suspend fun takeSession(connectionUid: String): Session? {
+        mutex.lock()
+        return try {
+            sessions.remove(connectionUid)
+        } finally {
+            mutex.unlock()
+        }
+    }
+
+    private fun McpConnectionConfig.validatedKey(): String {
+        require(connectionUid.isNotBlank()) { "MCP connection ID is required." }
+        require(endpointUrl.length <= MAX_ENDPOINT_LENGTH) { "MCP endpoint URL is too long." }
+        val uri = runCatching { URI(endpointUrl) }.getOrNull()
+            ?: throw IllegalArgumentException("MCP endpoint must be a valid URL.")
+        val scheme = uri.scheme?.lowercase()
+        require(scheme == "https" || scheme == "http") { "MCP endpoint must use HTTP or HTTPS." }
+        require(!uri.host.isNullOrBlank() && uri.userInfo == null && uri.fragment == null) { "MCP endpoint URL is invalid." }
+        require(scheme != "http" || allowCleartext) { "Cleartext MCP requires explicit user approval." }
+        require(authorizationHeader?.contains('\r') != true && authorizationHeader?.contains('\n') != true) {
+            "MCP authorization header is invalid."
+        }
+        require(authorizationHeader == null || authorizationHeader.length <= MAX_AUTHORIZATION_HEADER_LENGTH) {
+            "MCP authorization header is too long."
+        }
+        return "$endpointUrl|${authorizationHeader.orEmpty().sha256()}"
+    }
+
+    private data class Session(val key: String, val client: Client)
+
+    private companion object {
+        const val CLIENT_NAME = "gpt-mobile"
+        const val CLIENT_VERSION = "0.8.0"
+        const val MAX_TOOL_PAGES = 100
+        const val MAX_DISCOVERED_TOOLS = 512
+        const val MAX_ENDPOINT_LENGTH = 4 * 1024
+        const val MAX_AUTHORIZATION_HEADER_LENGTH = 32 * 1024
+    }
+}
+
+private fun String.sha256(): String = MessageDigest.getInstance("SHA-256")
+    .digest(toByteArray(Charsets.UTF_8))
+    .joinToString("") { byte -> "%02x".format(byte) }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpClientManager.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpClientManager.kt
@@ -15,7 +15,11 @@ import java.net.URI
 import java.security.MessageDigest
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonObject
 
 class McpConnectionConfig(
@@ -36,6 +40,7 @@ class McpClientManager internal constructor(
 
     // ponytail: one global lock serializes session setup only; use per-connection locks if startup contention becomes measurable.
     private val sessions = mutableMapOf<String, Session>()
+    private val inFlight = mutableMapOf<String, InFlight>()
 
     suspend fun listTools(config: McpConnectionConfig): List<Tool> = withSession(config) { client ->
         val tools = mutableListOf<Tool>()
@@ -82,6 +87,9 @@ class McpClientManager internal constructor(
         val session = session(config)
         return try {
             block(session.client)
+        } catch (error: CancellationException) {
+            withContext(NonCancellable) { invalidate(config.connectionUid, session) }
+            throw error
         } catch (error: Exception) {
             invalidate(config.connectionUid, session)
             throw error
@@ -90,24 +98,52 @@ class McpClientManager internal constructor(
 
     private suspend fun session(config: McpConnectionConfig): Session {
         val key = config.validatedKey()
-        mutex.lock()
-        try {
-            sessions[config.connectionUid]?.takeIf { it.key == key }?.let { return it }
-            sessions.remove(config.connectionUid)?.let { previous -> runCatching { previous.client.close() } }
-
-            val transport = StreamableHttpClientTransport(httpClient, config.endpointUrl) {
-                config.authorizationHeader?.let { header(HttpHeaders.Authorization, it) }
-            }
-            val client = Client(Implementation(name = CLIENT_NAME, version = CLIENT_VERSION))
+        while (true) {
+            val created = CompletableDeferred<Session>()
+            var stale: Session? = null
+            var awaiting: CompletableDeferred<Session>? = null
+            mutex.lock()
             try {
-                client.connect(transport)
-            } catch (error: Exception) {
-                runCatching { client.close() }
-                throw error
+                sessions[config.connectionUid]?.takeIf { it.key == key }?.let { return it }
+                inFlight[config.connectionUid]?.let { existing ->
+                    awaiting = existing.deferred
+                } ?: run {
+                    stale = sessions.remove(config.connectionUid)
+                    inFlight[config.connectionUid] = InFlight(key, created)
+                }
+            } finally {
+                mutex.unlock()
             }
-            return Session(key, client).also { sessions[config.connectionUid] = it }
-        } finally {
-            mutex.unlock()
+            awaiting?.await()
+            if (awaiting != null) continue
+            withContext(NonCancellable) { stale?.let { runCatching { it.client.close() } } }
+
+            val result = runCatching {
+                val transport = StreamableHttpClientTransport(httpClient, config.endpointUrl) {
+                    config.authorizationHeader?.let { header(HttpHeaders.Authorization, it) }
+                }
+                val client = Client(Implementation(name = CLIENT_NAME, version = CLIENT_VERSION))
+                try {
+                    client.connect(transport)
+                    Session(key, client)
+                } catch (error: Exception) {
+                    withContext(NonCancellable) { runCatching { client.close() } }
+                    throw error
+                }
+            }
+            withContext(NonCancellable) {
+                mutex.lock()
+                try {
+                    if (inFlight[config.connectionUid]?.deferred === created) {
+                        inFlight.remove(config.connectionUid)
+                        result.getOrNull()?.let { sessions[config.connectionUid] = it }
+                    }
+                } finally {
+                    mutex.unlock()
+                }
+                result.fold(created::complete, created::completeExceptionally)
+            }
+            return result.getOrThrow()
         }
     }
 
@@ -118,7 +154,7 @@ class McpClientManager internal constructor(
         } finally {
             mutex.unlock()
         }
-        removed?.let { runCatching { it.client.close() } }
+        withContext(NonCancellable) { removed?.let { runCatching { it.client.close() } } }
     }
 
     private suspend fun takeSession(connectionUid: String): Session? {
@@ -139,6 +175,7 @@ class McpClientManager internal constructor(
         require(scheme == "https" || scheme == "http") { "MCP endpoint must use HTTP or HTTPS." }
         require(!uri.host.isNullOrBlank() && uri.userInfo == null && uri.fragment == null) { "MCP endpoint URL is invalid." }
         require(scheme != "http" || allowCleartext) { "Cleartext MCP requires explicit user approval." }
+        require(authorizationHeader == null || authorizationHeader.isNotBlank()) { "MCP authorization header is required." }
         require(authorizationHeader?.contains('\r') != true && authorizationHeader?.contains('\n') != true) {
             "MCP authorization header is invalid."
         }
@@ -149,6 +186,7 @@ class McpClientManager internal constructor(
     }
 
     private data class Session(val key: String, val client: Client)
+    private data class InFlight(val key: String, val deferred: CompletableDeferred<Session>)
 
     private companion object {
         const val CLIENT_NAME = "gpt-mobile"

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpOAuthClient.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpOAuthClient.kt
@@ -1,0 +1,413 @@
+package dev.chungjungsoo.gptmobile.data.agent.tool
+
+import dev.chungjungsoo.gptmobile.data.network.NetworkClient
+import io.ktor.client.HttpClient
+import io.ktor.client.request.accept
+import io.ktor.client.request.forms.FormDataContent
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.http.URLBuilder
+import io.ktor.http.contentType
+import io.ktor.http.decodeURLPart
+import io.ktor.utils.io.readAvailable
+import java.io.ByteArrayOutputStream
+import java.net.URI
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.yield
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+data class McpOAuthDiscovery(
+    val resource: String,
+    val authorizationEndpoint: String,
+    val tokenEndpoint: String,
+    val registrationEndpoint: String?,
+    val scopes: List<String>
+)
+
+@Serializable
+data class McpOAuthPending(
+    val connectionUid: String? = null,
+    val clientId: String,
+    val tokenEndpoint: String,
+    val resource: String,
+    val redirectUri: String,
+    val state: String,
+    val codeVerifier: String
+)
+
+data class McpOAuthStart(
+    val authorizationUri: String,
+    val pending: McpOAuthPending
+)
+
+@Serializable
+data class McpOAuthCredential(
+    val clientId: String,
+    val tokenEndpoint: String,
+    val resource: String,
+    val accessToken: String,
+    val tokenType: String,
+    val refreshToken: String? = null,
+    val expiresAtEpochSeconds: Long? = null,
+    val scope: String? = null
+)
+
+class McpOAuthException(message: String, cause: Throwable? = null) : Exception(message, cause)
+
+@Singleton
+class McpOAuthClient internal constructor(
+    private val httpClient: HttpClient,
+    private val nowEpochSeconds: () -> Long = { System.currentTimeMillis() / 1000 },
+    private val randomBytes: (Int) -> ByteArray = { size -> ByteArray(size).also(SecureRandom()::nextBytes) }
+) {
+    @Inject
+    constructor(networkClient: NetworkClient) : this(networkClient())
+
+    suspend fun discover(resourceUrl: String, allowCleartext: Boolean): McpOAuthDiscovery {
+        val resourceUri = resourceUrl.validatedUrl(allowCleartext, "MCP resource")
+        val challenge = httpClient.get(resourceUrl) { accept(ContentType.Application.Json) }
+        val advertisedMetadata = if (challenge.status == HttpStatusCode.Unauthorized) {
+            challenge.headers[HttpHeaders.WWWAuthenticate]?.resourceMetadataUrl()
+        } else {
+            null
+        }
+        challenge.readBoundedBody()
+        val resourceMetadata = firstMetadata(
+            buildList {
+                advertisedMetadata?.let(::add)
+                add(resourceUri.wellKnown("oauth-protected-resource", resourceUri.path))
+                add(resourceUri.wellKnown("oauth-protected-resource", ""))
+            }.distinct(),
+            allowCleartext,
+            "OAuth protected-resource metadata"
+        )
+        val resource = resourceMetadata.requiredString("resource")
+        resource.validatedUrl(allowCleartext, "OAuth resource")
+        val authorizationServer = resourceMetadata.requiredStringList("authorization_servers").firstOrNull()
+            ?: throw McpOAuthException("OAuth protected-resource metadata has no authorization server.")
+        val issuerUri = authorizationServer.validatedUrl(allowCleartext, "OAuth issuer")
+        val authorizationMetadata = firstMetadata(
+            listOf(
+                issuerUri.wellKnown("oauth-authorization-server", issuerUri.path),
+                issuerUri.wellKnown("openid-configuration", issuerUri.path),
+                authorizationServer.trimEnd('/') + "/.well-known/openid-configuration"
+            ).distinct(),
+            allowCleartext,
+            "OAuth authorization-server metadata"
+        )
+        if (authorizationMetadata.requiredString("issuer") != authorizationServer) {
+            throw McpOAuthException("OAuth authorization-server issuer did not match discovery metadata.")
+        }
+        if ("S256" !in authorizationMetadata.requiredStringList("code_challenge_methods_supported")) {
+            throw McpOAuthException("OAuth authorization server does not advertise PKCE S256.")
+        }
+        val tokenAuthMethods = authorizationMetadata.stringList("token_endpoint_auth_methods_supported")
+        if (tokenAuthMethods.isNotEmpty() && "none" !in tokenAuthMethods) {
+            throw McpOAuthException("OAuth authorization server does not support public clients.")
+        }
+        val authorizationEndpoint = authorizationMetadata.requiredString("authorization_endpoint")
+        val tokenEndpoint = authorizationMetadata.requiredString("token_endpoint")
+        authorizationEndpoint.validatedUrl(allowCleartext, "OAuth authorization endpoint")
+        tokenEndpoint.validatedUrl(allowCleartext, "OAuth token endpoint")
+        val registrationEndpoint = authorizationMetadata.string("registration_endpoint")?.also {
+            it.validatedUrl(allowCleartext, "OAuth registration endpoint")
+        }
+        val scopes = resourceMetadata.stringList("scopes_supported")
+        if (scopes.size > MAX_SCOPES || scopes.any { it.length > MAX_SCOPE_ITEM_LENGTH || it.any(Char::isISOControl) }) {
+            throw McpOAuthException("OAuth protected-resource scopes are invalid.")
+        }
+        return McpOAuthDiscovery(
+            resource = resource,
+            authorizationEndpoint = authorizationEndpoint,
+            tokenEndpoint = tokenEndpoint,
+            registrationEndpoint = registrationEndpoint,
+            scopes = scopes
+        )
+    }
+
+    suspend fun beginAuthorization(
+        discovery: McpOAuthDiscovery,
+        redirectUri: String,
+        suppliedClientId: String?
+    ): McpOAuthStart {
+        require(redirectUri.isNotBlank()) { "OAuth redirect URI is required." }
+        require(redirectUri.length <= MAX_OAUTH_URL_LENGTH) { "OAuth redirect URI is too long." }
+        val clientId = suppliedClientId?.takeIf { it.isNotBlank() }
+            ?: registerClient(discovery.registrationEndpoint, redirectUri)
+        clientId.validateClientId()
+        val state = randomToken(32)
+        val verifier = randomToken(64)
+        val challenge = verifier.sha256Base64Url()
+        val authorizationUri = URLBuilder(discovery.authorizationEndpoint).apply {
+            parameters.append("response_type", "code")
+            parameters.append("client_id", clientId)
+            parameters.append("redirect_uri", redirectUri)
+            parameters.append("code_challenge", challenge)
+            parameters.append("code_challenge_method", "S256")
+            parameters.append("state", state)
+            parameters.append("resource", discovery.resource)
+            if (discovery.scopes.isNotEmpty()) parameters.append("scope", discovery.scopes.joinToString(" "))
+        }.buildString()
+        if (authorizationUri.length > MAX_CALLBACK_URI_LENGTH) throw McpOAuthException("OAuth authorization URI is too long.")
+        return McpOAuthStart(
+            authorizationUri = authorizationUri,
+            pending = McpOAuthPending(
+                clientId = clientId,
+                tokenEndpoint = discovery.tokenEndpoint,
+                resource = discovery.resource,
+                redirectUri = redirectUri,
+                state = state,
+                codeVerifier = verifier
+            )
+        )
+    }
+
+    suspend fun completeAuthorization(pending: McpOAuthPending, callbackUri: String): McpOAuthCredential {
+        if (callbackUri.length > MAX_CALLBACK_URI_LENGTH) throw McpOAuthException("OAuth callback URI is too long.")
+        val callback = runCatching { URI(callbackUri) }.getOrNull()
+            ?: throw McpOAuthException("OAuth callback URI is invalid.")
+        val expectedCallback = runCatching { URI(pending.redirectUri) }.getOrNull()
+            ?: throw McpOAuthException("OAuth redirect URI is invalid.")
+        if (callback.scheme != expectedCallback.scheme || callback.authority != expectedCallback.authority || callback.path != expectedCallback.path) {
+            throw McpOAuthException("OAuth callback did not match the redirect URI.")
+        }
+        val pairs = callback.rawQuery.orEmpty().formPairs()
+        if (pairs.groupingBy { it.first }.eachCount().values.any { it > 1 }) {
+            throw McpOAuthException("OAuth callback repeated a parameter.")
+        }
+        val parameters = pairs.toMap()
+        parameters["error"]?.let { throw McpOAuthException("OAuth authorization failed: $it") }
+        if (parameters["state"] != pending.state) throw McpOAuthException("OAuth callback state did not match.")
+        val code = parameters["code"]?.takeIf { it.isNotBlank() && it.length <= MAX_AUTHORIZATION_CODE_LENGTH }
+            ?: throw McpOAuthException("OAuth callback did not include an authorization code.")
+        return requestToken(
+            endpoint = pending.tokenEndpoint,
+            parameters = Parameters.build {
+                append("grant_type", "authorization_code")
+                append("client_id", pending.clientId)
+                append("code", code)
+                append("redirect_uri", pending.redirectUri)
+                append("code_verifier", pending.codeVerifier)
+                append("resource", pending.resource)
+            },
+            clientId = pending.clientId,
+            resource = pending.resource,
+            previousRefreshToken = null
+        )
+    }
+
+    suspend fun refresh(credential: McpOAuthCredential): McpOAuthCredential {
+        val refreshToken = credential.refreshToken
+            ?: throw McpOAuthException("OAuth credential has no refresh token.")
+        return requestToken(
+            endpoint = credential.tokenEndpoint,
+            parameters = Parameters.build {
+                append("grant_type", "refresh_token")
+                append("client_id", credential.clientId)
+                append("refresh_token", refreshToken)
+                append("resource", credential.resource)
+            },
+            clientId = credential.clientId,
+            resource = credential.resource,
+            previousRefreshToken = refreshToken
+        )
+    }
+
+    private suspend fun registerClient(registrationEndpoint: String?, redirectUri: String): String {
+        val endpoint = registrationEndpoint
+            ?: throw McpOAuthException("OAuth requires a pre-registered client ID or Dynamic Client Registration.")
+        val response = httpClient.post(endpoint) {
+            contentType(ContentType.Application.Json)
+            setBody(
+                buildJsonObject {
+                    put("client_name", "GPT Mobile")
+                    put("redirect_uris", buildJsonArray { add(JsonPrimitive(redirectUri)) })
+                    put("token_endpoint_auth_method", "none")
+                    put(
+                        "grant_types",
+                        buildJsonArray {
+                            add(JsonPrimitive("authorization_code"))
+                            add(JsonPrimitive("refresh_token"))
+                        }
+                    )
+                    put("response_types", buildJsonArray { add(JsonPrimitive("code")) })
+                }.toString()
+            )
+        }
+        return response.successfulJson("OAuth client registration").requiredString("client_id").also(String::validateClientId)
+    }
+
+    private suspend fun requestToken(
+        endpoint: String,
+        parameters: Parameters,
+        clientId: String,
+        resource: String,
+        previousRefreshToken: String?
+    ): McpOAuthCredential {
+        val response = httpClient.post(endpoint) {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(FormDataContent(parameters))
+        }.successfulJson("OAuth token request")
+        val tokenType = response.requiredString("token_type")
+        if (!tokenType.equals("Bearer", ignoreCase = true)) {
+            throw McpOAuthException("OAuth token type is not supported.")
+        }
+        val expiresIn = response["expires_in"]?.jsonPrimitive?.content?.toLongOrNull()
+        if (expiresIn != null && expiresIn !in 0..MAX_EXPIRES_IN_SECONDS) {
+            throw McpOAuthException("OAuth token lifetime is invalid.")
+        }
+        val accessToken = response.requiredString("access_token").validatedToken("access token")
+        val refreshToken = (response.string("refresh_token") ?: previousRefreshToken)?.validatedToken("refresh token")
+        val scope = response.string("scope")?.also {
+            if (it.length > MAX_SCOPE_LENGTH) throw McpOAuthException("OAuth token scope is too long.")
+        }
+        return McpOAuthCredential(
+            clientId = clientId,
+            tokenEndpoint = endpoint,
+            resource = resource,
+            accessToken = accessToken,
+            tokenType = tokenType,
+            refreshToken = refreshToken,
+            expiresAtEpochSeconds = expiresIn?.let { nowEpochSeconds() + it },
+            scope = scope
+        )
+    }
+
+    private suspend fun firstMetadata(
+        candidates: List<String>,
+        allowCleartext: Boolean,
+        label: String
+    ): JsonObject {
+        candidates.forEach { candidate ->
+            candidate.validatedUrl(allowCleartext, label)
+            val response = runCatching { httpClient.get(candidate) { accept(ContentType.Application.Json) } }.getOrNull()
+            if (response != null && response.status.value in 200..299) {
+                return response.successfulJson(label)
+            }
+            if (response != null) runCatching { response.readBoundedBody() }
+        }
+        throw McpOAuthException("$label could not be discovered.")
+    }
+
+    private suspend fun HttpResponse.successfulJson(label: String): JsonObject {
+        if (status.value !in 200..299) throw McpOAuthException("$label failed with HTTP ${status.value}.")
+        return try {
+            NetworkClient.json.parseToJsonElement(readBoundedBody().decodeToString()) as? JsonObject
+                ?: throw McpOAuthException("$label returned invalid JSON.")
+        } catch (error: McpOAuthException) {
+            throw error
+        } catch (error: Exception) {
+            throw McpOAuthException("$label returned invalid JSON.", error)
+        }
+    }
+
+    private fun randomToken(size: Int): String = Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes(size))
+}
+
+private suspend fun HttpResponse.readBoundedBody(): ByteArray {
+    val channel = bodyAsChannel()
+    val output = ByteArrayOutputStream()
+    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+    while (true) {
+        val read = channel.readAvailable(buffer, 0, buffer.size)
+        if (read == -1) break
+        if (read == 0) {
+            yield()
+            continue
+        }
+        output.write(buffer, 0, read)
+        if (output.size() > MAX_OAUTH_RESPONSE_BYTES) throw McpOAuthException("OAuth response is too large.")
+    }
+    return output.toByteArray()
+}
+
+private fun String.validatedUrl(allowCleartext: Boolean, label: String): URI {
+    if (length > MAX_OAUTH_URL_LENGTH) throw McpOAuthException("$label URL is too long.")
+    val uri = runCatching { URI(this) }.getOrNull() ?: throw McpOAuthException("$label URL is invalid.")
+    val scheme = uri.scheme?.lowercase()
+    if (scheme != "https" && (scheme != "http" || !allowCleartext)) {
+        throw McpOAuthException("$label must use HTTPS.")
+    }
+    if (uri.host.isNullOrBlank() || uri.userInfo != null || uri.fragment != null) {
+        throw McpOAuthException("$label URL is invalid.")
+    }
+    return uri
+}
+
+private fun URI.wellKnown(name: String, suffixPath: String): String = URI(
+    scheme,
+    null,
+    host,
+    port,
+    "/.well-known/$name" + suffixPath.takeUnless { it.isBlank() || it == "/" }.orEmpty(),
+    null,
+    null
+).toString()
+
+private fun String.resourceMetadataUrl(): String? = RESOURCE_METADATA_PATTERN.find(this)?.groupValues?.get(1)?.ifBlank { null }
+
+private fun JsonObject.requiredString(name: String): String = string(name)
+    ?: throw McpOAuthException("OAuth metadata is missing $name.")
+
+private fun JsonObject.string(name: String): String? = (this[name] as? JsonPrimitive)?.content?.takeIf { it.isNotBlank() }
+
+private fun JsonObject.requiredStringList(name: String): List<String> = stringList(name).takeIf { it.isNotEmpty() }
+    ?: throw McpOAuthException("OAuth metadata is missing $name.")
+
+private fun JsonObject.stringList(name: String): List<String> = (this[name] as? JsonArray)
+    ?.mapNotNull { (it as? JsonPrimitive)?.content?.takeIf(String::isNotBlank) }
+    .orEmpty()
+
+private fun String.formPairs(): List<Pair<String, String>> = split('&')
+    .filter(String::isNotBlank)
+    .map { item ->
+        val parts = item.split('=', limit = 2)
+        parts[0].decodeURLPart() to parts.getOrElse(1) { "" }.replace('+', ' ').decodeURLPart()
+    }
+
+private fun String.validateClientId() {
+    if (isBlank() || length > MAX_CLIENT_ID_LENGTH || any(Char::isISOControl)) {
+        throw McpOAuthException("OAuth client ID is invalid.")
+    }
+}
+
+private fun String.validatedToken(label: String): String {
+    if (length > MAX_TOKEN_LENGTH || contains('\r') || contains('\n')) {
+        throw McpOAuthException("OAuth $label is invalid.")
+    }
+    return this
+}
+
+private fun String.sha256Base64Url(): String = Base64.getUrlEncoder().withoutPadding().encodeToString(
+    MessageDigest.getInstance("SHA-256").digest(toByteArray())
+)
+
+private val RESOURCE_METADATA_PATTERN = Regex("""resource_metadata\s*=\s*\"([^\"]+)\"""", RegexOption.IGNORE_CASE)
+private const val MAX_OAUTH_URL_LENGTH = 4 * 1024
+private const val MAX_CALLBACK_URI_LENGTH = 16 * 1024
+private const val MAX_CLIENT_ID_LENGTH = 1024
+private const val MAX_AUTHORIZATION_CODE_LENGTH = 8 * 1024
+private const val MAX_TOKEN_LENGTH = 32 * 1024
+private const val MAX_SCOPE_LENGTH = 4 * 1024
+private const val MAX_SCOPES = 32
+private const val MAX_SCOPE_ITEM_LENGTH = 256
+private const val MAX_OAUTH_RESPONSE_BYTES = 64 * 1024
+private const val MAX_EXPIRES_IN_SECONDS = 10L * 365 * 24 * 60 * 60

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpOAuthClient.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpOAuthClient.kt
@@ -24,6 +24,8 @@ import java.security.SecureRandom
 import java.util.Base64
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonArray
@@ -76,20 +78,28 @@ class McpOAuthException(message: String, cause: Throwable? = null) : Exception(m
 class McpOAuthClient internal constructor(
     private val httpClient: HttpClient,
     private val nowEpochSeconds: () -> Long = { System.currentTimeMillis() / 1000 },
-    private val randomBytes: (Int) -> ByteArray = { size -> ByteArray(size).also(SecureRandom()::nextBytes) }
+    private val randomBytes: (Int) -> ByteArray = { size -> ByteArray(size).also(SecureRandom()::nextBytes) },
+    private val discoveryTimeoutMillis: Long = DEFAULT_DISCOVERY_TIMEOUT_MILLIS
 ) {
     @Inject
     constructor(networkClient: NetworkClient) : this(networkClient())
 
     suspend fun discover(resourceUrl: String, allowCleartext: Boolean): McpOAuthDiscovery {
         val resourceUri = resourceUrl.validatedUrl(allowCleartext, "MCP resource")
-        val challenge = httpClient.get(resourceUrl) { accept(ContentType.Application.Json) }
+        val challenge = discovering("OAuth challenge") {
+            httpClient.get(resourceUrl) { accept(ContentType.Application.Json) }
+        }
         val advertisedMetadata = if (challenge.status == HttpStatusCode.Unauthorized) {
             challenge.headers[HttpHeaders.WWWAuthenticate]?.resourceMetadataUrl()
         } else {
             null
         }
-        challenge.readBoundedBody()
+        discovering("OAuth challenge") { challenge.readBoundedBody() }
+        advertisedMetadata?.validatedUrl(allowCleartext, "OAuth protected-resource metadata")?.let { metadataUri ->
+            if (!metadataUri.sameOrigin(resourceUri)) {
+                throw McpOAuthException("OAuth protected-resource metadata must use the MCP resource same origin.")
+            }
+        }
         val resourceMetadata = firstMetadata(
             buildList {
                 advertisedMetadata?.let(::add)
@@ -100,7 +110,10 @@ class McpOAuthClient internal constructor(
             "OAuth protected-resource metadata"
         )
         val resource = resourceMetadata.requiredString("resource")
-        resource.validatedUrl(allowCleartext, "OAuth resource")
+        val discoveredResource = resource.validatedUrl(allowCleartext, "OAuth resource")
+        if (!discoveredResource.sameOrigin(resourceUri)) {
+            throw McpOAuthException("OAuth resource must use the MCP resource same origin.")
+        }
         val authorizationServer = resourceMetadata.requiredStringList("authorization_servers").firstOrNull()
             ?: throw McpOAuthException("OAuth protected-resource metadata has no authorization server.")
         val issuerUri = authorizationServer.validatedUrl(allowCleartext, "OAuth issuer")
@@ -298,7 +311,9 @@ class McpOAuthClient internal constructor(
     ): JsonObject {
         candidates.forEach { candidate ->
             candidate.validatedUrl(allowCleartext, label)
-            val response = runCatching { httpClient.get(candidate) { accept(ContentType.Application.Json) } }.getOrNull()
+            val response = runCatching {
+                discovering(label) { httpClient.get(candidate) { accept(ContentType.Application.Json) } }
+            }.getOrNull()
             if (response != null && response.status.value in 200..299) {
                 return response.successfulJson(label)
             }
@@ -307,10 +322,16 @@ class McpOAuthClient internal constructor(
         throw McpOAuthException("$label could not be discovered.")
     }
 
+    private suspend fun <T> discovering(label: String, block: suspend () -> T): T = try {
+        withTimeout(discoveryTimeoutMillis) { block() }
+    } catch (error: TimeoutCancellationException) {
+        throw McpOAuthException("$label timed out while discovering.", error)
+    }
+
     private suspend fun HttpResponse.successfulJson(label: String): JsonObject {
         if (status.value !in 200..299) throw McpOAuthException("$label failed with HTTP ${status.value}.")
         return try {
-            NetworkClient.json.parseToJsonElement(readBoundedBody().decodeToString()) as? JsonObject
+            NetworkClient.json.parseToJsonElement(discovering(label) { readBoundedBody() }.decodeToString()) as? JsonObject
                 ?: throw McpOAuthException("$label returned invalid JSON.")
         } catch (error: McpOAuthException) {
             throw error
@@ -362,6 +383,17 @@ private fun URI.wellKnown(name: String, suffixPath: String): String = URI(
     null
 ).toString()
 
+private fun URI.sameOrigin(other: URI): Boolean = scheme.equals(other.scheme, ignoreCase = true) &&
+    host.equals(other.host, ignoreCase = true) &&
+    effectivePort() == other.effectivePort()
+
+private fun URI.effectivePort(): Int = when {
+    port != -1 -> port
+    scheme.equals("https", ignoreCase = true) -> 443
+    scheme.equals("http", ignoreCase = true) -> 80
+    else -> -1
+}
+
 private fun String.resourceMetadataUrl(): String? = RESOURCE_METADATA_PATTERN.find(this)?.groupValues?.get(1)?.ifBlank { null }
 
 private fun JsonObject.requiredString(name: String): String = string(name)
@@ -411,3 +443,4 @@ private const val MAX_SCOPES = 32
 private const val MAX_SCOPE_ITEM_LENGTH = 256
 private const val MAX_OAUTH_RESPONSE_BYTES = 64 * 1024
 private const val MAX_EXPIRES_IN_SECONDS = 10L * 365 * 24 * 60 * 60
+private const val DEFAULT_DISCOVERY_TIMEOUT_MILLIS = 10_000L

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpOAuthCoordinator.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpOAuthCoordinator.kt
@@ -128,6 +128,8 @@ fun mcpOAuthConnectionUid(callbackUri: String): String? = runCatching { URI(call
     ?.substringAfterLast('/')
     ?.takeIf(MCP_CONNECTION_UID_PATTERN::matches)
 
+fun isMcpOAuthCallbackUri(callbackUri: String?): Boolean = callbackUri?.let(::mcpOAuthConnectionUid) != null
+
 const val MCP_OAUTH_SCHEME = "dev.chungjungsoo.gptmobile"
 const val MCP_OAUTH_HOST = "oauth"
 

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpOAuthCoordinator.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpOAuthCoordinator.kt
@@ -1,0 +1,134 @@
+package dev.chungjungsoo.gptmobile.data.agent.tool
+
+import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnection
+import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnectionAuthType
+import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnectionType
+import dev.chungjungsoo.gptmobile.data.network.NetworkClient
+import dev.chungjungsoo.gptmobile.data.repository.ToolConnectionRepository
+import dev.chungjungsoo.gptmobile.data.repository.mcpOAuthPendingSecretRef
+import dev.chungjungsoo.gptmobile.data.security.SecretVault
+import java.net.URI
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+
+@Singleton
+class McpOAuthCoordinator @Inject constructor(
+    private val oauthClient: McpOAuthClient,
+    private val connectionRepository: ToolConnectionRepository,
+    private val secretVault: SecretVault,
+    private val mcpClientManager: McpClientManager
+) {
+    private val credentialMutex = Mutex()
+
+    suspend fun begin(connectionUid: String, redirectUri: String): String {
+        val connection = requireOAuthConnection(connectionUid)
+        val discovery = oauthClient.discover(
+            resourceUrl = connection.endpointUrl ?: throw McpOAuthException("MCP endpoint is required."),
+            allowCleartext = connection.allowCleartext
+        )
+        val start = oauthClient.beginAuthorization(discovery, redirectUri, connection.oauthClientId)
+        if (start.pending.clientId != connection.oauthClientId) {
+            connectionRepository.upsertConnection(connection.copy(oauthClientId = start.pending.clientId))
+        }
+        storePending(start.pending.copy(connectionUid = connectionUid))
+        return start.authorizationUri
+    }
+
+    suspend fun complete(connectionUid: String, callbackUri: String) {
+        val connection = requireOAuthConnection(connectionUid)
+        val pendingRef = mcpOAuthPendingSecretRef(connectionUid)
+        val pending = readSecret<McpOAuthPending>(pendingRef)
+            ?: throw McpOAuthException("OAuth authorization is no longer pending.")
+        if (pending.connectionUid != connectionUid) throw McpOAuthException("OAuth pending connection did not match.")
+        val credential = oauthClient.completeAuthorization(pending, callbackUri)
+        connectionRepository.upsertConnection(
+            connection.copy(oauthClientId = credential.clientId),
+            credential = NetworkClient.json.encodeToString(credential).encodeToByteArray()
+        )
+        secretVault.delete(pendingRef)
+        mcpClientManager.close(connectionUid)
+    }
+
+    suspend fun authorizationHeader(
+        connection: ToolConnection,
+        forceRefresh: Boolean = false,
+        rejectedAuthorizationHeader: String? = null
+    ): String {
+        credentialMutex.lock()
+        try {
+            require(connection.authType == ToolConnectionAuthType.OAUTH) { "OAuth connection required." }
+            val secretRef = connection.secretRef ?: throw McpOAuthException("MCP OAuth connection is not authorized.")
+            var credential = readSecret<McpOAuthCredential>(secretRef)
+                ?: throw McpOAuthException("MCP OAuth credential is missing.")
+            val currentHeader = "${credential.tokenType} ${credential.accessToken}"
+            val isExpired = credential.expiresAtEpochSeconds?.let { it <= nowEpochSeconds() + REFRESH_SKEW_SECONDS } == true
+            val shouldRefreshRejected = forceRefresh && (rejectedAuthorizationHeader == null || rejectedAuthorizationHeader == currentHeader)
+            if (isExpired || shouldRefreshRejected) {
+                credential = oauthClient.refresh(credential)
+                connectionRepository.upsertConnection(
+                    connection.copy(oauthClientId = credential.clientId),
+                    credential = NetworkClient.json.encodeToString(credential).encodeToByteArray()
+                )
+                mcpClientManager.close(connection.connectionUid)
+            }
+            return "${credential.tokenType} ${credential.accessToken}"
+        } finally {
+            credentialMutex.unlock()
+        }
+    }
+
+    private suspend fun requireOAuthConnection(connectionUid: String): ToolConnection {
+        val connection = connectionRepository.getConnection(connectionUid)
+            ?: throw McpOAuthException("MCP connection was not found.")
+        if (connection.type != ToolConnectionType.MCP || connection.authType != ToolConnectionAuthType.OAUTH) {
+            throw McpOAuthException("Connection is not configured for MCP OAuth.")
+        }
+        return connection
+    }
+
+    private suspend fun storePending(pending: McpOAuthPending) {
+        val bytes = NetworkClient.json.encodeToString(pending).encodeToByteArray()
+        try {
+            secretVault.put(mcpOAuthPendingSecretRef(requireNotNull(pending.connectionUid)), bytes)
+        } finally {
+            bytes.fill(0)
+        }
+    }
+
+    private suspend inline fun <reified T> readSecret(secretRef: String): T? {
+        val bytes = secretVault.read(secretRef) ?: return null
+        return try {
+            NetworkClient.json.decodeFromString<T>(bytes.decodeToString())
+        } catch (error: Exception) {
+            throw McpOAuthException("MCP OAuth credential is invalid.", error)
+        } finally {
+            bytes.fill(0)
+        }
+    }
+
+    private fun nowEpochSeconds(): Long = System.currentTimeMillis() / 1000
+
+    private companion object {
+        const val REFRESH_SKEW_SECONDS = 60
+    }
+}
+
+fun mcpOAuthRedirectUri(connectionUid: String): String {
+    require(MCP_CONNECTION_UID_PATTERN.matches(connectionUid)) { "MCP connection ID is invalid." }
+    return "$MCP_OAUTH_SCHEME://$MCP_OAUTH_HOST/mcp/$connectionUid"
+}
+
+fun mcpOAuthConnectionUid(callbackUri: String): String? = runCatching { URI(callbackUri) }
+    .getOrNull()
+    ?.takeIf { it.scheme == MCP_OAUTH_SCHEME && it.host == MCP_OAUTH_HOST && it.path?.startsWith("/mcp/") == true }
+    ?.path
+    ?.substringAfterLast('/')
+    ?.takeIf(MCP_CONNECTION_UID_PATTERN::matches)
+
+const val MCP_OAUTH_SCHEME = "dev.chungjungsoo.gptmobile"
+const val MCP_OAUTH_HOST = "oauth"
+
+private val MCP_CONNECTION_UID_PATTERN = Regex("[A-Za-z0-9_-]{1,96}")

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpToolMapper.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpToolMapper.kt
@@ -1,0 +1,317 @@
+package dev.chungjungsoo.gptmobile.data.agent.tool
+
+import dev.chungjungsoo.gptmobile.data.agent.AgentResourceLink
+import dev.chungjungsoo.gptmobile.data.agent.AgentToolDefinition
+import dev.chungjungsoo.gptmobile.data.agent.AgentToolResult
+import dev.chungjungsoo.gptmobile.data.agent.ToolResultContent
+import io.modelcontextprotocol.kotlin.sdk.types.AudioContent
+import io.modelcontextprotocol.kotlin.sdk.types.BlobResourceContents
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.EmbeddedResource
+import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
+import io.modelcontextprotocol.kotlin.sdk.types.ResourceLink
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.TextResourceContents
+import io.modelcontextprotocol.kotlin.sdk.types.Tool
+import java.security.MessageDigest
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+internal fun namespaceMcpToolName(alias: String, toolName: String): String {
+    val raw = "mcp__${alias}__$toolName"
+    val safe = raw.map { character ->
+        if ((character.isLetterOrDigit() && character.code < 128) || character == '_' || character == '-') character else '_'
+    }.joinToString("")
+    if (safe == raw && safe.length <= MAX_MODEL_TOOL_NAME_LENGTH) return safe
+
+    val suffix = raw.sha256().take(10)
+    return safe.take(MAX_MODEL_TOOL_NAME_LENGTH - suffix.length - 2).trimEnd('_') + "__" + suffix
+}
+
+internal fun mcpToolDefinition(alias: String, tool: Tool): AgentToolDefinition = AgentToolDefinition(
+    name = namespaceMcpToolName(alias, tool.name),
+    description = tool.description.orEmpty().safeTake(MAX_TOOL_DESCRIPTION_CHARS),
+    inputSchema = buildJsonObject {
+        require(tool.name.isNotBlank() && tool.name.length <= MAX_REMOTE_TOOL_NAME_LENGTH && tool.name.none(Char::isISOControl)) {
+            "MCP tool name is invalid."
+        }
+        put("type", tool.inputSchema.type)
+        put("properties", tool.inputSchema.properties ?: JsonObject(emptyMap()))
+        if (!tool.inputSchema.required.isNullOrEmpty()) {
+            put("required", JsonArray(tool.inputSchema.required.orEmpty().map(::JsonPrimitive)))
+        }
+        if (!tool.inputSchema.defs.isNullOrEmpty()) put("\$defs", tool.inputSchema.defs ?: JsonObject(emptyMap()))
+    }.also { schema ->
+        require(schema.estimatedJsonUtf8Bytes(MAX_TOOL_SCHEMA_BYTES) != null) {
+            "MCP tool schema is too large."
+        }
+    }
+)
+
+internal fun mapMcpToolResult(callId: String, result: CallToolResult): AgentToolResult {
+    val text = mutableListOf<String>()
+    val links = mutableListOf<AgentResourceLink>()
+    val omitted = mutableListOf<String>()
+    val budget = Utf8Budget(MAX_MCP_MODEL_OUTPUT_BYTES)
+
+    fun omit(message: String) {
+        if (omitted.size < MAX_OMISSION_NOTICES) omitted += message.safeTake(MAX_OMISSION_NOTICE_CHARS)
+    }
+
+    fun addText(value: String) {
+        val bounded = budget.take(value)
+        if (bounded.isNotEmpty()) text += bounded
+        if (bounded.length != value.length) omit("text output truncated to the model-visible limit")
+    }
+
+    fun addLink(uri: String, name: String? = null, mimeType: String? = null) {
+        if (links.size >= MAX_RESOURCE_LINKS || !budget.consumeString(uri)) {
+            omit("resource link omitted from model context")
+            return
+        }
+        links += AgentResourceLink(
+            uri = uri,
+            name = name?.let(budget::take),
+            mimeType = mimeType?.let(budget::take)
+        )
+    }
+
+    result.content.forEach { block ->
+        when (block) {
+            is TextContent -> addText(block.text)
+
+            is ResourceLink -> addLink(block.uri, block.title ?: block.name, block.mimeType)
+
+            is EmbeddedResource -> when (val resource = block.resource) {
+                is TextResourceContents -> {
+                    addText(resource.text)
+                    addLink(resource.uri, mimeType = resource.mimeType)
+                }
+
+                is BlobResourceContents -> omit("${resource.mimeType ?: "binary resource"} omitted from model context")
+
+                else -> omit("unsupported MCP resource omitted from model context")
+            }
+
+            is ImageContent -> omit("${block.mimeType} image omitted from model context")
+
+            is AudioContent -> omit("${block.mimeType} audio omitted from model context")
+        }
+    }
+
+    val structured = result.structuredContent?.takeIf { value ->
+        val size = value.estimatedJsonUtf8Bytes(budget.remaining)
+        if (size == null) {
+            omit("structured JSON omitted from model context because it exceeded the model-visible limit")
+            false
+        } else {
+            budget.consume(size)
+            true
+        }
+    }
+    val modelContent = modelContent(text, structured, links)
+    val traceContent = if (omitted.isEmpty()) {
+        null
+    } else {
+        ToolResultContent.Text(buildTrace(text, structured, links, omitted))
+    }
+    return AgentToolResult(
+        callId = callId,
+        content = modelContent,
+        isError = result.isError == true,
+        traceContent = traceContent
+    )
+}
+
+private fun modelContent(
+    text: List<String>,
+    structured: JsonObject?,
+    links: List<AgentResourceLink>
+): ToolResultContent {
+    val populatedKinds = listOf(text.isNotEmpty(), structured != null, links.isNotEmpty()).count { it }
+    if (populatedKinds == 0) return ToolResultContent.Text("MCP tool returned no model-compatible content.")
+    if (populatedKinds == 1) {
+        if (structured != null) return ToolResultContent.Json(structured)
+        if (links.isNotEmpty()) return ToolResultContent.ResourceLinks(links)
+        return ToolResultContent.Text(text.joinToString("\n"))
+    }
+
+    return ToolResultContent.Json(
+        buildJsonObject {
+            if (text.isNotEmpty()) put("text", JsonArray(text.map(::JsonPrimitive)))
+            if (structured != null) put("structuredContent", structured)
+            if (links.isNotEmpty()) {
+                put(
+                    "resourceLinks",
+                    buildJsonArray {
+                        links.forEach { link ->
+                            add(
+                                buildJsonObject {
+                                    put("uri", link.uri)
+                                    link.name?.let { put("name", it) }
+                                    link.mimeType?.let { put("mimeType", it) }
+                                }
+                            )
+                        }
+                    }
+                )
+            }
+        }
+    )
+}
+
+private fun buildTrace(
+    text: List<String>,
+    structured: JsonElement?,
+    links: List<AgentResourceLink>,
+    omitted: List<String>
+): String = buildList {
+    addAll(text)
+    structured?.let { add("Structured content: $it") }
+    links.forEach { add("Resource: ${it.name ?: it.uri} (${it.uri})") }
+    omitted.forEach { add("[$it]") }
+}.joinToString("\n")
+
+private fun String.sha256(): String = MessageDigest.getInstance("SHA-256")
+    .digest(toByteArray(Charsets.UTF_8))
+    .joinToString("") { byte -> "%02x".format(byte) }
+
+private const val MAX_MODEL_TOOL_NAME_LENGTH = 64
+private const val MAX_REMOTE_TOOL_NAME_LENGTH = 512
+private const val MAX_TOOL_DESCRIPTION_CHARS = 4 * 1024
+private const val MAX_TOOL_SCHEMA_BYTES = 64 * 1024
+private const val MAX_MCP_MODEL_OUTPUT_BYTES = 64 * 1024
+private const val MAX_RESOURCE_LINKS = 100
+private const val MAX_OMISSION_NOTICES = 16
+private const val MAX_OMISSION_NOTICE_CHARS = 256
+private const val MAX_JSON_DEPTH = 128
+
+private fun String.safeTake(maxChars: Int): String = take(maxChars).let { value ->
+    if (value.lastOrNull()?.isHighSurrogate() == true) value.dropLast(1) else value
+}
+
+private class Utf8Budget(maxBytes: Int) {
+    var remaining = maxBytes
+        private set
+
+    fun consume(bytes: Int): Boolean {
+        if (bytes > remaining) return false
+        remaining -= bytes
+        return true
+    }
+
+    fun consumeString(value: String): Boolean {
+        val bytes = value.utf8BytesWithin(remaining) ?: return false
+        return consume(bytes)
+    }
+
+    fun take(value: String): String {
+        val result = StringBuilder(minOf(value.length, remaining))
+        var index = 0
+        var bytes = 0
+        while (index < value.length) {
+            val codePoint = value.codePointAt(index)
+            val size = codePoint.utf8Bytes()
+            if (bytes + size > remaining) break
+            result.appendCodePoint(codePoint)
+            bytes += size
+            index += Character.charCount(codePoint)
+        }
+        remaining -= bytes
+        return result.toString()
+    }
+}
+
+private fun JsonElement.estimatedJsonUtf8Bytes(limit: Int): Int? {
+    val counter = ByteCounter(limit)
+    return if (estimateJsonBytes(this, counter, 0)) counter.used else null
+}
+
+private fun estimateJsonBytes(value: JsonElement, counter: ByteCounter, depth: Int): Boolean {
+    if (depth > MAX_JSON_DEPTH) return false
+    return when (value) {
+        JsonNull -> counter.consume(4)
+
+        is JsonPrimitive -> if (value.isString) {
+            counter.consumeJsonString(value.content)
+        } else {
+            counter.consumeString(value.content)
+        }
+
+        is JsonArray -> {
+            if (!counter.consume(2)) return false
+            value.forEachIndexed { index, child ->
+                if (index > 0 && !counter.consume(1)) return false
+                if (!estimateJsonBytes(child, counter, depth + 1)) return false
+            }
+            true
+        }
+
+        is JsonObject -> {
+            if (!counter.consume(2)) return false
+            value.entries.forEachIndexed { index, (key, child) ->
+                if (index > 0 && !counter.consume(1)) return false
+                if (!counter.consumeJsonString(key) || !counter.consume(1)) return false
+                if (!estimateJsonBytes(child, counter, depth + 1)) return false
+            }
+            true
+        }
+    }
+}
+
+private class ByteCounter(private val limit: Int) {
+    var used = 0
+        private set
+
+    fun consume(bytes: Int): Boolean {
+        if (bytes > limit - used) return false
+        used += bytes
+        return true
+    }
+
+    fun consumeString(value: String): Boolean {
+        val bytes = value.utf8BytesWithin(limit - used) ?: return false
+        return consume(bytes)
+    }
+
+    fun consumeJsonString(value: String): Boolean {
+        if (!consume(2)) return false
+        var index = 0
+        while (index < value.length) {
+            val codePoint = value.codePointAt(index)
+            val bytes = when (codePoint) {
+                '"'.code, '\\'.code -> 2
+                in 0..0x1f -> 6
+                else -> codePoint.utf8Bytes()
+            }
+            if (!consume(bytes)) return false
+            index += Character.charCount(codePoint)
+        }
+        return true
+    }
+}
+
+private fun String.utf8BytesWithin(limit: Int): Int? {
+    var bytes = 0
+    var index = 0
+    while (index < length) {
+        val codePoint = codePointAt(index)
+        bytes += codePoint.utf8Bytes()
+        if (bytes > limit) return null
+        index += Character.charCount(codePoint)
+    }
+    return bytes
+}
+
+private fun Int.utf8Bytes(): Int = when {
+    this <= 0x7f -> 1
+    this <= 0x7ff -> 2
+    this <= 0xffff -> 3
+    else -> 4
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/network/NetworkClient.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/network/NetworkClient.kt
@@ -75,6 +75,7 @@ class NetworkClient @Inject constructor(
 
         internal fun isSensitiveHeader(header: String): Boolean = header.equals(HttpHeaders.Authorization, ignoreCase = true) ||
             header.equals("x-goog-api-key", ignoreCase = true) ||
-            header.equals("x-api-key", ignoreCase = true)
+            header.equals("x-api-key", ignoreCase = true) ||
+            header.equals("Mcp-Session-Id", ignoreCase = true)
     }
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ToolConnectionRepository.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ToolConnectionRepository.kt
@@ -56,6 +56,7 @@ class ToolConnectionRepository internal constructor(
         val secretRef = toolConnectionDao.getConnection(connectionUid)?.secretRef
         toolConnectionDao.deleteConnectionByUid(connectionUid)
         secretRef?.let { secretVault.delete(it) }
+        secretVault.delete(mcpOAuthPendingSecretRef(connectionUid))
     }
 
     suspend fun listBindingsByProfile(profileUid: String): List<AgentToolBinding> = toolConnectionDao.listBindingsByProfile(profileUid)
@@ -168,6 +169,8 @@ class ToolConnectionRepository internal constructor(
         val WEB_SEARCH_TYPES = setOf(ToolConnectionType.FIRECRAWL, ToolConnectionType.PERPLEXITY, ToolConnectionType.EXA)
     }
 }
+
+internal fun mcpOAuthPendingSecretRef(connectionUid: String): String = "mcp_oauth_pending_$connectionUid"
 
 private fun stableBindingUid(
     profileUid: String,

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ToolEventRecorder.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ToolEventRecorder.kt
@@ -67,7 +67,7 @@ class ToolEventRecorder @Inject constructor(
         completedAt: Long,
         error: String? = null
     ): ToolEvent? {
-        val content = result.content.serialized().forStorage()
+        val content = (result.traceContent ?: result.content).serialized().forStorage()
         val affectedRows = dao.finishToolEvent(
             eventId = eventId,
             callId = result.callId,

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/common/NavigationGraph.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/common/NavigationGraph.kt
@@ -23,6 +23,7 @@ import dev.chungjungsoo.gptmobile.presentation.ui.setting.LicenseScreen
 import dev.chungjungsoo.gptmobile.presentation.ui.setting.PlatformSettingScreen
 import dev.chungjungsoo.gptmobile.presentation.ui.setting.SettingScreen
 import dev.chungjungsoo.gptmobile.presentation.ui.setting.SettingViewModelV2
+import dev.chungjungsoo.gptmobile.presentation.ui.setting.ToolConnectionEditorScreen
 import dev.chungjungsoo.gptmobile.presentation.ui.setting.ToolConnectionsScreen
 import dev.chungjungsoo.gptmobile.presentation.ui.setting.ToolConnectionsViewModel
 import dev.chungjungsoo.gptmobile.presentation.ui.setup.SetupCompleteScreen
@@ -210,7 +211,29 @@ fun NavGraphBuilder.settingNavigation(
             ToolConnectionsScreen(
                 viewModel = toolConnectionsViewModel,
                 onLaunchOAuth = onLaunchOAuth,
-                onNavigationClick = { navController.navigateUp() }
+                onNavigationClick = { navController.navigateUp() },
+                onAddConnectionClick = { navController.navigate(Route.ADD_TOOL_CONNECTION) },
+                onEditConnectionClick = { connectionUid ->
+                    navController.navigate(Route.EDIT_TOOL_CONNECTION.replace("{connectionUid}", connectionUid))
+                }
+            )
+        }
+        composable(Route.ADD_TOOL_CONNECTION) {
+            ToolConnectionEditorScreen(
+                viewModel = toolConnectionsViewModel,
+                onNavigationClick = { navController.navigateUp() },
+                onSaveComplete = { navController.navigateUp() }
+            )
+        }
+        composable(
+            Route.EDIT_TOOL_CONNECTION,
+            arguments = listOf(navArgument("connectionUid") { type = NavType.StringType })
+        ) {
+            ToolConnectionEditorScreen(
+                connectionUid = it.arguments?.getString("connectionUid"),
+                viewModel = toolConnectionsViewModel,
+                onNavigationClick = { navController.navigateUp() },
+                onSaveComplete = { navController.navigateUp() }
             )
         }
         composable(Route.ABOUT_PAGE) {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/common/NavigationGraph.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/common/NavigationGraph.kt
@@ -24,19 +24,17 @@ import dev.chungjungsoo.gptmobile.presentation.ui.setting.PlatformSettingScreen
 import dev.chungjungsoo.gptmobile.presentation.ui.setting.SettingScreen
 import dev.chungjungsoo.gptmobile.presentation.ui.setting.SettingViewModelV2
 import dev.chungjungsoo.gptmobile.presentation.ui.setting.ToolConnectionsScreen
+import dev.chungjungsoo.gptmobile.presentation.ui.setting.ToolConnectionsViewModel
 import dev.chungjungsoo.gptmobile.presentation.ui.setup.SetupCompleteScreen
 import dev.chungjungsoo.gptmobile.presentation.ui.setup.SetupPlatformListScreen
 import dev.chungjungsoo.gptmobile.presentation.ui.setup.SetupPlatformTypeScreen
 import dev.chungjungsoo.gptmobile.presentation.ui.setup.SetupPlatformWizardScreen
 import dev.chungjungsoo.gptmobile.presentation.ui.setup.SetupViewModelV2
 import dev.chungjungsoo.gptmobile.presentation.ui.startscreen.StartScreen
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
-
 @Composable
 fun SetupNavGraph(
     navController: NavHostController,
-    oauthCallbacks: Flow<String?> = emptyFlow(),
+    toolConnectionsViewModel: ToolConnectionsViewModel,
     onLaunchOAuth: (String) -> Unit = {}
 ) {
     NavHost(
@@ -50,7 +48,7 @@ fun SetupNavGraph(
         migrationScreenNavigation(navController)
         startScreenNavigation(navController)
         setupNavigation(navController)
-        settingNavigation(navController, oauthCallbacks, onLaunchOAuth)
+        settingNavigation(navController, toolConnectionsViewModel, onLaunchOAuth)
         chatScreenNavigation(navController)
     }
 }
@@ -165,7 +163,7 @@ fun NavGraphBuilder.chatScreenNavigation(navController: NavHostController) {
 
 fun NavGraphBuilder.settingNavigation(
     navController: NavHostController,
-    oauthCallbacks: Flow<String?> = emptyFlow(),
+    toolConnectionsViewModel: ToolConnectionsViewModel,
     onLaunchOAuth: (String) -> Unit = {}
 ) {
     navigation(startDestination = Route.SETTINGS, route = Route.SETTING_ROUTE) {
@@ -210,7 +208,7 @@ fun NavGraphBuilder.settingNavigation(
         }
         composable(Route.TOOL_CONNECTIONS) {
             ToolConnectionsScreen(
-                oauthCallbacks = oauthCallbacks,
+                viewModel = toolConnectionsViewModel,
                 onLaunchOAuth = onLaunchOAuth,
                 onNavigationClick = { navController.navigateUp() }
             )

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/common/NavigationGraph.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/common/NavigationGraph.kt
@@ -30,9 +30,15 @@ import dev.chungjungsoo.gptmobile.presentation.ui.setup.SetupPlatformTypeScreen
 import dev.chungjungsoo.gptmobile.presentation.ui.setup.SetupPlatformWizardScreen
 import dev.chungjungsoo.gptmobile.presentation.ui.setup.SetupViewModelV2
 import dev.chungjungsoo.gptmobile.presentation.ui.startscreen.StartScreen
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 
 @Composable
-fun SetupNavGraph(navController: NavHostController) {
+fun SetupNavGraph(
+    navController: NavHostController,
+    oauthCallbacks: Flow<String?> = emptyFlow(),
+    onLaunchOAuth: (String) -> Unit = {}
+) {
     NavHost(
         modifier = Modifier
             .fillMaxSize()
@@ -44,7 +50,7 @@ fun SetupNavGraph(navController: NavHostController) {
         migrationScreenNavigation(navController)
         startScreenNavigation(navController)
         setupNavigation(navController)
-        settingNavigation(navController)
+        settingNavigation(navController, oauthCallbacks, onLaunchOAuth)
         chatScreenNavigation(navController)
     }
 }
@@ -157,7 +163,11 @@ fun NavGraphBuilder.chatScreenNavigation(navController: NavHostController) {
     }
 }
 
-fun NavGraphBuilder.settingNavigation(navController: NavHostController) {
+fun NavGraphBuilder.settingNavigation(
+    navController: NavHostController,
+    oauthCallbacks: Flow<String?> = emptyFlow(),
+    onLaunchOAuth: (String) -> Unit = {}
+) {
     navigation(startDestination = Route.SETTINGS, route = Route.SETTING_ROUTE) {
         composable(Route.SETTINGS) {
             val parentEntry = remember(it) {
@@ -199,7 +209,11 @@ fun NavGraphBuilder.settingNavigation(navController: NavHostController) {
             )
         }
         composable(Route.TOOL_CONNECTIONS) {
-            ToolConnectionsScreen(onNavigationClick = { navController.navigateUp() })
+            ToolConnectionsScreen(
+                oauthCallbacks = oauthCallbacks,
+                onLaunchOAuth = onLaunchOAuth,
+                onNavigationClick = { navController.navigateUp() }
+            )
         }
         composable(Route.ABOUT_PAGE) {
             AboutScreen(

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/common/Route.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/common/Route.kt
@@ -27,6 +27,8 @@ object Route {
     const val SETTINGS = "settings"
     const val ADD_PLATFORM = "add_platform"
     const val TOOL_CONNECTIONS = "tool_connections"
+    const val ADD_TOOL_CONNECTION = "tool_connections/add"
+    const val EDIT_TOOL_CONNECTION = "tool_connections/edit/{connectionUid}"
     const val PLATFORM_SETTINGS = "platform_settings/{platformUid}"
     const val OPENAI_SETTINGS = "openai_settings"
     const val ANTHROPIC_SETTINGS = "anthropic_settings"

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/main/MainActivity.kt
@@ -18,25 +18,23 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
-import dev.chungjungsoo.gptmobile.data.agent.tool.MCP_OAUTH_HOST
 import dev.chungjungsoo.gptmobile.data.agent.tool.MCP_OAUTH_SCHEME
+import dev.chungjungsoo.gptmobile.data.agent.tool.isMcpOAuthCallbackUri
 import dev.chungjungsoo.gptmobile.presentation.common.LocalDynamicTheme
 import dev.chungjungsoo.gptmobile.presentation.common.LocalThemeMode
 import dev.chungjungsoo.gptmobile.presentation.common.Route
 import dev.chungjungsoo.gptmobile.presentation.common.SetupNavGraph
 import dev.chungjungsoo.gptmobile.presentation.common.ThemeSettingProvider
 import dev.chungjungsoo.gptmobile.presentation.theme.GPTMobileTheme
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.receiveAsFlow
+import dev.chungjungsoo.gptmobile.presentation.ui.setting.ToolConnectionsViewModel
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     private val mainViewModel: MainViewModel by viewModels()
+    private val toolConnectionsViewModel: ToolConnectionsViewModel by viewModels()
     private lateinit var authTabLauncher: ActivityResultLauncher<Intent>
-    private val oauthCallbackChannel = Channel<String?>(Channel.BUFFERED)
-    private val oauthCallbacks = oauthCallbackChannel.receiveAsFlow()
     private var lastOAuthCallback: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -65,19 +63,19 @@ class MainActivity : ComponentActivity() {
                 ) {
                     SetupNavGraph(
                         navController = navController,
-                        oauthCallbacks = oauthCallbacks,
+                        toolConnectionsViewModel = toolConnectionsViewModel,
                         onLaunchOAuth = ::launchOAuth
                     )
                 }
             }
         }
-        intent?.data?.toString()?.takeIf { it.startsWith("$MCP_OAUTH_SCHEME://$MCP_OAUTH_HOST/mcp/") }?.let(::dispatchOAuthCallback)
+        dispatchOAuthIntent(intent)
     }
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        intent.data?.toString()?.let(::dispatchOAuthCallback)
+        dispatchOAuthIntent(intent)
     }
 
     private fun launchOAuth(authorizationUri: String) {
@@ -92,8 +90,12 @@ class MainActivity : ComponentActivity() {
     private fun dispatchOAuthCallback(callbackUri: String?) {
         if (callbackUri != null && callbackUri == lastOAuthCallback) return
         lastOAuthCallback = callbackUri
-        oauthCallbackChannel.trySend(callbackUri)
+        toolConnectionsViewModel.completeOAuthCallback(callbackUri)
     }
+
+    private fun dispatchOAuthIntent(intent: Intent?) = intent?.data?.toString()
+        ?.takeIf(::isMcpOAuthCallbackUri)
+        ?.let(::dispatchOAuthCallback)
 
     private fun NavHostController.checkForExistingSettings() {
         lifecycleScope.launch {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/main/MainActivity.kt
@@ -83,7 +83,11 @@ class MainActivity : ComponentActivity() {
         try {
             AuthTabIntent.Builder().build().launch(authTabLauncher, uri, MCP_OAUTH_SCHEME)
         } catch (_: ActivityNotFoundException) {
-            CustomTabsIntent.Builder().build().launchUrl(this, uri)
+            try {
+                CustomTabsIntent.Builder().build().launchUrl(this, uri)
+            } catch (_: ActivityNotFoundException) {
+                toolConnectionsViewModel.failOAuthLaunch()
+            }
         }
     }
 

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/main/MainActivity.kt
@@ -1,10 +1,16 @@
 package dev.chungjungsoo.gptmobile.presentation.ui.main
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.viewModels
+import androidx.browser.auth.AuthTabIntent
+import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -12,18 +18,26 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
+import dev.chungjungsoo.gptmobile.data.agent.tool.MCP_OAUTH_HOST
+import dev.chungjungsoo.gptmobile.data.agent.tool.MCP_OAUTH_SCHEME
 import dev.chungjungsoo.gptmobile.presentation.common.LocalDynamicTheme
 import dev.chungjungsoo.gptmobile.presentation.common.LocalThemeMode
 import dev.chungjungsoo.gptmobile.presentation.common.Route
 import dev.chungjungsoo.gptmobile.presentation.common.SetupNavGraph
 import dev.chungjungsoo.gptmobile.presentation.common.ThemeSettingProvider
 import dev.chungjungsoo.gptmobile.presentation.theme.GPTMobileTheme
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     private val mainViewModel: MainViewModel by viewModels()
+    private lateinit var authTabLauncher: ActivityResultLauncher<Intent>
+    private val oauthCallbackChannel = Channel<String?>(Channel.BUFFERED)
+    private val oauthCallbacks = oauthCallbackChannel.receiveAsFlow()
+    private var lastOAuthCallback: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen().apply {
@@ -33,6 +47,9 @@ class MainActivity : ComponentActivity() {
         }
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        authTabLauncher = AuthTabIntent.registerActivityResultLauncher(this) { result ->
+            dispatchOAuthCallback(result.resultUri?.toString())
+        }
 
         // Prevent keyboard from pushing the entire view up - composable handles insets via imePadding()
         window.setSoftInputMode(android.view.WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING)
@@ -46,10 +63,36 @@ class MainActivity : ComponentActivity() {
                     dynamicTheme = LocalDynamicTheme.current,
                     themeMode = LocalThemeMode.current
                 ) {
-                    SetupNavGraph(navController)
+                    SetupNavGraph(
+                        navController = navController,
+                        oauthCallbacks = oauthCallbacks,
+                        onLaunchOAuth = ::launchOAuth
+                    )
                 }
             }
         }
+        intent?.data?.toString()?.takeIf { it.startsWith("$MCP_OAUTH_SCHEME://$MCP_OAUTH_HOST/mcp/") }?.let(::dispatchOAuthCallback)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        intent.data?.toString()?.let(::dispatchOAuthCallback)
+    }
+
+    private fun launchOAuth(authorizationUri: String) {
+        val uri = Uri.parse(authorizationUri)
+        try {
+            AuthTabIntent.Builder().build().launch(authTabLauncher, uri, MCP_OAUTH_SCHEME)
+        } catch (_: ActivityNotFoundException) {
+            CustomTabsIntent.Builder().build().launchUrl(this, uri)
+        }
+    }
+
+    private fun dispatchOAuthCallback(callbackUri: String?) {
+        if (callbackUri != null && callbackUri == lastOAuthCallback) return
+        lastOAuthCallback = callbackUri
+        oauthCallbackChannel.trySend(callbackUri)
     }
 
     private fun NavHostController.checkForExistingSettings() {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.material.icons.automirrored.filled.Label
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -274,6 +276,15 @@ fun PlatformSettingScreen(
                     isChecked = toolBindingState.readUrlEnabled,
                     onCheckedChange = settingViewModel::toggleReadUrl
                 )
+                SettingItem(
+                    modifier = Modifier.height(64.dp),
+                    title = stringResource(R.string.mcp_tools),
+                    description = stringResource(R.string.mcp_tools_assigned, toolBindingState.selectedMcpTools.size),
+                    enabled = platformData.enabled,
+                    onItemClick = settingViewModel::openMcpToolsDialog,
+                    showTrailingIcon = true,
+                    showLeadingIcon = false
+                )
 
                 PlatformNameDialog(dialogState, platformData.name, settingViewModel)
                 APIUrlDialog(dialogState, platformData.apiUrl, settingViewModel)
@@ -286,6 +297,7 @@ fun PlatformSettingScreen(
                 GeminiSafetySettingsDialog(dialogState, platformData, settingViewModel)
                 DeletePlatformDialog(dialogState, settingViewModel)
                 SearchBackendDialog(toolBindingState, settingViewModel)
+                McpToolsDialog(toolBindingState, settingViewModel)
                 toolBindingState.errorMessage?.let { message ->
                     AlertDialog(
                         title = { Text(stringResource(R.string.error)) },
@@ -301,6 +313,72 @@ fun PlatformSettingScreen(
             }
         }
     }
+}
+
+@Composable
+private fun McpToolsDialog(
+    toolBindingState: PlatformSettingViewModel.ToolBindingState,
+    settingViewModel: PlatformSettingViewModel
+) {
+    if (!toolBindingState.isMcpToolsDialogOpen) return
+    AlertDialog(
+        title = { Text(stringResource(R.string.mcp_tools)) },
+        text = {
+            Column(Modifier.verticalScroll(rememberScrollState())) {
+                when {
+                    toolBindingState.mcpConnections.isEmpty() -> Text(stringResource(R.string.no_mcp_connections))
+
+                    toolBindingState.isMcpToolsLoading -> CircularProgressIndicator(
+                        modifier = Modifier
+                            .padding(16.dp)
+                            .semantics { contentDescription = "Discovering MCP tools" }
+                    )
+
+                    toolBindingState.mcpToolOptions.isEmpty() -> Text(stringResource(R.string.no_mcp_tools))
+
+                    else -> toolBindingState.mcpToolOptions.forEach { option ->
+                        val selected = toolBindingState.pendingMcpTools.any {
+                            it.connectionUid == option.connectionUid && it.toolName == option.toolName
+                        }
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .toggleable(
+                                    value = selected,
+                                    onValueChange = { settingViewModel.toggleMcpTool(option.connectionUid, option.toolName) }
+                                )
+                                .semantics { contentDescription = "${option.connectionName} ${option.toolName}" }
+                                .padding(vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Checkbox(checked = selected, onCheckedChange = null)
+                            Column(Modifier.padding(start = 8.dp)) {
+                                Text("${option.connectionName} · ${option.toolName}")
+                                Text(
+                                    option.description ?: option.modelToolName,
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        onDismissRequest = settingViewModel::closeMcpToolsDialog,
+        confirmButton = {
+            TextButton(
+                enabled = !toolBindingState.isMcpToolsLoading,
+                onClick = settingViewModel::saveMcpTools
+            ) {
+                Text(stringResource(R.string.save))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = settingViewModel::closeMcpToolsDialog) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingViewModel.kt
@@ -17,6 +17,8 @@ import dev.chungjungsoo.gptmobile.data.repository.ToolBindingSelection
 import dev.chungjungsoo.gptmobile.data.repository.ToolConnectionRepository
 import dev.chungjungsoo.gptmobile.data.security.SecretVault
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -49,6 +51,7 @@ class PlatformSettingViewModel @Inject constructor(
 
     private val _toolBindingState = MutableStateFlow(ToolBindingState())
     val toolBindingState: StateFlow<ToolBindingState> = _toolBindingState.asStateFlow()
+    private var mcpDiscoveryJob: Job? = null
 
     init {
         loadPlatform()
@@ -258,6 +261,7 @@ class PlatformSettingViewModel @Inject constructor(
     }
 
     fun openMcpToolsDialog() {
+        mcpDiscoveryJob?.cancel()
         val connections = _toolBindingState.value.mcpConnections
         _toolBindingState.update {
             it.copy(
@@ -268,37 +272,52 @@ class PlatformSettingViewModel @Inject constructor(
                 errorMessage = null
             )
         }
-        viewModelScope.launch {
-            val results = coroutineScope {
-                connections.map { connection ->
-                    async { connection to runCatching { agentToolResolver.discoverMcpTools(connection) } }
-                }.awaitAll()
-            }
-            val options = results.flatMap { (connection, result) ->
-                result.getOrDefault(emptyList()).map { tool ->
-                    McpToolOption(
-                        connectionUid = connection.connectionUid,
-                        connectionName = connection.name,
-                        toolName = tool.name,
-                        modelToolName = namespaceMcpToolName(connection.alias, tool.name),
-                        description = tool.description
+        mcpDiscoveryJob = viewModelScope.launch {
+            try {
+                val results = coroutineScope {
+                    connections.map { connection ->
+                        async { connection to discoverMcpTools(connection) }
+                    }.awaitAll()
+                }
+                val options = results.flatMap { (connection, result) ->
+                    result.getOrDefault(emptyList()).map { tool ->
+                        McpToolOption(
+                            connectionUid = connection.connectionUid,
+                            connectionName = connection.name,
+                            toolName = tool.name,
+                            modelToolName = namespaceMcpToolName(connection.alias, tool.name),
+                            description = tool.description
+                        )
+                    }
+                }.sortedWith(compareBy<McpToolOption> { it.connectionName }.thenBy { it.toolName })
+                val failures = results.mapNotNull { (connection, result) ->
+                    result.exceptionOrNull()?.let { "${connection.name}: ${it.message ?: "discovery failed"}" }
+                }
+                _toolBindingState.update {
+                    it.copy(
+                        isMcpToolsLoading = false,
+                        mcpToolOptions = options,
+                        errorMessage = failures.takeIf(List<String>::isNotEmpty)?.joinToString("\n")
                     )
                 }
-            }.sortedWith(compareBy<McpToolOption> { it.connectionName }.thenBy { it.toolName })
-            val failures = results.mapNotNull { (connection, result) ->
-                result.exceptionOrNull()?.let { "${connection.name}: ${it.message ?: "discovery failed"}" }
-            }
-            _toolBindingState.update {
-                it.copy(
-                    isMcpToolsLoading = false,
-                    mcpToolOptions = options,
-                    errorMessage = failures.takeIf(List<String>::isNotEmpty)?.joinToString("\n")
-                )
+            } catch (error: CancellationException) {
+                throw error
             }
         }
     }
 
-    fun closeMcpToolsDialog() = _toolBindingState.update { it.copy(isMcpToolsDialogOpen = false) }
+    fun closeMcpToolsDialog() {
+        mcpDiscoveryJob?.cancel()
+        _toolBindingState.update { it.copy(isMcpToolsDialogOpen = false, isMcpToolsLoading = false) }
+    }
+
+    private suspend fun discoverMcpTools(connection: ToolConnection) = try {
+        Result.success(agentToolResolver.discoverMcpTools(connection))
+    } catch (error: CancellationException) {
+        throw error
+    } catch (error: Exception) {
+        Result.failure(error)
+    }
 
     fun toggleMcpTool(connectionUid: String, toolName: String) {
         val selection = ToolBindingSelection(connectionUid, toolName)

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.chungjungsoo.gptmobile.data.agent.tool.AgentToolResolver
+import dev.chungjungsoo.gptmobile.data.agent.tool.namespaceMcpToolName
 import dev.chungjungsoo.gptmobile.data.database.dao.ToolConnectionDao
 import dev.chungjungsoo.gptmobile.data.database.entity.BuiltInAgentTool
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
@@ -11,9 +13,13 @@ import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnection
 import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnectionType
 import dev.chungjungsoo.gptmobile.data.model.GeminiSafetySettings
 import dev.chungjungsoo.gptmobile.data.repository.SettingRepository
+import dev.chungjungsoo.gptmobile.data.repository.ToolBindingSelection
 import dev.chungjungsoo.gptmobile.data.repository.ToolConnectionRepository
 import dev.chungjungsoo.gptmobile.data.security.SecretVault
 import javax.inject.Inject
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -25,6 +31,7 @@ class PlatformSettingViewModel @Inject constructor(
     private val settingRepository: SettingRepository,
     toolConnectionDao: ToolConnectionDao,
     secretVault: SecretVault,
+    private val agentToolResolver: AgentToolResolver,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     private val toolConnectionRepository = ToolConnectionRepository(toolConnectionDao, secretVault)
@@ -59,12 +66,22 @@ class PlatformSettingViewModel @Inject constructor(
     fun loadToolBindings() {
         viewModelScope.launch {
             runCatching {
-                val connections = toolConnectionRepository.listConnections().filter { it.type in WEB_SEARCH_TYPES }
+                val connections = toolConnectionRepository.listConnections()
                 val bindings = toolConnectionRepository.listBindingsByProfile(platformUid)
+                val mcpConnections = connections.filter { it.type == ToolConnectionType.MCP }
+                val mcpConnectionUids = mcpConnections.map { it.connectionUid }.toSet()
+                val searchConnections = connections.filter { it.type in WEB_SEARCH_TYPES }
+                val searchConnectionUids = searchConnections.map { it.connectionUid }.toSet()
                 ToolBindingState(
-                    searchConnections = connections,
-                    selectedSearchConnectionUid = bindings.firstOrNull { it.toolName == WEB_SEARCH_TOOL }?.connectionUid,
-                    readUrlEnabled = bindings.any { it.toolName == BuiltInAgentTool.READ_URL },
+                    searchConnections = searchConnections,
+                    selectedSearchConnectionUid = bindings.firstOrNull {
+                        it.toolName == WEB_SEARCH_TOOL && it.connectionUid in searchConnectionUids
+                    }?.connectionUid,
+                    readUrlEnabled = bindings.any { it.toolName == BuiltInAgentTool.READ_URL && it.connectionUid == null },
+                    mcpConnections = mcpConnections,
+                    selectedMcpTools = bindings.mapNotNull { binding ->
+                        binding.connectionUid?.takeIf { it in mcpConnectionUids }?.let { ToolBindingSelection(it, binding.toolName) }
+                    }.toSet(),
                     errorMessage = null
                 )
             }.onSuccess { state ->
@@ -240,6 +257,78 @@ class PlatformSettingViewModel @Inject constructor(
         }
     }
 
+    fun openMcpToolsDialog() {
+        val connections = _toolBindingState.value.mcpConnections
+        _toolBindingState.update {
+            it.copy(
+                isMcpToolsDialogOpen = true,
+                isMcpToolsLoading = true,
+                mcpToolOptions = emptyList(),
+                pendingMcpTools = it.selectedMcpTools,
+                errorMessage = null
+            )
+        }
+        viewModelScope.launch {
+            val results = coroutineScope {
+                connections.map { connection ->
+                    async { connection to runCatching { agentToolResolver.discoverMcpTools(connection) } }
+                }.awaitAll()
+            }
+            val options = results.flatMap { (connection, result) ->
+                result.getOrDefault(emptyList()).map { tool ->
+                    McpToolOption(
+                        connectionUid = connection.connectionUid,
+                        connectionName = connection.name,
+                        toolName = tool.name,
+                        modelToolName = namespaceMcpToolName(connection.alias, tool.name),
+                        description = tool.description
+                    )
+                }
+            }.sortedWith(compareBy<McpToolOption> { it.connectionName }.thenBy { it.toolName })
+            val failures = results.mapNotNull { (connection, result) ->
+                result.exceptionOrNull()?.let { "${connection.name}: ${it.message ?: "discovery failed"}" }
+            }
+            _toolBindingState.update {
+                it.copy(
+                    isMcpToolsLoading = false,
+                    mcpToolOptions = options,
+                    errorMessage = failures.takeIf(List<String>::isNotEmpty)?.joinToString("\n")
+                )
+            }
+        }
+    }
+
+    fun closeMcpToolsDialog() = _toolBindingState.update { it.copy(isMcpToolsDialogOpen = false) }
+
+    fun toggleMcpTool(connectionUid: String, toolName: String) {
+        val selection = ToolBindingSelection(connectionUid, toolName)
+        _toolBindingState.update { state ->
+            state.copy(
+                pendingMcpTools = state.pendingMcpTools.toMutableSet().apply {
+                    if (!add(selection)) remove(selection)
+                }
+            )
+        }
+    }
+
+    fun saveMcpTools() {
+        val selections = _toolBindingState.value.pendingMcpTools
+            .sortedWith(compareBy<ToolBindingSelection> { it.connectionUid }.thenBy { it.toolName })
+        viewModelScope.launch {
+            runCatching { toolConnectionRepository.replaceMcpToolBindings(platformUid, selections) }
+                .onSuccess {
+                    _toolBindingState.update {
+                        it.copy(
+                            selectedMcpTools = selections.toSet(),
+                            isMcpToolsDialogOpen = false,
+                            errorMessage = null
+                        )
+                    }
+                }
+                .onFailure(::showToolError)
+        }
+    }
+
     private fun showToolError(error: Throwable) {
         _toolBindingState.update { it.copy(errorMessage = error.message ?: "Tool binding update failed.") }
     }
@@ -261,8 +350,22 @@ class PlatformSettingViewModel @Inject constructor(
         val searchConnections: List<ToolConnection> = emptyList(),
         val selectedSearchConnectionUid: String? = null,
         val readUrlEnabled: Boolean = false,
+        val mcpConnections: List<ToolConnection> = emptyList(),
+        val selectedMcpTools: Set<ToolBindingSelection> = emptySet(),
+        val pendingMcpTools: Set<ToolBindingSelection> = emptySet(),
+        val mcpToolOptions: List<McpToolOption> = emptyList(),
         val isSearchBackendDialogOpen: Boolean = false,
+        val isMcpToolsDialogOpen: Boolean = false,
+        val isMcpToolsLoading: Boolean = false,
         val errorMessage: String? = null
+    )
+
+    data class McpToolOption(
+        val connectionUid: String,
+        val connectionName: String,
+        val toolName: String,
+        val modelToolName: String,
+        val description: String?
     )
 
     companion object {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsScreen.kt
@@ -2,10 +2,12 @@ package dev.chungjungsoo.gptmobile.presentation.ui.setting
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -35,8 +37,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.error
@@ -46,7 +46,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -58,12 +57,15 @@ import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnectionAuthType
 import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnectionType
 import dev.chungjungsoo.gptmobile.presentation.common.RadioItem
 import dev.chungjungsoo.gptmobile.util.pinnedExitUntilCollapsedScrollBehavior
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ToolConnectionsScreen(
     modifier: Modifier = Modifier,
     viewModel: ToolConnectionsViewModel = hiltViewModel(),
     onLaunchOAuth: (String) -> Unit = {},
+    onAddConnectionClick: () -> Unit,
+    onEditConnectionClick: (String) -> Unit,
     onNavigationClick: () -> Unit
 ) {
     val scrollState = rememberScrollState()
@@ -71,8 +73,6 @@ fun ToolConnectionsScreen(
         canScroll = { scrollState.canScrollForward || scrollState.canScrollBackward }
     )
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    var editingConnection by remember { mutableStateOf<ToolConnection?>(null) }
-    var showForm by remember { mutableStateOf(false) }
     var deletingConnection by remember { mutableStateOf<ToolConnection?>(null) }
     val lifecycleOwner = LocalLifecycleOwner.current
 
@@ -97,10 +97,7 @@ fun ToolConnectionsScreen(
             ToolConnectionsTopBar(
                 scrollBehavior = scrollBehavior,
                 onNavigationClick = onNavigationClick,
-                onAddClick = {
-                    editingConnection = null
-                    showForm = true
-                }
+                onAddClick = onAddConnectionClick
             )
         }
     ) { innerPadding ->
@@ -112,37 +109,12 @@ fun ToolConnectionsScreen(
             uiState.connections.forEach { connection ->
                 ToolConnectionItem(
                     connection = connection,
-                    onEditClick = {
-                        editingConnection = connection
-                        showForm = true
-                    },
+                    onEditClick = { onEditConnectionClick(connection.connectionUid) },
                     onOAuthClick = { viewModel.startOAuth(connection.connectionUid) },
                     onDeleteClick = { deletingConnection = connection }
                 )
             }
         }
-    }
-
-    if (showForm) {
-        ToolConnectionDialog(
-            connection = editingConnection,
-            onDismissRequest = { showForm = false },
-            onSave = { provider, name, alias, endpoint, authType, credential, clientId, allowCleartext, clearCredential ->
-                viewModel.saveConnection(
-                    editingConnection,
-                    provider,
-                    name,
-                    alias,
-                    endpoint,
-                    authType,
-                    credential,
-                    clientId,
-                    allowCleartext,
-                    clearCredential
-                )
-                showForm = false
-            }
-        )
     }
 
     deletingConnection?.let { connection ->
@@ -167,6 +139,149 @@ fun ToolConnectionsScreen(
                     Text(stringResource(R.string.cancel))
                 }
             }
+        )
+    }
+
+    uiState.errorMessage?.let { message ->
+        AlertDialog(
+            title = { Text(stringResource(R.string.error)) },
+            text = { Text(message) },
+            onDismissRequest = viewModel::clearError,
+            confirmButton = {
+                TextButton(onClick = viewModel::clearError) {
+                    Text(stringResource(R.string.close))
+                }
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ToolConnectionEditorScreen(
+    modifier: Modifier = Modifier,
+    connectionUid: String? = null,
+    viewModel: ToolConnectionsViewModel = hiltViewModel(),
+    onNavigationClick: () -> Unit,
+    onSaveComplete: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val connection = connectionUid?.let { uid -> uiState.connections.firstOrNull { it.connectionUid == uid } }
+    val isEditing = connectionUid != null
+    val title = stringResource(if (isEditing) R.string.edit_tool_connection else R.string.add_tool_connection)
+    val scrollState = rememberScrollState()
+    val scrollBehavior = pinnedExitUntilCollapsedScrollBehavior(
+        canScroll = { scrollState.canScrollForward || scrollState.canScrollBackward }
+    )
+
+    if (isEditing && connection == null) {
+        Scaffold(
+            modifier = modifier,
+            topBar = {
+                ToolConnectionEditorTopBar(
+                    title = title,
+                    scrollBehavior = scrollBehavior,
+                    isSaveEnabled = false,
+                    onNavigationClick = onNavigationClick,
+                    onSaveClick = {}
+                )
+            }
+        ) { innerPadding ->
+            Text(
+                modifier = Modifier
+                    .padding(innerPadding)
+                    .padding(24.dp),
+                text = stringResource(R.string.tool_connection_not_found)
+            )
+        }
+        return
+    }
+
+    val initialProvider = ToolConnectionsViewModel.providers.firstOrNull { it.type == connection?.type }
+        ?: ToolConnectionsViewModel.providers.first()
+    var provider by remember(connection?.connectionUid) { mutableStateOf(initialProvider) }
+    var name by remember(connection?.connectionUid) { mutableStateOf(connection?.name.orEmpty()) }
+    var alias by remember(connection?.connectionUid) { mutableStateOf(connection?.alias.orEmpty()) }
+    var endpoint by remember(connection?.connectionUid) { mutableStateOf(connection?.endpointUrl.orEmpty()) }
+    var authType by remember(connection?.connectionUid) { mutableStateOf(connection?.authType ?: initialProvider.authType) }
+    var credential by remember(connection?.connectionUid) { mutableStateOf("") }
+    var oauthClientId by remember(connection?.connectionUid) { mutableStateOf(connection?.oauthClientId.orEmpty()) }
+    var allowCleartext by remember(connection?.connectionUid) { mutableStateOf(connection?.allowCleartext == true) }
+    var clearCredential by remember(connection?.connectionUid) { mutableStateOf(false) }
+    val normalizedAlias = ToolConnectionsViewModel.normalizeAlias(alias)
+    val isMcp = provider.type == ToolConnectionType.MCP
+    val actualEndpoint = if (isMcp) endpoint else provider.endpointUrl
+    val isEndpointValid = !isMcp || ToolConnectionsViewModel.isValidMcpEndpoint(actualEndpoint, allowCleartext)
+    val isSaveEnabled = name.isNotBlank() && ToolConnectionsViewModel.isValidAlias(normalizedAlias) && isEndpointValid
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            ToolConnectionEditorTopBar(
+                title = title,
+                scrollBehavior = scrollBehavior,
+                isSaveEnabled = isSaveEnabled,
+                onNavigationClick = onNavigationClick,
+                onSaveClick = {
+                    viewModel.saveConnection(
+                        connection,
+                        provider,
+                        name,
+                        alias,
+                        actualEndpoint,
+                        authType,
+                        credential,
+                        oauthClientId,
+                        allowCleartext,
+                        clearCredential,
+                        onSaveComplete
+                    )
+                }
+            )
+        }
+    ) { innerPadding ->
+        ToolConnectionForm(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(scrollState)
+                .imePadding()
+                .padding(horizontal = 24.dp),
+            connection = connection,
+            provider = provider,
+            name = name,
+            alias = alias,
+            endpoint = actualEndpoint,
+            authType = authType,
+            credential = credential,
+            oauthClientId = oauthClientId,
+            allowCleartext = allowCleartext,
+            clearCredential = clearCredential,
+            isMcp = isMcp,
+            isEndpointValid = isEndpointValid,
+            onProviderChange = { option ->
+                provider = option
+                if (name.isBlank()) name = option.label
+                if (alias.isBlank()) alias = ToolConnectionsViewModel.normalizeAlias(option.label)
+                endpoint = if (option.type == ToolConnectionType.MCP) {
+                    connection?.endpointUrl?.takeIf { connection.type == ToolConnectionType.MCP }.orEmpty()
+                } else {
+                    option.endpointUrl
+                }
+                authType = if (option.type == ToolConnectionType.MCP) {
+                    connection?.authType?.takeIf { connection.type == ToolConnectionType.MCP } ?: ToolConnectionAuthType.NONE
+                } else {
+                    option.authType
+                }
+            },
+            onNameChange = { name = it },
+            onAliasChange = { alias = it },
+            onEndpointChange = { endpoint = it },
+            onAuthTypeChange = { authType = it },
+            onCredentialChange = { credential = it },
+            onOAuthClientIdChange = { oauthClientId = it },
+            onAllowCleartextChange = { allowCleartext = it },
+            onClearCredentialChange = { clearCredential = it }
         )
     }
 
@@ -279,25 +394,30 @@ private fun ToolConnectionItem(
 }
 
 @Composable
-private fun ToolConnectionDialog(
+private fun ToolConnectionForm(
+    modifier: Modifier = Modifier,
     connection: ToolConnection?,
-    onDismissRequest: () -> Unit,
-    onSave: (ToolConnectionProvider, String, String, String, String, String, String, Boolean, Boolean) -> Unit
+    provider: ToolConnectionProvider,
+    name: String,
+    alias: String,
+    endpoint: String,
+    authType: String,
+    credential: String,
+    oauthClientId: String,
+    allowCleartext: Boolean,
+    clearCredential: Boolean,
+    isMcp: Boolean,
+    isEndpointValid: Boolean,
+    onProviderChange: (ToolConnectionProvider) -> Unit,
+    onNameChange: (String) -> Unit,
+    onAliasChange: (String) -> Unit,
+    onEndpointChange: (String) -> Unit,
+    onAuthTypeChange: (String) -> Unit,
+    onCredentialChange: (String) -> Unit,
+    onOAuthClientIdChange: (String) -> Unit,
+    onAllowCleartextChange: (Boolean) -> Unit,
+    onClearCredentialChange: (Boolean) -> Unit
 ) {
-    val initialProvider = ToolConnectionsViewModel.providers.firstOrNull { it.type == connection?.type }
-        ?: ToolConnectionsViewModel.providers.first()
-    var provider by remember { mutableStateOf(initialProvider) }
-    var name by remember { mutableStateOf(connection?.name.orEmpty()) }
-    var alias by remember { mutableStateOf(connection?.alias.orEmpty()) }
-    var endpoint by remember { mutableStateOf(connection?.endpointUrl.orEmpty()) }
-    var authType by remember { mutableStateOf(connection?.authType ?: initialProvider.authType) }
-    var credential by remember { mutableStateOf("") }
-    var oauthClientId by remember { mutableStateOf(connection?.oauthClientId.orEmpty()) }
-    var allowCleartext by remember { mutableStateOf(connection?.allowCleartext == true) }
-    var clearCredential by remember { mutableStateOf(false) }
-    val configuration = LocalWindowInfo.current
-    val screenWidth = with(LocalDensity.current) { configuration.containerSize.width.toDp() }
-    val screenHeight = with(LocalDensity.current) { configuration.containerSize.height.toDp() }
     val normalizedAlias = ToolConnectionsViewModel.normalizeAlias(alias)
     val isAliasInvalid = alias.isNotBlank() && !ToolConnectionsViewModel.isValidAlias(normalizedAlias)
     val aliasDescription = stringResource(R.string.stable_alias_description)
@@ -309,192 +429,209 @@ private fun ToolConnectionDialog(
     val bearerToken = stringResource(R.string.bearer_token)
     val clearCredentialDescription = stringResource(R.string.clear_saved_credential)
     val allowCleartextDescription = stringResource(R.string.allow_cleartext_mcp_endpoint)
-    val isMcp = provider.type == ToolConnectionType.MCP
-    val actualEndpoint = if (isMcp) endpoint else provider.endpointUrl
-    val isEndpointValid = !isMcp || ToolConnectionsViewModel.isValidMcpEndpoint(actualEndpoint, allowCleartext)
-
-    AlertDialog(
-        properties = DialogProperties(usePlatformDefaultWidth = false),
-        modifier = Modifier
-            .widthIn(max = screenWidth - 40.dp)
-            .heightIn(max = screenHeight - 80.dp),
-        title = { Text(if (connection == null) stringResource(R.string.add_tool_connection) else stringResource(R.string.edit_tool_connection)) },
-        text = {
-            Column(Modifier.verticalScroll(rememberScrollState())) {
-                ToolConnectionsViewModel.providers.forEach { option ->
-                    val providerDescription = stringResource(R.string.provider_option, option.label)
-                    RadioItem(
-                        modifier = Modifier.semantics { contentDescription = providerDescription },
-                        title = option.label,
-                        description = option.endpointUrl.ifBlank { streamableHttp },
-                        value = option.type,
-                        selected = provider.type == option.type
-                    ) {
-                        provider = option
-                        if (name.isBlank()) name = option.label
-                        if (alias.isBlank()) alias = ToolConnectionsViewModel.normalizeAlias(option.label)
-                        endpoint = if (option.type == ToolConnectionType.MCP) {
-                            connection?.endpointUrl?.takeIf { connection.type == ToolConnectionType.MCP }.orEmpty()
-                        } else {
-                            option.endpointUrl
-                        }
-                        authType = if (option.type == ToolConnectionType.MCP) {
-                            connection?.authType?.takeIf { connection.type == ToolConnectionType.MCP } ?: ToolConnectionAuthType.NONE
-                        } else {
-                            option.authType
-                        }
-                    }
-                }
-                OutlinedTextField(
+    Column(modifier) {
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.tool_connection_provider_section),
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        ToolConnectionsViewModel.providers.forEach { option ->
+            val providerDescription = stringResource(R.string.provider_option, option.label)
+            RadioItem(
+                modifier = Modifier.semantics { contentDescription = providerDescription },
+                title = option.label,
+                description = option.endpointUrl.ifBlank { streamableHttp },
+                value = option.type,
+                selected = provider.type == option.type
+            ) { onProviderChange(option) }
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = stringResource(R.string.tool_connection_details_section),
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        OutlinedTextField(
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { contentDescription = connectionName },
+            value = name,
+            onValueChange = onNameChange,
+            label = { Text(stringResource(R.string.name)) },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
+        )
+        OutlinedTextField(
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics {
+                    contentDescription = stableAlias
+                    if (isAliasInvalid) error(aliasError)
+                },
+            value = alias,
+            onValueChange = onAliasChange,
+            label = { Text(stringResource(R.string.stable_alias)) },
+            isError = isAliasInvalid,
+            supportingText = { Text(if (isAliasInvalid) aliasError else aliasDescription) },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
+        )
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth(),
+            value = endpoint,
+            onValueChange = onEndpointChange,
+            enabled = isMcp,
+            label = { Text(stringResource(R.string.api_url)) },
+            isError = !isEndpointValid,
+            supportingText = if (isMcp && !isEndpointValid) {
+                { Text(stringResource(R.string.mcp_endpoint_error)) }
+            } else {
+                null
+            },
+            singleLine = true
+        )
+        if (isMcp) {
+            Text(
+                text = stringResource(R.string.authentication),
+                style = MaterialTheme.typography.titleSmall,
+                modifier = Modifier.padding(top = 12.dp)
+            )
+            listOf(
+                ToolConnectionAuthType.NONE to stringResource(R.string.public_access),
+                ToolConnectionAuthType.BEARER to bearerToken,
+                ToolConnectionAuthType.OAUTH to stringResource(R.string.oauth_pkce)
+            ).forEach { (value, label) ->
+                val authDescription = stringResource(R.string.mcp_authentication, label)
+                RadioItem(
+                    modifier = Modifier.semantics { contentDescription = authDescription },
+                    title = label,
+                    description = null,
+                    value = value,
+                    selected = authType == value
+                ) { onAuthTypeChange(value) }
+            }
+            if (endpoint.startsWith("http://", ignoreCase = true)) {
+                Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .semantics { contentDescription = connectionName },
-                    value = name,
-                    onValueChange = { name = it },
-                    label = { Text(stringResource(R.string.name)) },
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
-                )
-                OutlinedTextField(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .semantics {
-                            contentDescription = stableAlias
-                            if (isAliasInvalid) error(aliasError)
-                        },
-                    value = alias,
-                    onValueChange = { alias = it },
-                    label = { Text(stringResource(R.string.stable_alias)) },
-                    isError = isAliasInvalid,
-                    supportingText = { Text(if (isAliasInvalid) aliasError else aliasDescription) },
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
-                )
-                OutlinedTextField(
-                    modifier = Modifier.fillMaxWidth(),
-                    value = actualEndpoint,
-                    onValueChange = { endpoint = it },
-                    enabled = isMcp,
-                    label = { Text(stringResource(R.string.api_url)) },
-                    isError = !isEndpointValid,
-                    supportingText = if (isMcp && !isEndpointValid) {
-                        { Text(stringResource(R.string.mcp_endpoint_error)) }
-                    } else {
-                        null
-                    },
-                    singleLine = true
-                )
-                if (isMcp) {
-                    Text(stringResource(R.string.authentication), style = MaterialTheme.typography.titleSmall, modifier = Modifier.padding(top = 12.dp))
-                    listOf(
-                        ToolConnectionAuthType.NONE to stringResource(R.string.public_access),
-                        ToolConnectionAuthType.BEARER to bearerToken,
-                        ToolConnectionAuthType.OAUTH to stringResource(R.string.oauth_pkce)
-                    ).forEach { (value, label) ->
-                        val authDescription = stringResource(R.string.mcp_authentication, label)
-                        RadioItem(
-                            modifier = Modifier.semantics { contentDescription = authDescription },
-                            title = label,
-                            description = null,
-                            value = value,
-                            selected = authType == value
-                        ) { authType = value }
-                    }
-                    if (actualEndpoint.startsWith("http://", ignoreCase = true)) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .semantics { contentDescription = allowCleartextDescription }
-                                .padding(top = 8.dp)
-                        ) {
-                            Checkbox(checked = allowCleartext, onCheckedChange = { allowCleartext = it })
-                            Text(
-                                modifier = Modifier.padding(top = 12.dp),
-                                text = stringResource(R.string.cleartext_mcp_warning)
-                            )
-                        }
-                    }
-                }
-                if (!isMcp || authType == ToolConnectionAuthType.BEARER) {
-                    OutlinedTextField(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .semantics { contentDescription = if (isMcp) bearerToken else apiKey },
-                        value = credential,
-                        onValueChange = { credential = it },
-                        label = { Text(if (isMcp) bearerToken else apiKey) },
-                        supportingText = {
-                            Text(
-                                if (connection?.secretRef == null) {
-                                    stringResource(R.string.credential_not_set)
-                                } else {
-                                    stringResource(R.string.blank_key_preserves_credential)
-                                }
-                            )
-                        },
-                        singleLine = true,
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Done),
-                        visualTransformation = PasswordVisualTransformation()
+                        .semantics { contentDescription = allowCleartextDescription }
+                        .padding(top = 8.dp)
+                ) {
+                    Checkbox(checked = allowCleartext, onCheckedChange = onAllowCleartextChange)
+                    Text(
+                        modifier = Modifier.padding(top = 12.dp),
+                        text = stringResource(R.string.cleartext_mcp_warning)
                     )
-                }
-                if (isMcp && authType == ToolConnectionAuthType.OAUTH) {
-                    val oauthClientIdDescription = stringResource(R.string.oauth_client_id)
-                    OutlinedTextField(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .semantics { contentDescription = oauthClientIdDescription },
-                        value = oauthClientId,
-                        onValueChange = { oauthClientId = it },
-                        label = { Text(stringResource(R.string.preregistered_client_id_optional)) },
-                        supportingText = { Text(stringResource(R.string.dynamic_client_registration_hint)) },
-                        singleLine = true
-                    )
-                }
-                if (connection != null && (!isMcp || authType != ToolConnectionAuthType.NONE)) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .semantics { contentDescription = clearCredentialDescription }
-                            .padding(top = 8.dp)
-                    ) {
-                        Checkbox(
-                            checked = clearCredential,
-                            onCheckedChange = { clearCredential = it }
-                        )
-                        Text(
-                            modifier = Modifier.padding(top = 12.dp),
-                            text = stringResource(R.string.clear_saved_credential)
-                        )
-                    }
                 }
             }
-        },
-        onDismissRequest = onDismissRequest,
-        confirmButton = {
-            TextButton(
-                enabled = name.isNotBlank() && ToolConnectionsViewModel.isValidAlias(normalizedAlias) && isEndpointValid,
-                onClick = {
-                    onSave(
-                        provider,
-                        name,
-                        alias,
-                        actualEndpoint,
-                        authType,
-                        credential,
-                        oauthClientId,
-                        allowCleartext,
-                        clearCredential
+        }
+        if (!isMcp || authType != ToolConnectionAuthType.NONE) {
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = stringResource(R.string.tool_connection_credentials_section),
+                style = MaterialTheme.typography.titleSmall,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+        }
+        if (!isMcp || authType == ToolConnectionAuthType.BEARER) {
+            OutlinedTextField(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = if (isMcp) bearerToken else apiKey },
+                value = credential,
+                onValueChange = onCredentialChange,
+                label = { Text(if (isMcp) bearerToken else apiKey) },
+                supportingText = {
+                    Text(
+                        if (connection?.secretRef == null) {
+                            stringResource(R.string.credential_not_set)
+                        } else {
+                            stringResource(R.string.blank_key_preserves_credential)
+                        }
                     )
-                }
+                },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Done),
+                visualTransformation = PasswordVisualTransformation()
+            )
+        }
+        if (isMcp && authType == ToolConnectionAuthType.OAUTH) {
+            val oauthClientIdDescription = stringResource(R.string.oauth_client_id)
+            OutlinedTextField(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = oauthClientIdDescription },
+                value = oauthClientId,
+                onValueChange = onOAuthClientIdChange,
+                label = { Text(stringResource(R.string.preregistered_client_id_optional)) },
+                supportingText = { Text(stringResource(R.string.dynamic_client_registration_hint)) },
+                singleLine = true
+            )
+        }
+        if (connection != null && (!isMcp || authType != ToolConnectionAuthType.NONE)) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { contentDescription = clearCredentialDescription }
+                    .padding(top = 8.dp)
+            ) {
+                Checkbox(
+                    checked = clearCredential,
+                    onCheckedChange = onClearCredentialChange
+                )
+                Text(
+                    modifier = Modifier.padding(top = 12.dp),
+                    text = stringResource(R.string.clear_saved_credential)
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ToolConnectionEditorTopBar(
+    title: String,
+    scrollBehavior: TopAppBarScrollBehavior,
+    isSaveEnabled: Boolean,
+    onNavigationClick: () -> Unit,
+    onSaveClick: () -> Unit
+) {
+    val saveDescription = stringResource(R.string.save_tool_connection)
+
+    LargeTopAppBar(
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = MaterialTheme.colorScheme.background,
+            titleContentColor = MaterialTheme.colorScheme.onBackground
+        ),
+        title = {
+            Text(
+                modifier = Modifier.padding(4.dp),
+                text = title,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        },
+        navigationIcon = {
+            IconButton(
+                modifier = Modifier.padding(4.dp),
+                onClick = onNavigationClick
+            ) {
+                Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.go_back))
+            }
+        },
+        actions = {
+            TextButton(
+                modifier = Modifier.semantics { contentDescription = saveDescription },
+                enabled = isSaveEnabled,
+                onClick = onSaveClick
             ) {
                 Text(stringResource(R.string.save))
             }
         },
-        dismissButton = {
-            TextButton(onClick = onDismissRequest) {
-                Text(stringResource(R.string.cancel))
-            }
-        }
+        scrollBehavior = scrollBehavior
     )
 }
 

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -53,14 +54,20 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.chungjungsoo.gptmobile.R
 import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnection
+import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnectionAuthType
+import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnectionType
 import dev.chungjungsoo.gptmobile.presentation.common.RadioItem
 import dev.chungjungsoo.gptmobile.util.pinnedExitUntilCollapsedScrollBehavior
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ToolConnectionsScreen(
     modifier: Modifier = Modifier,
     viewModel: ToolConnectionsViewModel = hiltViewModel(),
+    oauthCallbacks: Flow<String?> = emptyFlow(),
+    onLaunchOAuth: (String) -> Unit = {},
     onNavigationClick: () -> Unit
 ) {
     val scrollState = rememberScrollState()
@@ -72,6 +79,13 @@ fun ToolConnectionsScreen(
     var showForm by remember { mutableStateOf(false) }
     var deletingConnection by remember { mutableStateOf<ToolConnection?>(null) }
     val lifecycleOwner = LocalLifecycleOwner.current
+
+    LaunchedEffect(viewModel) {
+        viewModel.oauthLaunches.collect(onLaunchOAuth)
+    }
+    LaunchedEffect(viewModel, oauthCallbacks) {
+        oauthCallbacks.collect(viewModel::completeOAuthCallback)
+    }
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
@@ -110,6 +124,7 @@ fun ToolConnectionsScreen(
                         editingConnection = connection
                         showForm = true
                     },
+                    onOAuthClick = { viewModel.startOAuth(connection.connectionUid) },
                     onDeleteClick = { deletingConnection = connection }
                 )
             }
@@ -120,8 +135,19 @@ fun ToolConnectionsScreen(
         ToolConnectionDialog(
             connection = editingConnection,
             onDismissRequest = { showForm = false },
-            onSave = { provider, name, alias, apiKey, clearCredential ->
-                viewModel.saveConnection(editingConnection, provider, name, alias, apiKey, clearCredential)
+            onSave = { provider, name, alias, endpoint, authType, credential, clientId, allowCleartext, clearCredential ->
+                viewModel.saveConnection(
+                    editingConnection,
+                    provider,
+                    name,
+                    alias,
+                    endpoint,
+                    authType,
+                    credential,
+                    clientId,
+                    allowCleartext,
+                    clearCredential
+                )
                 showForm = false
             }
         )
@@ -180,7 +206,7 @@ private fun ToolConnectionsTopBar(
         title = {
             Text(
                 modifier = Modifier.padding(4.dp),
-                text = stringResource(R.string.web_tools),
+                text = stringResource(R.string.tool_connections),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
@@ -189,7 +215,7 @@ private fun ToolConnectionsTopBar(
             IconButton(
                 modifier = Modifier
                     .padding(4.dp)
-                    .semantics { contentDescription = "Navigate back from Web tools" },
+                    .semantics { contentDescription = "Navigate back from Tool connections" },
                 onClick = onNavigationClick
             ) {
                 Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.go_back))
@@ -197,7 +223,7 @@ private fun ToolConnectionsTopBar(
         },
         actions = {
             IconButton(
-                modifier = Modifier.semantics { contentDescription = "Add web tool connection" },
+                modifier = Modifier.semantics { contentDescription = "Add tool connection" },
                 onClick = onAddClick
             ) {
                 Icon(imageVector = Icons.Filled.Add, contentDescription = stringResource(R.string.add_tool_connection))
@@ -211,6 +237,7 @@ private fun ToolConnectionsTopBar(
 private fun ToolConnectionItem(
     connection: ToolConnection,
     onEditClick: () -> Unit,
+    onOAuthClick: () -> Unit,
     onDeleteClick: () -> Unit
 ) {
     ListItem(
@@ -221,10 +248,12 @@ private fun ToolConnectionItem(
         supportingContent = {
             Text(
                 text = "${providerLabel(connection.type)} • ${connection.alias} • ${connection.endpointUrl.orEmpty()} • ${
-                    if (connection.secretRef == null) {
-                        stringResource(R.string.credential_not_set)
-                    } else {
-                        stringResource(R.string.credential_set)
+                    when {
+                        connection.authType == ToolConnectionAuthType.NONE -> "Public"
+                        connection.authType == ToolConnectionAuthType.OAUTH && connection.secretRef == null -> "OAuth not connected"
+                        connection.authType == ToolConnectionAuthType.OAUTH -> "OAuth connected"
+                        connection.secretRef == null -> stringResource(R.string.credential_not_set)
+                        else -> stringResource(R.string.credential_set)
                     }
                 }",
                 overflow = TextOverflow.Ellipsis
@@ -232,6 +261,14 @@ private fun ToolConnectionItem(
         },
         trailingContent = {
             Row {
+                if (connection.type == ToolConnectionType.MCP && connection.authType == ToolConnectionAuthType.OAUTH) {
+                    TextButton(
+                        modifier = Modifier.semantics { contentDescription = "Connect ${connection.name} with OAuth" },
+                        onClick = onOAuthClick
+                    ) {
+                        Text(if (connection.secretRef == null) "Connect" else "Reconnect")
+                    }
+                }
                 TextButton(
                     modifier = Modifier.semantics { contentDescription = "Edit ${connection.name}" },
                     onClick = onEditClick
@@ -253,14 +290,18 @@ private fun ToolConnectionItem(
 private fun ToolConnectionDialog(
     connection: ToolConnection?,
     onDismissRequest: () -> Unit,
-    onSave: (WebToolProvider, String, String, String, Boolean) -> Unit
+    onSave: (ToolConnectionProvider, String, String, String, String, String, String, Boolean, Boolean) -> Unit
 ) {
     val initialProvider = ToolConnectionsViewModel.providers.firstOrNull { it.type == connection?.type }
         ?: ToolConnectionsViewModel.providers.first()
     var provider by remember { mutableStateOf(initialProvider) }
     var name by remember { mutableStateOf(connection?.name.orEmpty()) }
     var alias by remember { mutableStateOf(connection?.alias.orEmpty()) }
-    var apiKey by remember { mutableStateOf("") }
+    var endpoint by remember { mutableStateOf(connection?.endpointUrl.orEmpty()) }
+    var authType by remember { mutableStateOf(connection?.authType ?: initialProvider.authType) }
+    var credential by remember { mutableStateOf("") }
+    var oauthClientId by remember { mutableStateOf(connection?.oauthClientId.orEmpty()) }
+    var allowCleartext by remember { mutableStateOf(connection?.allowCleartext == true) }
     var clearCredential by remember { mutableStateOf(false) }
     val configuration = LocalWindowInfo.current
     val screenWidth = with(LocalDensity.current) { configuration.containerSize.width.toDp() }
@@ -269,6 +310,9 @@ private fun ToolConnectionDialog(
     val isAliasInvalid = alias.isNotBlank() && !ToolConnectionsViewModel.isValidAlias(normalizedAlias)
     val aliasDescription = stringResource(R.string.stable_alias_description)
     val aliasError = stringResource(R.string.stable_alias_error)
+    val isMcp = provider.type == ToolConnectionType.MCP
+    val actualEndpoint = if (isMcp) endpoint else provider.endpointUrl
+    val isEndpointValid = !isMcp || ToolConnectionsViewModel.isValidMcpEndpoint(actualEndpoint, allowCleartext)
 
     AlertDialog(
         properties = DialogProperties(usePlatformDefaultWidth = false),
@@ -282,13 +326,23 @@ private fun ToolConnectionDialog(
                     RadioItem(
                         modifier = Modifier.semantics { contentDescription = "Provider ${option.label}" },
                         title = option.label,
-                        description = option.endpointUrl,
+                        description = option.endpointUrl.ifBlank { "Streamable HTTP" },
                         value = option.type,
                         selected = provider.type == option.type
                     ) {
                         provider = option
                         if (name.isBlank()) name = option.label
                         if (alias.isBlank()) alias = ToolConnectionsViewModel.normalizeAlias(option.label)
+                        endpoint = if (option.type == ToolConnectionType.MCP) {
+                            connection?.endpointUrl?.takeIf { connection.type == ToolConnectionType.MCP }.orEmpty()
+                        } else {
+                            option.endpointUrl
+                        }
+                        authType = if (option.type == ToolConnectionType.MCP) {
+                            connection?.authType?.takeIf { connection.type == ToolConnectionType.MCP } ?: ToolConnectionAuthType.NONE
+                        } else {
+                            option.authType
+                        }
                     }
                 }
                 OutlinedTextField(
@@ -318,37 +372,87 @@ private fun ToolConnectionDialog(
                 )
                 OutlinedTextField(
                     modifier = Modifier.fillMaxWidth(),
-                    value = provider.endpointUrl,
-                    onValueChange = {},
-                    enabled = false,
+                    value = actualEndpoint,
+                    onValueChange = { endpoint = it },
+                    enabled = isMcp,
                     label = { Text(stringResource(R.string.api_url)) },
+                    isError = !isEndpointValid,
+                    supportingText = if (isMcp && !isEndpointValid) {
+                        { Text("Use an HTTP(S) MCP endpoint. Approve cleartext HTTP below.") }
+                    } else {
+                        null
+                    },
                     singleLine = true
                 )
-                OutlinedTextField(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .semantics { contentDescription = "API key" },
-                    value = apiKey,
-                    onValueChange = { apiKey = it },
-                    label = { Text(stringResource(R.string.api_key)) },
-                    supportingText = {
-                        Text(
-                            if (connection?.secretRef == null) {
-                                stringResource(R.string.credential_not_set)
-                            } else {
-                                stringResource(R.string.blank_key_preserves_credential)
-                            }
-                        )
-                    },
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Done),
-                    visualTransformation = PasswordVisualTransformation()
-                )
-                if (connection != null) {
+                if (isMcp) {
+                    Text("Authentication", style = MaterialTheme.typography.titleSmall, modifier = Modifier.padding(top = 12.dp))
+                    listOf(
+                        ToolConnectionAuthType.NONE to "Public",
+                        ToolConnectionAuthType.BEARER to "Bearer token",
+                        ToolConnectionAuthType.OAUTH to "OAuth 2.1 / PKCE"
+                    ).forEach { (value, label) ->
+                        RadioItem(
+                            modifier = Modifier.semantics { contentDescription = "MCP authentication $label" },
+                            title = label,
+                            description = null,
+                            value = value,
+                            selected = authType == value
+                        ) { authType = value }
+                    }
+                    if (actualEndpoint.startsWith("http://")) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .semantics { contentDescription = "Allow cleartext MCP endpoint" }
+                                .padding(top = 8.dp)
+                        ) {
+                            Checkbox(checked = allowCleartext, onCheckedChange = { allowCleartext = it })
+                            Text(
+                                modifier = Modifier.padding(top = 12.dp),
+                                text = "Allow unencrypted HTTP. Credentials and tool data could be intercepted."
+                            )
+                        }
+                    }
+                }
+                if (!isMcp || authType == ToolConnectionAuthType.BEARER) {
+                    OutlinedTextField(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .semantics { contentDescription = if (isMcp) "Bearer token" else "API key" },
+                        value = credential,
+                        onValueChange = { credential = it },
+                        label = { Text(if (isMcp) "Bearer token" else stringResource(R.string.api_key)) },
+                        supportingText = {
+                            Text(
+                                if (connection?.secretRef == null) {
+                                    stringResource(R.string.credential_not_set)
+                                } else {
+                                    stringResource(R.string.blank_key_preserves_credential)
+                                }
+                            )
+                        },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Done),
+                        visualTransformation = PasswordVisualTransformation()
+                    )
+                }
+                if (isMcp && authType == ToolConnectionAuthType.OAUTH) {
+                    OutlinedTextField(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .semantics { contentDescription = "OAuth client ID" },
+                        value = oauthClientId,
+                        onValueChange = { oauthClientId = it },
+                        label = { Text("Pre-registered client ID (optional)") },
+                        supportingText = { Text("Leave blank to use Dynamic Client Registration when advertised.") },
+                        singleLine = true
+                    )
+                }
+                if (connection != null && (!isMcp || authType != ToolConnectionAuthType.NONE)) {
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .semantics { contentDescription = "Clear API key" }
+                            .semantics { contentDescription = "Clear saved credential" }
                             .padding(top = 8.dp)
                     ) {
                         Checkbox(
@@ -357,7 +461,7 @@ private fun ToolConnectionDialog(
                         )
                         Text(
                             modifier = Modifier.padding(top = 12.dp),
-                            text = stringResource(R.string.clear_api_key)
+                            text = stringResource(R.string.clear_saved_credential)
                         )
                     }
                 }
@@ -366,8 +470,20 @@ private fun ToolConnectionDialog(
         onDismissRequest = onDismissRequest,
         confirmButton = {
             TextButton(
-                enabled = name.isNotBlank() && ToolConnectionsViewModel.isValidAlias(normalizedAlias),
-                onClick = { onSave(provider, name, alias, apiKey, clearCredential) }
+                enabled = name.isNotBlank() && ToolConnectionsViewModel.isValidAlias(normalizedAlias) && isEndpointValid,
+                onClick = {
+                    onSave(
+                        provider,
+                        name,
+                        alias,
+                        actualEndpoint,
+                        authType,
+                        credential,
+                        oauthClientId,
+                        allowCleartext,
+                        clearCredential
+                    )
+                }
             ) {
                 Text(stringResource(R.string.save))
             }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsScreen.kt
@@ -58,15 +58,11 @@ import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnectionAuthType
 import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnectionType
 import dev.chungjungsoo.gptmobile.presentation.common.RadioItem
 import dev.chungjungsoo.gptmobile.util.pinnedExitUntilCollapsedScrollBehavior
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ToolConnectionsScreen(
     modifier: Modifier = Modifier,
     viewModel: ToolConnectionsViewModel = hiltViewModel(),
-    oauthCallbacks: Flow<String?> = emptyFlow(),
     onLaunchOAuth: (String) -> Unit = {},
     onNavigationClick: () -> Unit
 ) {
@@ -83,10 +79,6 @@ fun ToolConnectionsScreen(
     LaunchedEffect(viewModel) {
         viewModel.oauthLaunches.collect(onLaunchOAuth)
     }
-    LaunchedEffect(viewModel, oauthCallbacks) {
-        oauthCallbacks.collect(viewModel::completeOAuthCallback)
-    }
-
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
@@ -154,13 +146,14 @@ fun ToolConnectionsScreen(
     }
 
     deletingConnection?.let { connection ->
+        val deleteDescription = stringResource(R.string.delete_named_connection, connection.name)
         AlertDialog(
             title = { Text(stringResource(R.string.delete_tool_connection)) },
             text = { Text(stringResource(R.string.delete_tool_connection_confirmation, connection.name)) },
             onDismissRequest = { deletingConnection = null },
             confirmButton = {
                 TextButton(
-                    modifier = Modifier.semantics { contentDescription = "Delete ${connection.name}" },
+                    modifier = Modifier.semantics { contentDescription = deleteDescription },
                     onClick = {
                         viewModel.deleteConnection(connection.connectionUid)
                         deletingConnection = null
@@ -213,9 +206,7 @@ private fun ToolConnectionsTopBar(
         },
         navigationIcon = {
             IconButton(
-                modifier = Modifier
-                    .padding(4.dp)
-                    .semantics { contentDescription = "Navigate back from Tool connections" },
+                modifier = Modifier.padding(4.dp),
                 onClick = onNavigationClick
             ) {
                 Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.go_back))
@@ -223,7 +214,6 @@ private fun ToolConnectionsTopBar(
         },
         actions = {
             IconButton(
-                modifier = Modifier.semantics { contentDescription = "Add tool connection" },
                 onClick = onAddClick
             ) {
                 Icon(imageVector = Icons.Filled.Add, contentDescription = stringResource(R.string.add_tool_connection))
@@ -240,22 +230,24 @@ private fun ToolConnectionItem(
     onOAuthClick: () -> Unit,
     onDeleteClick: () -> Unit
 ) {
+    val editDescription = stringResource(R.string.edit_named_connection, connection.name)
+    val deleteDescription = stringResource(R.string.delete_named_connection, connection.name)
+    val connectDescription = stringResource(R.string.connect_with_oauth, connection.name)
+    val credentialStatus = when {
+        connection.authType == ToolConnectionAuthType.NONE -> stringResource(R.string.public_access)
+        connection.authType == ToolConnectionAuthType.OAUTH && connection.secretRef == null -> stringResource(R.string.oauth_not_connected)
+        connection.authType == ToolConnectionAuthType.OAUTH -> stringResource(R.string.oauth_connected)
+        connection.secretRef == null -> stringResource(R.string.credential_not_set)
+        else -> stringResource(R.string.credential_set)
+    }
     ListItem(
         modifier = Modifier
             .fillMaxWidth()
-            .semantics { contentDescription = "Edit ${connection.name}" },
+            .semantics { contentDescription = editDescription },
         headlineContent = { Text(connection.name, overflow = TextOverflow.Ellipsis) },
         supportingContent = {
             Text(
-                text = "${providerLabel(connection.type)} • ${connection.alias} • ${connection.endpointUrl.orEmpty()} • ${
-                    when {
-                        connection.authType == ToolConnectionAuthType.NONE -> "Public"
-                        connection.authType == ToolConnectionAuthType.OAUTH && connection.secretRef == null -> "OAuth not connected"
-                        connection.authType == ToolConnectionAuthType.OAUTH -> "OAuth connected"
-                        connection.secretRef == null -> stringResource(R.string.credential_not_set)
-                        else -> stringResource(R.string.credential_set)
-                    }
-                }",
+                text = "${providerLabel(connection.type)} • ${connection.alias} • ${connection.endpointUrl.orEmpty()} • $credentialStatus",
                 overflow = TextOverflow.Ellipsis
             )
         },
@@ -263,20 +255,20 @@ private fun ToolConnectionItem(
             Row {
                 if (connection.type == ToolConnectionType.MCP && connection.authType == ToolConnectionAuthType.OAUTH) {
                     TextButton(
-                        modifier = Modifier.semantics { contentDescription = "Connect ${connection.name} with OAuth" },
+                        modifier = Modifier.semantics { contentDescription = connectDescription },
                         onClick = onOAuthClick
                     ) {
-                        Text(if (connection.secretRef == null) "Connect" else "Reconnect")
+                        Text(stringResource(if (connection.secretRef == null) R.string.connect else R.string.reconnect))
                     }
                 }
                 TextButton(
-                    modifier = Modifier.semantics { contentDescription = "Edit ${connection.name}" },
+                    modifier = Modifier.semantics { contentDescription = editDescription },
                     onClick = onEditClick
                 ) {
                     Text(stringResource(R.string.edit))
                 }
                 IconButton(
-                    modifier = Modifier.semantics { contentDescription = "Delete ${connection.name}" },
+                    modifier = Modifier.semantics { contentDescription = deleteDescription },
                     onClick = onDeleteClick
                 ) {
                     Icon(imageVector = Icons.Filled.Delete, contentDescription = stringResource(R.string.delete))
@@ -310,6 +302,13 @@ private fun ToolConnectionDialog(
     val isAliasInvalid = alias.isNotBlank() && !ToolConnectionsViewModel.isValidAlias(normalizedAlias)
     val aliasDescription = stringResource(R.string.stable_alias_description)
     val aliasError = stringResource(R.string.stable_alias_error)
+    val streamableHttp = stringResource(R.string.streamable_http)
+    val connectionName = stringResource(R.string.connection_name)
+    val stableAlias = stringResource(R.string.stable_alias)
+    val apiKey = stringResource(R.string.api_key)
+    val bearerToken = stringResource(R.string.bearer_token)
+    val clearCredentialDescription = stringResource(R.string.clear_saved_credential)
+    val allowCleartextDescription = stringResource(R.string.allow_cleartext_mcp_endpoint)
     val isMcp = provider.type == ToolConnectionType.MCP
     val actualEndpoint = if (isMcp) endpoint else provider.endpointUrl
     val isEndpointValid = !isMcp || ToolConnectionsViewModel.isValidMcpEndpoint(actualEndpoint, allowCleartext)
@@ -323,10 +322,11 @@ private fun ToolConnectionDialog(
         text = {
             Column(Modifier.verticalScroll(rememberScrollState())) {
                 ToolConnectionsViewModel.providers.forEach { option ->
+                    val providerDescription = stringResource(R.string.provider_option, option.label)
                     RadioItem(
-                        modifier = Modifier.semantics { contentDescription = "Provider ${option.label}" },
+                        modifier = Modifier.semantics { contentDescription = providerDescription },
                         title = option.label,
-                        description = option.endpointUrl.ifBlank { "Streamable HTTP" },
+                        description = option.endpointUrl.ifBlank { streamableHttp },
                         value = option.type,
                         selected = provider.type == option.type
                     ) {
@@ -348,7 +348,7 @@ private fun ToolConnectionDialog(
                 OutlinedTextField(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .semantics { contentDescription = "Connection name" },
+                        .semantics { contentDescription = connectionName },
                     value = name,
                     onValueChange = { name = it },
                     label = { Text(stringResource(R.string.name)) },
@@ -359,7 +359,7 @@ private fun ToolConnectionDialog(
                     modifier = Modifier
                         .fillMaxWidth()
                         .semantics {
-                            contentDescription = "Stable alias"
+                            contentDescription = stableAlias
                             if (isAliasInvalid) error(aliasError)
                         },
                     value = alias,
@@ -378,38 +378,39 @@ private fun ToolConnectionDialog(
                     label = { Text(stringResource(R.string.api_url)) },
                     isError = !isEndpointValid,
                     supportingText = if (isMcp && !isEndpointValid) {
-                        { Text("Use an HTTP(S) MCP endpoint. Approve cleartext HTTP below.") }
+                        { Text(stringResource(R.string.mcp_endpoint_error)) }
                     } else {
                         null
                     },
                     singleLine = true
                 )
                 if (isMcp) {
-                    Text("Authentication", style = MaterialTheme.typography.titleSmall, modifier = Modifier.padding(top = 12.dp))
+                    Text(stringResource(R.string.authentication), style = MaterialTheme.typography.titleSmall, modifier = Modifier.padding(top = 12.dp))
                     listOf(
-                        ToolConnectionAuthType.NONE to "Public",
-                        ToolConnectionAuthType.BEARER to "Bearer token",
-                        ToolConnectionAuthType.OAUTH to "OAuth 2.1 / PKCE"
+                        ToolConnectionAuthType.NONE to stringResource(R.string.public_access),
+                        ToolConnectionAuthType.BEARER to bearerToken,
+                        ToolConnectionAuthType.OAUTH to stringResource(R.string.oauth_pkce)
                     ).forEach { (value, label) ->
+                        val authDescription = stringResource(R.string.mcp_authentication, label)
                         RadioItem(
-                            modifier = Modifier.semantics { contentDescription = "MCP authentication $label" },
+                            modifier = Modifier.semantics { contentDescription = authDescription },
                             title = label,
                             description = null,
                             value = value,
                             selected = authType == value
                         ) { authType = value }
                     }
-                    if (actualEndpoint.startsWith("http://")) {
+                    if (actualEndpoint.startsWith("http://", ignoreCase = true)) {
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .semantics { contentDescription = "Allow cleartext MCP endpoint" }
+                                .semantics { contentDescription = allowCleartextDescription }
                                 .padding(top = 8.dp)
                         ) {
                             Checkbox(checked = allowCleartext, onCheckedChange = { allowCleartext = it })
                             Text(
                                 modifier = Modifier.padding(top = 12.dp),
-                                text = "Allow unencrypted HTTP. Credentials and tool data could be intercepted."
+                                text = stringResource(R.string.cleartext_mcp_warning)
                             )
                         }
                     }
@@ -418,10 +419,10 @@ private fun ToolConnectionDialog(
                     OutlinedTextField(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .semantics { contentDescription = if (isMcp) "Bearer token" else "API key" },
+                            .semantics { contentDescription = if (isMcp) bearerToken else apiKey },
                         value = credential,
                         onValueChange = { credential = it },
-                        label = { Text(if (isMcp) "Bearer token" else stringResource(R.string.api_key)) },
+                        label = { Text(if (isMcp) bearerToken else apiKey) },
                         supportingText = {
                             Text(
                                 if (connection?.secretRef == null) {
@@ -437,14 +438,15 @@ private fun ToolConnectionDialog(
                     )
                 }
                 if (isMcp && authType == ToolConnectionAuthType.OAUTH) {
+                    val oauthClientIdDescription = stringResource(R.string.oauth_client_id)
                     OutlinedTextField(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .semantics { contentDescription = "OAuth client ID" },
+                            .semantics { contentDescription = oauthClientIdDescription },
                         value = oauthClientId,
                         onValueChange = { oauthClientId = it },
-                        label = { Text("Pre-registered client ID (optional)") },
-                        supportingText = { Text("Leave blank to use Dynamic Client Registration when advertised.") },
+                        label = { Text(stringResource(R.string.preregistered_client_id_optional)) },
+                        supportingText = { Text(stringResource(R.string.dynamic_client_registration_hint)) },
                         singleLine = true
                     )
                 }
@@ -452,7 +454,7 @@ private fun ToolConnectionDialog(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .semantics { contentDescription = "Clear saved credential" }
+                            .semantics { contentDescription = clearCredentialDescription }
                             .padding(top = 8.dp)
                     ) {
                         Checkbox(

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsScreen.kt
@@ -420,6 +420,11 @@ private fun ToolConnectionForm(
 ) {
     val normalizedAlias = ToolConnectionsViewModel.normalizeAlias(alias)
     val isAliasInvalid = alias.isNotBlank() && !ToolConnectionsViewModel.isValidAlias(normalizedAlias)
+    val blankCredentialPreserves = connection?.secretRef != null &&
+        connection.type == provider.type &&
+        connection.endpointUrl == endpoint &&
+        connection.authType == authType &&
+        (authType != ToolConnectionAuthType.OAUTH || connection.oauthClientId == oauthClientId.trim().takeIf(String::isNotEmpty))
     val aliasDescription = stringResource(R.string.stable_alias_description)
     val aliasError = stringResource(R.string.stable_alias_error)
     val streamableHttp = stringResource(R.string.streamable_http)
@@ -546,8 +551,10 @@ private fun ToolConnectionForm(
                     Text(
                         if (connection?.secretRef == null) {
                             stringResource(R.string.credential_not_set)
-                        } else {
+                        } else if (blankCredentialPreserves) {
                             stringResource(R.string.blank_key_preserves_credential)
+                        } else {
+                            stringResource(R.string.credential_not_set)
                         }
                     )
                 },

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsViewModel.kt
@@ -123,8 +123,8 @@ class ToolConnectionsViewModel @Inject constructor(
                     credential = credentialBytes,
                     clearCredential = (shouldClear || shouldClearCredential) && credentialBytes == null
                 )
-                mcpClientManager.close(connection.connectionUid)
             }.onSuccess {
+                runCatching { mcpClientManager.close(connection.connectionUid) }
                 refresh()
                 onSuccess()
             }.onFailure(::showError)
@@ -172,6 +172,10 @@ class ToolConnectionsViewModel @Inject constructor(
                 .onFailure(::showError)
             _uiState.update { it.copy(isOAuthBusy = false) }
         }
+    }
+
+    fun failOAuthLaunch(message: String = "No browser is available for OAuth authorization.") {
+        _uiState.update { it.copy(isOAuthBusy = false, errorMessage = message) }
     }
 
     private fun showError(error: Throwable) {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsViewModel.kt
@@ -3,6 +3,10 @@ package dev.chungjungsoo.gptmobile.presentation.ui.setting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.chungjungsoo.gptmobile.data.agent.tool.McpClientManager
+import dev.chungjungsoo.gptmobile.data.agent.tool.McpOAuthCoordinator
+import dev.chungjungsoo.gptmobile.data.agent.tool.mcpOAuthConnectionUid
+import dev.chungjungsoo.gptmobile.data.agent.tool.mcpOAuthRedirectUri
 import dev.chungjungsoo.gptmobile.data.database.dao.ToolConnectionDao
 import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnection
 import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnectionAuthType
@@ -12,8 +16,11 @@ import dev.chungjungsoo.gptmobile.data.security.SecretVault
 import java.util.Locale
 import java.util.UUID
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -21,12 +28,16 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class ToolConnectionsViewModel @Inject constructor(
     toolConnectionDao: ToolConnectionDao,
-    secretVault: SecretVault
+    secretVault: SecretVault,
+    private val oauthCoordinator: McpOAuthCoordinator,
+    private val mcpClientManager: McpClientManager
 ) : ViewModel() {
     private val toolConnectionRepository = ToolConnectionRepository(toolConnectionDao, secretVault)
 
     private val _uiState = MutableStateFlow(ToolConnectionsUiState())
     val uiState: StateFlow<ToolConnectionsUiState> = _uiState.asStateFlow()
+    private val _oauthLaunches = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    val oauthLaunches: SharedFlow<String> = _oauthLaunches.asSharedFlow()
 
     init {
         refresh()
@@ -34,7 +45,7 @@ class ToolConnectionsViewModel @Inject constructor(
 
     fun refresh() {
         viewModelScope.launch {
-            runCatching { toolConnectionRepository.listConnections().filter { it.type in WEB_SEARCH_TYPES } }
+            runCatching { toolConnectionRepository.listConnections() }
                 .onSuccess { connections ->
                     _uiState.update { it.copy(connections = connections, errorMessage = null) }
                 }
@@ -44,10 +55,14 @@ class ToolConnectionsViewModel @Inject constructor(
 
     fun saveConnection(
         existing: ToolConnection?,
-        provider: WebToolProvider,
+        provider: ToolConnectionProvider,
         name: String,
         alias: String,
-        apiKey: String,
+        endpointUrl: String,
+        authType: String,
+        credential: String,
+        oauthClientId: String,
+        allowCleartext: Boolean,
         clearCredential: Boolean
     ) {
         val normalizedAlias = normalizeAlias(alias)
@@ -59,32 +74,53 @@ class ToolConnectionsViewModel @Inject constructor(
             _uiState.update { it.copy(errorMessage = "Name is required.") }
             return
         }
+        val actualEndpoint = if (provider.type == ToolConnectionType.MCP) endpointUrl.trim() else provider.endpointUrl
+        val actualAuthType = if (provider.type == ToolConnectionType.MCP) authType else provider.authType
+        if (provider.type == ToolConnectionType.MCP && !isValidMcpEndpoint(actualEndpoint, allowCleartext)) {
+            _uiState.update { it.copy(errorMessage = "MCP endpoint must be HTTP(S); cleartext HTTP requires explicit approval.") }
+            return
+        }
         viewModelScope.launch {
             val now = System.currentTimeMillis() / 1000
+            val clientId = oauthClientId.trim().takeIf { actualAuthType == ToolConnectionAuthType.OAUTH && it.isNotEmpty() }
             val connection = ToolConnection(
                 connectionUid = existing?.connectionUid ?: UUID.randomUUID().toString(),
                 name = name.trim(),
                 alias = normalizedAlias,
                 type = provider.type,
-                endpointUrl = provider.endpointUrl,
-                authType = provider.authType,
+                endpointUrl = actualEndpoint,
+                authType = actualAuthType,
                 secretRef = existing?.secretRef,
-                oauthClientId = null,
+                oauthClientId = clientId,
+                allowCleartext = provider.type == ToolConnectionType.MCP && actualEndpoint.startsWith("http://") && allowCleartext,
                 createdAt = existing?.createdAt ?: now,
                 updatedAt = now
             )
+            val metadataChanged = existing?.let {
+                it.type != connection.type ||
+                    it.endpointUrl != connection.endpointUrl ||
+                    it.authType != connection.authType ||
+                    it.oauthClientId != connection.oauthClientId
+            } == true
+            val shouldClear = clearCredential || actualAuthType == ToolConnectionAuthType.NONE || metadataChanged
+            val credentialBytes = if (actualAuthType == ToolConnectionAuthType.BEARER || actualAuthType == ToolConnectionAuthType.API_KEY) {
+                credentialInput(credential, clearCredential)
+            } else {
+                null
+            }
             runCatching {
                 val shouldClearCredential = shouldClearCredential(
                     existingType = existing?.type,
                     providerType = provider.type,
-                    apiKey = apiKey,
+                    credential = credential,
                     clearCredential = clearCredential
                 )
                 toolConnectionRepository.upsertConnection(
                     connection = connection,
-                    credential = credentialInput(apiKey, shouldClearCredential),
-                    clearCredential = shouldClearCredential
+                    credential = credentialBytes,
+                    clearCredential = (shouldClear || shouldClearCredential) && credentialBytes == null
                 )
+                mcpClientManager.close(connection.connectionUid)
             }.onSuccess {
                 refresh()
             }.onFailure(::showError)
@@ -93,7 +129,10 @@ class ToolConnectionsViewModel @Inject constructor(
 
     fun deleteConnection(connectionUid: String) {
         viewModelScope.launch {
-            runCatching { toolConnectionRepository.deleteConnection(connectionUid) }
+            runCatching {
+                mcpClientManager.close(connectionUid)
+                toolConnectionRepository.deleteConnection(connectionUid)
+            }
                 .onSuccess { refresh() }
                 .onFailure(::showError)
         }
@@ -101,23 +140,53 @@ class ToolConnectionsViewModel @Inject constructor(
 
     fun clearError() = _uiState.update { it.copy(errorMessage = null) }
 
+    fun startOAuth(connectionUid: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isOAuthBusy = true, errorMessage = null) }
+            runCatching { oauthCoordinator.begin(connectionUid, mcpOAuthRedirectUri(connectionUid)) }
+                .onSuccess { authorizationUri -> _oauthLaunches.emit(authorizationUri) }
+                .onFailure(::showError)
+            _uiState.update { it.copy(isOAuthBusy = false) }
+        }
+    }
+
+    fun completeOAuthCallback(callbackUri: String?) {
+        if (callbackUri == null) {
+            _uiState.update { it.copy(errorMessage = "OAuth authorization was canceled.") }
+            return
+        }
+        val connectionUid = mcpOAuthConnectionUid(callbackUri)
+        if (connectionUid == null) {
+            _uiState.update { it.copy(errorMessage = "OAuth callback URI is invalid.") }
+            return
+        }
+        viewModelScope.launch {
+            _uiState.update { it.copy(isOAuthBusy = true, errorMessage = null) }
+            runCatching { oauthCoordinator.complete(connectionUid, callbackUri) }
+                .onSuccess { refresh() }
+                .onFailure(::showError)
+            _uiState.update { it.copy(isOAuthBusy = false) }
+        }
+    }
+
     private fun showError(error: Throwable) {
         _uiState.update { it.copy(errorMessage = error.message ?: "Tool connection update failed.") }
     }
 
     data class ToolConnectionsUiState(
         val connections: List<ToolConnection> = emptyList(),
+        val isOAuthBusy: Boolean = false,
         val errorMessage: String? = null
     )
 
     companion object {
         val providers = listOf(
-            WebToolProvider("Firecrawl", ToolConnectionType.FIRECRAWL, "https://api.firecrawl.dev/v2/search", ToolConnectionAuthType.BEARER),
-            WebToolProvider("Perplexity", ToolConnectionType.PERPLEXITY, "https://api.perplexity.ai/search", ToolConnectionAuthType.BEARER),
-            WebToolProvider("Exa", ToolConnectionType.EXA, "https://api.exa.ai/search", ToolConnectionAuthType.API_KEY)
+            ToolConnectionProvider("Firecrawl", ToolConnectionType.FIRECRAWL, "https://api.firecrawl.dev/v2/search", ToolConnectionAuthType.BEARER),
+            ToolConnectionProvider("Perplexity", ToolConnectionType.PERPLEXITY, "https://api.perplexity.ai/search", ToolConnectionAuthType.BEARER),
+            ToolConnectionProvider("Exa", ToolConnectionType.EXA, "https://api.exa.ai/search", ToolConnectionAuthType.API_KEY),
+            ToolConnectionProvider("MCP server", ToolConnectionType.MCP, "", ToolConnectionAuthType.NONE)
         )
 
-        private val WEB_SEARCH_TYPES = providers.map { it.type }.toSet()
         private val aliasRegex = Regex("[a-z][a-z0-9_]{0,31}")
 
         fun normalizeAlias(alias: String): String = alias.trim().lowercase(Locale.ROOT).replace(Regex("[^a-z0-9_]"), "_")
@@ -129,13 +198,21 @@ class ToolConnectionsViewModel @Inject constructor(
         fun shouldClearCredential(
             existingType: String?,
             providerType: String,
-            apiKey: String,
+            credential: String,
             clearCredential: Boolean
-        ): Boolean = clearCredential || (existingType != null && existingType != providerType && apiKey.isBlank())
+        ): Boolean = clearCredential || (existingType != null && existingType != providerType && credential.isBlank())
+
+        fun isValidMcpEndpoint(endpointUrl: String, allowCleartext: Boolean): Boolean = runCatching {
+            val uri = java.net.URI(endpointUrl)
+            uri.host != null &&
+                uri.userInfo == null &&
+                uri.fragment == null &&
+                (uri.scheme == "https" || (uri.scheme == "http" && allowCleartext))
+        }.getOrDefault(false)
     }
 }
 
-data class WebToolProvider(
+data class ToolConnectionProvider(
     val label: String,
     val type: String,
     val endpointUrl: String,

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsViewModel.kt
@@ -65,7 +65,8 @@ class ToolConnectionsViewModel @Inject constructor(
         credential: String,
         oauthClientId: String,
         allowCleartext: Boolean,
-        clearCredential: Boolean
+        clearCredential: Boolean,
+        onSuccess: () -> Unit = {}
     ) {
         val normalizedAlias = normalizeAlias(alias)
         if (!isValidAlias(normalizedAlias)) {
@@ -125,6 +126,7 @@ class ToolConnectionsViewModel @Inject constructor(
                 mcpClientManager.close(connection.connectionUid)
             }.onSuccess {
                 refresh()
+                onSuccess()
             }.onFailure(::showError)
         }
     }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsViewModel.kt
@@ -16,6 +16,7 @@ import dev.chungjungsoo.gptmobile.data.security.SecretVault
 import java.util.Locale
 import java.util.UUID
 import javax.inject.Inject
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -38,6 +39,7 @@ class ToolConnectionsViewModel @Inject constructor(
     val uiState: StateFlow<ToolConnectionsUiState> = _uiState.asStateFlow()
     private val _oauthLaunches = MutableSharedFlow<String>(extraBufferCapacity = 1)
     val oauthLaunches: SharedFlow<String> = _oauthLaunches.asSharedFlow()
+    private var oauthStartJob: Job? = null
 
     init {
         refresh()
@@ -92,7 +94,7 @@ class ToolConnectionsViewModel @Inject constructor(
                 authType = actualAuthType,
                 secretRef = existing?.secretRef,
                 oauthClientId = clientId,
-                allowCleartext = provider.type == ToolConnectionType.MCP && actualEndpoint.startsWith("http://") && allowCleartext,
+                allowCleartext = provider.type == ToolConnectionType.MCP && actualEndpoint.startsWith("http://", ignoreCase = true) && allowCleartext,
                 createdAt = existing?.createdAt ?: now,
                 updatedAt = now
             )
@@ -141,7 +143,8 @@ class ToolConnectionsViewModel @Inject constructor(
     fun clearError() = _uiState.update { it.copy(errorMessage = null) }
 
     fun startOAuth(connectionUid: String) {
-        viewModelScope.launch {
+        if (oauthStartJob?.isActive == true) return
+        oauthStartJob = viewModelScope.launch {
             _uiState.update { it.copy(isOAuthBusy = true, errorMessage = null) }
             runCatching { oauthCoordinator.begin(connectionUid, mcpOAuthRedirectUri(connectionUid)) }
                 .onSuccess { authorizationUri -> _oauthLaunches.emit(authorizationUri) }
@@ -207,7 +210,7 @@ class ToolConnectionsViewModel @Inject constructor(
             uri.host != null &&
                 uri.userInfo == null &&
                 uri.fragment == null &&
-                (uri.scheme == "https" || (uri.scheme == "http" && allowCleartext))
+                (uri.scheme.equals("https", ignoreCase = true) || (uri.scheme.equals("http", ignoreCase = true) && allowCleartext))
         }.getOrDefault(false)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -346,4 +346,25 @@
     <string name="mcp_tools_assigned">%1$d assigned</string>
     <string name="no_mcp_connections">Add an MCP connection first.</string>
     <string name="no_mcp_tools">No tools were discovered.</string>
+    <string name="public_access">Public</string>
+    <string name="oauth_not_connected">OAuth not connected</string>
+    <string name="oauth_connected">OAuth connected</string>
+    <string name="connect">Connect</string>
+    <string name="reconnect">Reconnect</string>
+    <string name="connect_with_oauth">Connect %1$s with OAuth</string>
+    <string name="edit_named_connection">Edit %1$s</string>
+    <string name="delete_named_connection">Delete %1$s</string>
+    <string name="provider_option">Provider %1$s</string>
+    <string name="streamable_http" translatable="false">Streamable HTTP</string>
+    <string name="connection_name">Connection name</string>
+    <string name="mcp_endpoint_error">Use an HTTP(S) MCP endpoint. Approve cleartext HTTP below.</string>
+    <string name="authentication">Authentication</string>
+    <string name="bearer_token">Bearer token</string>
+    <string name="oauth_pkce" translatable="false">OAuth 2.1 / PKCE</string>
+    <string name="mcp_authentication">MCP authentication %1$s</string>
+    <string name="allow_cleartext_mcp_endpoint">Allow cleartext MCP endpoint</string>
+    <string name="cleartext_mcp_warning">Allow unencrypted HTTP. Credentials and tool data could be intercepted.</string>
+    <string name="oauth_client_id">OAuth client ID</string>
+    <string name="preregistered_client_id_optional">Pre-registered client ID (optional)</string>
+    <string name="dynamic_client_registration_hint">Leave blank to use Dynamic Client Registration when advertised.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,8 +300,9 @@
     <string name="revision_counter">Revision %1$d/%2$d</string>
     <string name="previous_revision" translatable="false">Previous revision</string>
     <string name="next_revision" translatable="false">Next revision</string>
-    <string name="web_tools">Web tools</string>
-    <string name="web_tools_description">Firecrawl, Perplexity, Exa connections</string>
+    <string name="web_tools">Tool connections</string>
+    <string name="tool_connections">Tool connections</string>
+    <string name="web_tools_description">Web search and MCP connections</string>
     <string name="add_tool_connection">Add tool connection</string>
     <string name="edit_tool_connection">Edit tool connection</string>
     <string name="delete_tool_connection">Delete tool connection</string>
@@ -313,6 +314,7 @@
     <string name="stable_alias_error">Use lowercase letters, numbers, and underscores, starting with a letter.</string>
     <string name="blank_key_preserves_credential">Credential set. Leave blank to keep it.</string>
     <string name="clear_api_key">Clear API key</string>
+    <string name="clear_saved_credential">Clear saved credential</string>
     <string name="search_backend">Search backend</string>
     <string name="search_tool_trace">Search tool trace</string>
     <string name="tool_trace_block_content_description">Tool trace block, %1$s</string>
@@ -340,4 +342,8 @@
     <string name="tool_trace_export_header">Tool calls (%1$d)</string>
     <string name="tool_trace_timing_started_at">started at</string>
     <string name="read_url">Read URL</string>
+    <string name="mcp_tools">MCP tools</string>
+    <string name="mcp_tools_assigned">%1$d assigned</string>
+    <string name="no_mcp_connections">Add an MCP connection first.</string>
+    <string name="no_mcp_tools">No tools were discovered.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -305,8 +305,13 @@
     <string name="web_tools_description">Web search and MCP connections</string>
     <string name="add_tool_connection">Add tool connection</string>
     <string name="edit_tool_connection">Edit tool connection</string>
+    <string name="save_tool_connection">Save tool connection</string>
     <string name="delete_tool_connection">Delete tool connection</string>
     <string name="delete_tool_connection_confirmation">Delete %1$s?</string>
+    <string name="tool_connection_not_found">Tool connection not found.</string>
+    <string name="tool_connection_provider_section">Provider</string>
+    <string name="tool_connection_details_section">Connection details</string>
+    <string name="tool_connection_credentials_section">Credentials</string>
     <string name="credential_set">Credential set</string>
     <string name="credential_not_set">Credential not set</string>
     <string name="stable_alias">Stable alias</string>

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/AgentToolResolverTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/AgentToolResolverTest.kt
@@ -243,8 +243,8 @@ class AgentToolResolverTest {
     }
 
     @Test
-    fun `MCP OAuth 401 refreshes stored token reconnects and retries discovery once`() = runBlocking {
-        McpClientManagerTest.McpFixtureServer(acceptedAuthorization = "Bearer access-2").use { server ->
+    fun `MCP OAuth 401 refreshes stored token reconnects and retries tool call once`() = runBlocking {
+        McpClientManagerTest.McpFixtureServer(acceptedAuthorization = "Bearer access-1").use { server ->
             val dao = ResolverFakeToolConnectionDao()
             val credential = McpOAuthCredential(
                 clientId = "client-1",
@@ -280,6 +280,7 @@ class AgentToolResolverTest {
             )
 
             val tool = resolver.resolve("profile-1").single().tool
+            server.acceptedAuthorization = "Bearer access-2"
             val result = tool.execute("call-1", buildJsonObject { put("text", "hello") })
             val stored = NetworkClient.json.decodeFromString<McpOAuthCredential>(vault.value("connection_mcp-1")!!.decodeToString())
 
@@ -288,6 +289,38 @@ class AgentToolResolverTest {
             assertEquals("access-2", stored.accessToken)
             assertTrue("Bearer access-1" in server.authorizationHeaders)
             assertEquals("Bearer access-2", server.authorizationHeaders.last())
+            manager.closeAll()
+            networkClient().close()
+        }
+    }
+
+    @Test
+    fun `one unavailable MCP connection does not hide tools from healthy connections`() = runBlocking {
+        McpClientManagerTest.McpFixtureServer().use { server ->
+            val dao = ResolverFakeToolConnectionDao()
+            val vault = ResolverFakeSecretVault()
+            val repository = ToolConnectionRepository(dao, vault)
+            val networkClient = NetworkClient(CIO)
+            val manager = McpClientManager(networkClient())
+            val resolver = AgentToolResolver(
+                repository,
+                vault,
+                networkClient,
+                manager,
+                McpOAuthCoordinator(McpOAuthClient(networkClient()), repository, vault, manager)
+            )
+            dao.bind(
+                connection("mcp-bad", ToolConnectionType.MCP, endpointUrl = "not-a-url", authType = ToolConnectionAuthType.NONE),
+                binding("profile-1", "mcp-bad", "echo")
+            )
+            dao.bind(
+                connection("mcp-good", ToolConnectionType.MCP, endpointUrl = server.url, authType = ToolConnectionAuthType.NONE, allowCleartext = true),
+                binding("profile-1", "mcp-good", "echo")
+            )
+
+            val resolved = resolver.resolve("profile-1")
+
+            assertEquals(listOf("mcp__mcp-good__echo"), resolved.map { it.modelToolName })
             manager.closeAll()
             networkClient().close()
         }

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/AgentToolResolverTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/AgentToolResolverTest.kt
@@ -17,7 +17,10 @@ import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -155,14 +158,139 @@ class AgentToolResolverTest {
     }
 
     @Test
-    fun `orphan unknown and mcp bindings are ignored in web resolver branch`() = runBlocking {
+    fun `orphan and unknown bindings are ignored`() = runBlocking {
         val dao = ResolverFakeToolConnectionDao()
         val resolver = resolver(dao)
         dao.bind(null, binding("profile-1", "missing", "web_search"))
-        dao.bind(connection("mcp-1", ToolConnectionType.MCP, secretRef = "secret-mcp"), binding("profile-1", "mcp-1", "mcp_tool"))
         dao.bind(connection("search-1", ToolConnectionType.FIRECRAWL, secretRef = "secret-1"), binding("profile-1", "search-1", "unknown_tool"))
 
         assertEquals(listOf("current_date"), resolver.resolve("profile-1").map { it.modelToolName })
+    }
+
+    @Test
+    fun `assigned MCP tool is namespaced and executable while unassigned tools stay hidden`() = runBlocking {
+        McpClientManagerTest.McpFixtureServer().use { server ->
+            val dao = ResolverFakeToolConnectionDao()
+            val vault = ResolverFakeSecretVault()
+            val repository = ToolConnectionRepository(dao, vault)
+            val networkClient = NetworkClient(CIO)
+            val manager = McpClientManager(networkClient())
+            val resolver = AgentToolResolver(
+                repository,
+                vault,
+                networkClient,
+                manager,
+                McpOAuthCoordinator(McpOAuthClient(networkClient()), repository, vault, manager)
+            )
+            dao.bind(
+                connection(
+                    uid = "mcp-1",
+                    type = ToolConnectionType.MCP,
+                    endpointUrl = server.url,
+                    authType = ToolConnectionAuthType.NONE,
+                    allowCleartext = true
+                ),
+                binding("profile-1", "mcp-1", "echo")
+            )
+
+            val resolved = resolver.resolve("profile-1").single()
+            val result = resolved.tool.execute("call-1", buildJsonObject { put("text", "hello") })
+
+            assertEquals("mcp__mcp-1__echo", resolved.modelToolName)
+            assertEquals("echo", resolved.realToolName)
+            assertEquals("hello", (result.content as ToolResultContent.Text).text)
+            manager.closeAll()
+            networkClient().close()
+        }
+    }
+
+    @Test
+    fun `MCP bearer binding reads vault token and authenticates discovery and call`() = runBlocking {
+        McpClientManagerTest.McpFixtureServer(acceptedAuthorization = "Bearer secret-token").use { server ->
+            val dao = ResolverFakeToolConnectionDao()
+            val vault = ResolverFakeSecretVault(mapOf("connection_mcp-1" to "secret-token".encodeToByteArray()))
+            val repository = ToolConnectionRepository(dao, vault)
+            val networkClient = NetworkClient(CIO)
+            val manager = McpClientManager(networkClient())
+            val resolver = AgentToolResolver(
+                repository,
+                vault,
+                networkClient,
+                manager,
+                McpOAuthCoordinator(McpOAuthClient(networkClient()), repository, vault, manager)
+            )
+            dao.bind(
+                connection(
+                    uid = "mcp-1",
+                    type = ToolConnectionType.MCP,
+                    endpointUrl = server.url,
+                    secretRef = "connection_mcp-1",
+                    authType = ToolConnectionAuthType.BEARER,
+                    allowCleartext = true
+                ),
+                binding("profile-1", "mcp-1", "echo")
+            )
+
+            val tool = resolver.resolve("profile-1").single().tool
+            val result = tool.execute("call-1", buildJsonObject { put("text", "hello") })
+
+            assertEquals("hello", (result.content as ToolResultContent.Text).text)
+            assertTrue(server.authorizationHeaders.all { it == "Bearer secret-token" })
+            assertTrue(vault.lastReadBytes!!.all { it == 0.toByte() })
+            manager.closeAll()
+            networkClient().close()
+        }
+    }
+
+    @Test
+    fun `MCP OAuth 401 refreshes stored token reconnects and retries discovery once`() = runBlocking {
+        McpClientManagerTest.McpFixtureServer(acceptedAuthorization = "Bearer access-2").use { server ->
+            val dao = ResolverFakeToolConnectionDao()
+            val credential = McpOAuthCredential(
+                clientId = "client-1",
+                tokenEndpoint = server.tokenUrl,
+                resource = server.url,
+                accessToken = "access-1",
+                tokenType = "Bearer",
+                refreshToken = "refresh-1"
+            )
+            val vault = ResolverFakeSecretVault(
+                mapOf("connection_mcp-1" to NetworkClient.json.encodeToString(credential).encodeToByteArray())
+            )
+            val repository = ToolConnectionRepository(dao, vault)
+            val networkClient = NetworkClient(CIO)
+            val manager = McpClientManager(networkClient())
+            val resolver = AgentToolResolver(
+                repository,
+                vault,
+                networkClient,
+                manager,
+                McpOAuthCoordinator(McpOAuthClient(networkClient()), repository, vault, manager)
+            )
+            dao.bind(
+                connection(
+                    uid = "mcp-1",
+                    type = ToolConnectionType.MCP,
+                    endpointUrl = server.url,
+                    secretRef = "connection_mcp-1",
+                    authType = ToolConnectionAuthType.OAUTH,
+                    allowCleartext = true
+                ),
+                binding("profile-1", "mcp-1", "echo")
+            )
+
+            val tool = resolver.resolve("profile-1").single().tool
+            val result = tool.execute("call-1", buildJsonObject { put("text", "hello") })
+            val stored = NetworkClient.json.decodeFromString<McpOAuthCredential>(vault.value("connection_mcp-1")!!.decodeToString())
+
+            assertEquals("hello", (result.content as ToolResultContent.Text).text)
+            assertEquals(1, server.refreshRequests.get())
+            assertEquals("access-2", stored.accessToken)
+            assertTrue("Bearer access-1" in server.authorizationHeaders)
+            assertEquals("Bearer access-2", server.authorizationHeaders.last())
+            manager.closeAll()
+            networkClient().close()
+        }
     }
 
     @Test
@@ -189,22 +317,36 @@ class AgentToolResolverTest {
     private fun resolver(
         dao: ResolverFakeToolConnectionDao = ResolverFakeToolConnectionDao(),
         vault: ResolverFakeSecretVault = ResolverFakeSecretVault()
-    ) = AgentToolResolver(ToolConnectionRepository(dao, vault), vault, NetworkClient(CIO))
+    ): AgentToolResolver {
+        val repository = ToolConnectionRepository(dao, vault)
+        val networkClient = NetworkClient(CIO)
+        val manager = McpClientManager(networkClient())
+        return AgentToolResolver(
+            repository,
+            vault,
+            networkClient,
+            manager,
+            McpOAuthCoordinator(McpOAuthClient(networkClient()), repository, vault, manager)
+        )
+    }
 
     private fun connection(
         uid: String,
         type: String,
         endpointUrl: String? = "https://$uid.example/search",
-        secretRef: String? = null
+        secretRef: String? = null,
+        authType: String = ToolConnectionAuthType.BEARER,
+        allowCleartext: Boolean = false
     ) = ToolConnection(
         connectionUid = uid,
         name = "Search ${uid.substringAfterLast("-")}",
         alias = uid,
         type = type,
         endpointUrl = endpointUrl,
-        authType = ToolConnectionAuthType.BEARER,
+        authType = authType,
         secretRef = secretRef,
-        oauthClientId = null
+        oauthClientId = null,
+        allowCleartext = allowCleartext
     )
 
     private fun binding(
@@ -228,19 +370,26 @@ class AgentToolResolverTest {
 }
 
 private class ResolverFakeSecretVault(
-    private val values: Map<String, ByteArray> = emptyMap(),
+    values: Map<String, ByteArray> = emptyMap(),
     private val readError: Throwable? = null
 ) : SecretVault {
+    private val values = values.mapValues { it.value.copyOf() }.toMutableMap()
     var lastReadBytes: ByteArray? = null
 
-    override suspend fun put(secretRef: String, secret: ByteArray) = Unit
+    override suspend fun put(secretRef: String, secret: ByteArray) {
+        values[secretRef] = secret.copyOf()
+    }
 
     override suspend fun read(secretRef: String): ByteArray? {
         readError?.let { throw it }
         return values[secretRef]?.copyOf()?.also { lastReadBytes = it }
     }
 
-    override suspend fun delete(secretRef: String) = Unit
+    override suspend fun delete(secretRef: String) {
+        values.remove(secretRef)?.fill(0)
+    }
+
+    fun value(secretRef: String): ByteArray? = values[secretRef]?.copyOf()
 }
 
 private class ResolverFakeToolConnectionDao : ToolConnectionDao {

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/AgentToolResolverTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/AgentToolResolverTest.kt
@@ -193,7 +193,7 @@ class AgentToolResolverTest {
                 binding("profile-1", "mcp-1", "echo")
             )
 
-            val resolved = resolver.resolve("profile-1").single()
+            val resolved = resolver.resolve("profile-1").single { it.connectionUid == "mcp-1" }
             val result = resolved.tool.execute("call-1", buildJsonObject { put("text", "hello") })
 
             assertEquals("mcp__mcp-1__echo", resolved.modelToolName)
@@ -231,7 +231,7 @@ class AgentToolResolverTest {
                 binding("profile-1", "mcp-1", "echo")
             )
 
-            val tool = resolver.resolve("profile-1").single().tool
+            val tool = resolver.resolve("profile-1").single { it.connectionUid == "mcp-1" }.tool
             val result = tool.execute("call-1", buildJsonObject { put("text", "hello") })
 
             assertEquals("hello", (result.content as ToolResultContent.Text).text)
@@ -240,6 +240,27 @@ class AgentToolResolverTest {
             manager.closeAll()
             networkClient().close()
         }
+    }
+
+    @Test
+    fun `MCP bearer binding rejects blank stored token before authorization header is built`() = runBlocking {
+        val dao = ResolverFakeToolConnectionDao()
+        val vault = ResolverFakeSecretVault(mapOf("connection_mcp-1" to " ".encodeToByteArray()))
+        val resolver = resolver(dao, vault)
+        dao.bind(
+            connection(
+                uid = "mcp-1",
+                type = ToolConnectionType.MCP,
+                endpointUrl = "https://example.com/mcp",
+                secretRef = "connection_mcp-1",
+                authType = ToolConnectionAuthType.BEARER
+            ),
+            binding("profile-1", "mcp-1", "echo")
+        )
+
+        val resolved = resolver.resolve("profile-1")
+
+        assertEquals(listOf("current_date"), resolved.map { it.modelToolName })
     }
 
     @Test
@@ -279,7 +300,7 @@ class AgentToolResolverTest {
                 binding("profile-1", "mcp-1", "echo")
             )
 
-            val tool = resolver.resolve("profile-1").single().tool
+            val tool = resolver.resolve("profile-1").single { it.connectionUid == "mcp-1" }.tool
             server.acceptedAuthorization = "Bearer access-2"
             val result = tool.execute("call-1", buildJsonObject { put("text", "hello") })
             val stored = NetworkClient.json.decodeFromString<McpOAuthCredential>(vault.value("connection_mcp-1")!!.decodeToString())
@@ -320,7 +341,7 @@ class AgentToolResolverTest {
 
             val resolved = resolver.resolve("profile-1")
 
-            assertEquals(listOf("mcp__mcp-good__echo"), resolved.map { it.modelToolName })
+            assertEquals(listOf("current_date", "mcp__mcp-good__echo"), resolved.map { it.modelToolName })
             manager.closeAll()
             networkClient().close()
         }

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpClientManagerTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpClientManagerTest.kt
@@ -10,8 +10,12 @@ import io.ktor.serialization.kotlinx.json.json
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
@@ -83,6 +87,40 @@ class McpClientManagerTest {
             manager.closeAll()
             client.close()
         }
+    }
+
+    @Test
+    fun `connects independent sessions without holding the global lock`() = runBlocking {
+        val started = CompletableDeferred<Unit>()
+        val startCount = AtomicInteger()
+        SlowInitializeMcpFixtureServer(started, startCount).use { first ->
+            SlowInitializeMcpFixtureServer(started, startCount).use { second ->
+                val client = testClient()
+                val manager = McpClientManager(client)
+
+                val one = async { manager.listTools(McpConnectionConfig("connection-1", first.url, allowCleartext = true)) }
+                val two = async { manager.listTools(McpConnectionConfig("connection-2", second.url, allowCleartext = true)) }
+
+                withTimeout(2_000) { started.await() }
+                assertEquals(listOf("echo"), one.await().map { it.name })
+                assertEquals(listOf("echo"), two.await().map { it.name })
+                manager.closeAll()
+                client.close()
+            }
+        }
+    }
+
+    @Test
+    fun `rejects blank authorization header before opening a session`() = runBlocking {
+        val client = testClient()
+        val manager = McpClientManager(client)
+
+        val error = runCatching {
+            manager.listTools(McpConnectionConfig("connection-1", "https://example.com/mcp", allowCleartext = false, authorizationHeader = " "))
+        }.exceptionOrNull()
+
+        assertTrue(error is IllegalArgumentException)
+        client.close()
     }
 
     private fun testClient(): HttpClient = HttpClient(CIO) {
@@ -181,6 +219,52 @@ class McpClientManagerTest {
         }
 
         private fun toolList(name: String, nextCursor: String? = null): String = """{"tools":[{"name":"$name","description":"Echo text","inputSchema":{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}}]${nextCursor?.let { ",\"nextCursor\":\"$it\"" }.orEmpty()}}"""
+    }
+
+    private class SlowInitializeMcpFixtureServer(
+        private val started: CompletableDeferred<Unit>,
+        private val startCount: AtomicInteger
+    ) : AutoCloseable {
+        private val executor = Executors.newCachedThreadPool()
+        private val server = HttpServer.create(InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0).apply {
+            executor = this@SlowInitializeMcpFixtureServer.executor
+            createContext("/mcp", ::handle)
+            start()
+        }
+        val url: String = "http://127.0.0.1:${server.address.port}/mcp"
+
+        private fun handle(exchange: HttpExchange) {
+            try {
+                val request = JSON.parseToJsonElement(exchange.requestBody.bufferedReader().readText()).let { it as JsonObject }
+                val method = request["method"]?.jsonPrimitive?.content.orEmpty()
+                if (method == "notifications/initialized") {
+                    exchange.sendResponseHeaders(202, -1)
+                    return
+                }
+                if (method == "initialize") {
+                    if (startCount.incrementAndGet() == 2) started.complete(Unit)
+                    Thread.sleep(250)
+                    exchange.responseHeaders.add("Mcp-Session-Id", "session-${server.address.port}")
+                    respond(exchange, """{"jsonrpc":"2.0","id":${request["id"]},"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{}},"serverInfo":{"name":"fixture","version":"1"}}}""")
+                    return
+                }
+                respond(exchange, """{"jsonrpc":"2.0","id":${request["id"]},"result":{"tools":[{"name":"echo","description":"Echo text","inputSchema":{"type":"object"}}]}}""")
+            } finally {
+                exchange.close()
+            }
+        }
+
+        override fun close() {
+            server.stop(0)
+            executor.shutdownNow()
+        }
+
+        private fun respond(exchange: HttpExchange, body: String) {
+            val bytes = body.toByteArray()
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
     }
 
     private companion object {

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpClientManagerTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpClientManagerTest.kt
@@ -1,0 +1,187 @@
+package dev.chungjungsoo.gptmobile.data.agent.tool
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.sse.SSE
+import io.ktor.serialization.kotlinx.json.json
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class McpClientManagerTest {
+    @Test
+    fun `reuses initialized session for discovery and SSE tool call`() = runBlocking {
+        McpFixtureServer().use { server ->
+            val client = testClient()
+            val manager = McpClientManager(client)
+            val config = McpConnectionConfig(
+                connectionUid = "connection-1",
+                endpointUrl = server.url,
+                allowCleartext = true,
+                authorizationHeader = "Bearer test-token"
+            )
+
+            val tools = manager.listTools(config)
+            val result = manager.callTool(config, "echo", buildJsonObject { put("text", "hello") })
+
+            assertEquals(listOf("echo"), tools.map { it.name })
+            assertEquals("hello", result.content.single().let { it as io.modelcontextprotocol.kotlin.sdk.types.TextContent }.text)
+            assertEquals(1, server.methods.count { it == "initialize" })
+            assertTrue(server.sessionHeaders.filterNotNull().all { it == "session-1" })
+            assertTrue(server.authorizationHeaders.all { it == "Bearer test-token" })
+            manager.closeAll()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `rejects cleartext endpoint until user allowed it`() = runBlocking {
+        val client = testClient()
+        val manager = McpClientManager(client)
+
+        try {
+            manager.listTools(
+                McpConnectionConfig(
+                    connectionUid = "connection-1",
+                    endpointUrl = "http://127.0.0.1:8080/mcp",
+                    allowCleartext = false
+                )
+            )
+            fail("Expected a cleartext validation failure")
+        } catch (_: IllegalArgumentException) {
+        }
+        client.close()
+    }
+
+    @Test
+    fun `follows tool list cursors without reinitializing session`() = runBlocking {
+        McpFixtureServer(paginateTools = true).use { server ->
+            val client = testClient()
+            val manager = McpClientManager(client)
+            val config = McpConnectionConfig("connection-1", server.url, allowCleartext = true)
+
+            val tools = manager.listTools(config)
+
+            assertEquals(listOf("echo", "second"), tools.map { it.name })
+            assertEquals(2, server.methods.count { it == "tools/list" })
+            assertEquals(1, server.methods.count { it == "initialize" })
+            manager.closeAll()
+            client.close()
+        }
+    }
+
+    private fun testClient(): HttpClient = HttpClient(CIO) {
+        expectSuccess = false
+        install(ContentNegotiation) { json(JSON) }
+        install(SSE)
+    }
+
+    internal class McpFixtureServer(
+        private val paginateTools: Boolean = false,
+        private val acceptedAuthorization: String? = null
+    ) : AutoCloseable {
+        val methods = CopyOnWriteArrayList<String>()
+        val sessionHeaders = CopyOnWriteArrayList<String?>()
+        val authorizationHeaders = CopyOnWriteArrayList<String>()
+        val refreshRequests = AtomicInteger()
+        private val server = HttpServer.create(InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0).apply {
+            createContext("/mcp", ::handle)
+            createContext("/token", ::token)
+            start()
+        }
+        val url: String = "http://127.0.0.1:${server.address.port}/mcp"
+        val tokenUrl: String = "http://127.0.0.1:${server.address.port}/token"
+
+        private fun handle(exchange: HttpExchange) {
+            try {
+                val authorization = exchange.requestHeaders.getFirst("Authorization")
+                authorization?.let(authorizationHeaders::add)
+                exchange.requestHeaders.getFirst("Mcp-Session-Id")?.let(sessionHeaders::add)
+                if (acceptedAuthorization != null && authorization != acceptedAuthorization) {
+                    exchange.sendResponseHeaders(401, -1)
+                    return
+                }
+                val request = JSON.parseToJsonElement(exchange.requestBody.bufferedReader().readText()).let { it as JsonObject }
+                val method = request["method"]?.jsonPrimitive?.content.orEmpty()
+                methods += method
+
+                if (method == "notifications/initialized") {
+                    exchange.sendResponseHeaders(202, -1)
+                    return
+                }
+
+                val result = when (method) {
+                    "initialize" -> """{"protocolVersion":"2025-06-18","capabilities":{"tools":{}},"serverInfo":{"name":"fixture","version":"1"}}"""
+
+                    "tools/list" -> {
+                        val cursor = (request["params"] as? JsonObject)?.get("cursor")?.jsonPrimitive?.content
+                        when {
+                            !paginateTools -> toolList("echo")
+                            cursor == null -> toolList("echo", nextCursor = "page-2")
+                            else -> toolList("second")
+                        }
+                    }
+
+                    "tools/call" -> {
+                        val text = request["params"]!!.let { it as JsonObject }["arguments"]!!.let { it as JsonObject }["text"]!!.jsonPrimitive.content
+                        """{"content":[{"type":"text","text":"$text"}]}"""
+                    }
+
+                    else -> error("Unexpected MCP method: $method")
+                }
+                val response = """{"jsonrpc":"2.0","id":${request["id"] ?: JsonNull},"result":$result}"""
+                if (method == "initialize") exchange.responseHeaders.add("Mcp-Session-Id", "session-1")
+                if (method == "tools/call") {
+                    respond(exchange, "text/event-stream", "event: message\ndata: $response\n\n")
+                } else {
+                    respond(exchange, "application/json", response)
+                }
+            } finally {
+                exchange.close()
+            }
+        }
+
+        private fun token(exchange: HttpExchange) {
+            exchange.requestBody.bufferedReader().readText()
+            refreshRequests.incrementAndGet()
+            respond(
+                exchange,
+                "application/json",
+                """{"access_token":"access-2","token_type":"Bearer","refresh_token":"refresh-2","expires_in":120}"""
+            )
+            exchange.close()
+        }
+
+        override fun close() {
+            server.stop(0)
+        }
+
+        private fun respond(exchange: HttpExchange, contentType: String, body: String) {
+            val bytes = body.toByteArray()
+            exchange.responseHeaders.add("Content-Type", contentType)
+            exchange.sendResponseHeaders(200, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+
+        private fun toolList(name: String, nextCursor: String? = null): String = """{"tools":[{"name":"$name","description":"Echo text","inputSchema":{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}}]${nextCursor?.let { ",\"nextCursor\":\"$it\"" }.orEmpty()}}"""
+    }
+
+    private companion object {
+        val JSON = Json { ignoreUnknownKeys = true }
+    }
+}

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpClientManagerTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpClientManagerTest.kt
@@ -93,8 +93,10 @@ class McpClientManagerTest {
 
     internal class McpFixtureServer(
         private val paginateTools: Boolean = false,
-        private val acceptedAuthorization: String? = null
+        acceptedAuthorization: String? = null
     ) : AutoCloseable {
+        @Volatile
+        var acceptedAuthorization: String? = acceptedAuthorization
         val methods = CopyOnWriteArrayList<String>()
         val sessionHeaders = CopyOnWriteArrayList<String?>()
         val authorizationHeaders = CopyOnWriteArrayList<String>()

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpOAuthClientTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpOAuthClientTest.kt
@@ -11,14 +11,24 @@ import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.URI
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class McpOAuthClientTest {
+    @Test
+    fun `callback filter accepts only MCP OAuth redirect URIs`() {
+        assertTrue(isMcpOAuthCallbackUri("dev.chungjungsoo.gptmobile://oauth/mcp/connection-1?code=code&state=state"))
+        assertFalse(isMcpOAuthCallbackUri("dev.chungjungsoo.gptmobile://oauth/other/connection-1"))
+        assertFalse(isMcpOAuthCallbackUri("https://example.com/mcp/connection-1"))
+        assertFalse(isMcpOAuthCallbackUri(null))
+    }
+
     @Test
     fun `discovers registers completes PKCE and refreshes public client`() = runBlocking {
         OAuthFixtureServer().use { server ->
@@ -109,6 +119,7 @@ class McpOAuthClientTest {
 
     internal class OAuthFixtureServer : AutoCloseable {
         val tokenForms = CopyOnWriteArrayList<Map<String, String>>()
+        val protectedResourceRequests = AtomicInteger()
         private val server = HttpServer.create(InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0)
         private val baseUrl = "http://127.0.0.1:${server.address.port}"
 
@@ -123,6 +134,7 @@ class McpOAuthClientTest {
         val mcpUrl: String get() = "$baseUrl/mcp"
 
         private fun protectedResource(exchange: HttpExchange) {
+            protectedResourceRequests.incrementAndGet()
             exchange.responseHeaders.add(
                 "WWW-Authenticate",
                 "Bearer resource_metadata=\"$baseUrl/.well-known/oauth-protected-resource/mcp\""

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpOAuthClientTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpOAuthClientTest.kt
@@ -117,6 +117,36 @@ class McpOAuthClientTest {
         }
     }
 
+    @Test
+    fun `challenge discovery times out instead of hanging authorization`() = runBlocking {
+        HangingChallengeServer().use { server ->
+            val httpClient = HttpClient(CIO) { expectSuccess = false }
+            val client = McpOAuthClient(httpClient, discoveryTimeoutMillis = 50)
+
+            val error = runCatching { client.discover(server.mcpUrl, allowCleartext = true) }.exceptionOrNull()
+
+            assertTrue(error is McpOAuthException)
+            assertTrue(error!!.message!!.contains("timed out"))
+            httpClient.close()
+        }
+    }
+
+    @Test
+    fun `advertised resource metadata must stay on the MCP resource origin`() = runBlocking {
+        OAuthFixtureServer().use { metadataServer ->
+            CrossOriginMetadataServer(metadataServer).use { server ->
+                val httpClient = HttpClient(CIO) { expectSuccess = false }
+                val client = McpOAuthClient(httpClient)
+
+                val error = runCatching { client.discover(server.mcpUrl, allowCleartext = true) }.exceptionOrNull()
+
+                assertTrue(error is McpOAuthException)
+                assertTrue(error!!.message!!.contains("same origin"))
+                httpClient.close()
+            }
+        }
+    }
+
     internal class OAuthFixtureServer : AutoCloseable {
         val tokenForms = CopyOnWriteArrayList<Map<String, String>>()
         val protectedResourceRequests = AtomicInteger()
@@ -173,6 +203,43 @@ class McpOAuthClientTest {
             exchange.responseBody.use { it.write(bytes) }
             exchange.close()
         }
+
+        override fun close() {
+            server.stop(0)
+        }
+    }
+
+    private class HangingChallengeServer : AutoCloseable {
+        private val server = HttpServer.create(InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0).apply {
+            createContext("/mcp") { exchange ->
+                Thread.sleep(2_000)
+                exchange.sendResponseHeaders(401, -1)
+                exchange.close()
+            }
+            start()
+        }
+        val mcpUrl: String = "http://127.0.0.1:${server.address.port}/mcp"
+
+        override fun close() {
+            server.stop(0)
+        }
+    }
+
+    private class CrossOriginMetadataServer(
+        metadataServer: OAuthFixtureServer
+    ) : AutoCloseable {
+        private val server = HttpServer.create(InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0).apply {
+            createContext("/mcp") { exchange ->
+                exchange.responseHeaders.add(
+                    "WWW-Authenticate",
+                    "Bearer resource_metadata=\"${metadataServer.mcpUrl.replace("/mcp", "/.well-known/oauth-protected-resource/mcp")}\""
+                )
+                exchange.sendResponseHeaders(401, -1)
+                exchange.close()
+            }
+            start()
+        }
+        val mcpUrl: String = "http://127.0.0.1:${server.address.port}/mcp"
 
         override fun close() {
             server.stop(0)

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpOAuthClientTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpOAuthClientTest.kt
@@ -1,0 +1,180 @@
+package dev.chungjungsoo.gptmobile.data.agent.tool
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.decodeURLPart
+import io.ktor.serialization.kotlinx.json.json
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.URI
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class McpOAuthClientTest {
+    @Test
+    fun `discovers registers completes PKCE and refreshes public client`() = runBlocking {
+        OAuthFixtureServer().use { server ->
+            val httpClient = HttpClient(CIO) {
+                expectSuccess = false
+                install(ContentNegotiation) { json(JSON) }
+            }
+            val client = McpOAuthClient(httpClient, nowEpochSeconds = { 1_000 })
+            val discovery = client.discover(server.mcpUrl, allowCleartext = true)
+            val started = client.beginAuthorization(
+                discovery = discovery,
+                redirectUri = "dev.chungjungsoo.gptmobile://oauth/mcp",
+                suppliedClientId = null
+            )
+            val authorization = URI(started.authorizationUri).rawQuery.formValues()
+
+            assertEquals(server.mcpUrl, discovery.resource)
+            assertEquals("fixture-client", started.pending.clientId)
+            assertEquals("S256", authorization["code_challenge_method"])
+            assertEquals(server.mcpUrl, authorization["resource"])
+            assertEquals(started.pending.state, authorization["state"])
+            assertNotEquals(started.pending.codeVerifier, authorization["code_challenge"])
+
+            val tokens = client.completeAuthorization(
+                started.pending,
+                "dev.chungjungsoo.gptmobile://oauth/mcp?code=auth-code&state=${started.pending.state}"
+            )
+            val refreshed = client.refresh(tokens)
+
+            assertEquals("access-1", tokens.accessToken)
+            assertEquals("refresh-1", tokens.refreshToken)
+            assertEquals(1_120L, tokens.expiresAtEpochSeconds)
+            assertEquals("access-2", refreshed.accessToken)
+            assertEquals("refresh-2", refreshed.refreshToken)
+            assertTrue(server.tokenForms.single { it["grant_type"] == "authorization_code" }["code_verifier"]!!.length >= 43)
+            assertEquals(server.mcpUrl, server.tokenForms.last()["resource"])
+            httpClient.close()
+        }
+    }
+
+    @Test
+    fun `callback with wrong state is rejected before token request`() = runBlocking {
+        OAuthFixtureServer().use { server ->
+            val httpClient = HttpClient(CIO) { expectSuccess = false }
+            val client = McpOAuthClient(httpClient)
+            val started = client.beginAuthorization(
+                client.discover(server.mcpUrl, allowCleartext = true),
+                "dev.chungjungsoo.gptmobile://oauth/mcp",
+                "manual-client"
+            )
+
+            val error = runCatching {
+                client.completeAuthorization(
+                    started.pending,
+                    "dev.chungjungsoo.gptmobile://oauth/mcp?code=auth-code&state=wrong"
+                )
+            }.exceptionOrNull()
+
+            assertTrue(error is McpOAuthException)
+            assertTrue(server.tokenForms.isEmpty())
+            httpClient.close()
+        }
+    }
+
+    @Test
+    fun `callback for another redirect path is rejected before token request`() = runBlocking {
+        OAuthFixtureServer().use { server ->
+            val httpClient = HttpClient(CIO) { expectSuccess = false }
+            val client = McpOAuthClient(httpClient)
+            val started = client.beginAuthorization(
+                client.discover(server.mcpUrl, allowCleartext = true),
+                "dev.chungjungsoo.gptmobile://oauth/mcp/connection-1",
+                "manual-client"
+            )
+
+            val error = runCatching {
+                client.completeAuthorization(
+                    started.pending,
+                    "dev.chungjungsoo.gptmobile://oauth/mcp/connection-2?code=auth-code&state=${started.pending.state}"
+                )
+            }.exceptionOrNull()
+
+            assertTrue(error is McpOAuthException)
+            assertTrue(server.tokenForms.isEmpty())
+            httpClient.close()
+        }
+    }
+
+    internal class OAuthFixtureServer : AutoCloseable {
+        val tokenForms = CopyOnWriteArrayList<Map<String, String>>()
+        private val server = HttpServer.create(InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0)
+        private val baseUrl = "http://127.0.0.1:${server.address.port}"
+
+        init {
+            server.createContext("/mcp", ::protectedResource)
+            server.createContext("/.well-known/oauth-protected-resource/mcp", ::resourceMetadata)
+            server.createContext("/.well-known/oauth-authorization-server/issuer", ::authorizationMetadata)
+            server.createContext("/register", ::register)
+            server.createContext("/token", ::token)
+            server.start()
+        }
+        val mcpUrl: String get() = "$baseUrl/mcp"
+
+        private fun protectedResource(exchange: HttpExchange) {
+            exchange.responseHeaders.add(
+                "WWW-Authenticate",
+                "Bearer resource_metadata=\"$baseUrl/.well-known/oauth-protected-resource/mcp\""
+            )
+            exchange.sendResponseHeaders(401, -1)
+            exchange.close()
+        }
+
+        private fun resourceMetadata(exchange: HttpExchange) = respond(
+            exchange,
+            """{"resource":"$mcpUrl","authorization_servers":["$baseUrl/issuer"],"scopes_supported":["mcp:tools"]}"""
+        )
+
+        private fun authorizationMetadata(exchange: HttpExchange) = respond(
+            exchange,
+            """{"issuer":"$baseUrl/issuer","authorization_endpoint":"$baseUrl/authorize","token_endpoint":"$baseUrl/token","registration_endpoint":"$baseUrl/register","code_challenge_methods_supported":["S256"],"token_endpoint_auth_methods_supported":["none"]}"""
+        )
+
+        private fun register(exchange: HttpExchange) = respond(exchange, """{"client_id":"fixture-client"}""")
+
+        private fun token(exchange: HttpExchange) {
+            val form = exchange.requestBody.bufferedReader().readText().formValues()
+            tokenForms += form
+            val body = if (form["grant_type"] == "refresh_token") {
+                """{"access_token":"access-2","token_type":"Bearer","refresh_token":"refresh-2","expires_in":120}"""
+            } else {
+                """{"access_token":"access-1","token_type":"Bearer","refresh_token":"refresh-1","expires_in":120,"scope":"mcp:tools"}"""
+            }
+            respond(exchange, body)
+        }
+
+        private fun respond(exchange: HttpExchange, body: String) {
+            val bytes = body.toByteArray()
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+            exchange.close()
+        }
+
+        override fun close() {
+            server.stop(0)
+        }
+    }
+
+    private companion object {
+        val JSON = Json { ignoreUnknownKeys = true }
+    }
+}
+
+private fun String.formValues(): Map<String, String> = split('&')
+    .filter { it.isNotBlank() }
+    .associate { item ->
+        val parts = item.split('=', limit = 2)
+        parts[0].decodeURLPart() to parts.getOrElse(1) { "" }.decodeURLPart()
+    }

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpToolMapperTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/tool/McpToolMapperTest.kt
@@ -1,0 +1,125 @@
+package dev.chungjungsoo.gptmobile.data.agent.tool
+
+import dev.chungjungsoo.gptmobile.data.agent.ToolResultContent
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
+import io.modelcontextprotocol.kotlin.sdk.types.ResourceLink
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.Tool
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class McpToolMapperTest {
+    @Test
+    fun `model tool names are stable bounded and collision resistant`() {
+        assertEquals("mcp__docs__read", namespaceMcpToolName("docs", "read"))
+
+        val spaced = namespaceMcpToolName("docs", "read page")
+        assertEquals(spaced, namespaceMcpToolName("docs", "read page"))
+        assertNotEquals(spaced, namespaceMcpToolName("docs", "read_page"))
+        assertTrue(spaced.matches(Regex("[A-Za-z0-9_-]+")))
+        assertTrue(namespaceMcpToolName("a".repeat(32), "x".repeat(200)).length <= 64)
+    }
+
+    @Test
+    fun `remote tool schema maps to provider neutral definition`() {
+        val definition = mcpToolDefinition(
+            alias = "docs",
+            tool = Tool(
+                name = "read",
+                description = "Read a document",
+                inputSchema = ToolSchema(
+                    properties = buildJsonObject {
+                        put("uri", buildJsonObject { put("type", "string") })
+                    },
+                    required = listOf("uri")
+                )
+            )
+        )
+
+        assertEquals("mcp__docs__read", definition.name)
+        assertEquals("Read a document", definition.description)
+        assertEquals("object", definition.inputSchema["type"]!!.jsonPrimitive.content)
+        assertEquals("string", definition.inputSchema["properties"]!!.jsonObject["uri"]!!.jsonObject["type"]!!.jsonPrimitive.content)
+        assertEquals("uri", definition.inputSchema["required"]!!.jsonArray.single().jsonPrimitive.content)
+    }
+
+    @Test
+    fun `text and resource results are forwarded without binary blocks`() {
+        val mapped = mapMcpToolResult(
+            callId = "call-1",
+            result = CallToolResult(
+                content = listOf(
+                    TextContent("hello"),
+                    ResourceLink(name = "Document", uri = "https://example.com/doc", mimeType = "text/plain"),
+                    ImageContent(data = "base64-image", mimeType = "image/png")
+                ),
+                structuredContent = buildJsonObject { put("count", 1) }
+            )
+        )
+
+        val modelJson = (mapped.content as ToolResultContent.Json).value.jsonObject
+        assertEquals("hello", modelJson["text"]!!.jsonArray.single().jsonPrimitive.content)
+        assertEquals(1, modelJson["structuredContent"]!!.jsonObject["count"]!!.jsonPrimitive.content.toInt())
+        assertEquals("https://example.com/doc", modelJson["resourceLinks"]!!.jsonArray.single().jsonObject["uri"]!!.jsonPrimitive.content)
+        val trace = (mapped.traceContent as ToolResultContent.Text).text
+        assertTrue(trace.contains("image/png"))
+        assertTrue(trace.contains("omitted"))
+        assertTrue(!modelJson.toString().contains("base64-image"))
+    }
+
+    @Test
+    fun `unsupported only result gives model a safe empty summary and trace detail`() {
+        val mapped = mapMcpToolResult(
+            "call-2",
+            CallToolResult(content = listOf(ImageContent(data = "secret-binary", mimeType = "image/webp")), isError = true)
+        )
+
+        assertEquals(
+            "MCP tool returned no model-compatible content.",
+            (mapped.content as ToolResultContent.Text).text
+        )
+        assertTrue(mapped.isError)
+        val traceText = (mapped.traceContent as ToolResultContent.Text).text
+        assertTrue(traceText.contains("image/webp"))
+        assertTrue(!traceText.contains("secret-binary"))
+    }
+
+    @Test
+    fun `oversized text is bounded before model and trace content are built`() {
+        val mapped = mapMcpToolResult(
+            "call-large-text",
+            CallToolResult(content = listOf(TextContent("x".repeat(1024 * 1024))))
+        )
+
+        val modelText = (mapped.content as ToolResultContent.Text).text
+        val traceText = (mapped.traceContent as ToolResultContent.Text).text
+        assertTrue(modelText.toByteArray().size <= 64 * 1024)
+        assertTrue(traceText.length < 70 * 1024)
+        assertTrue(traceText.contains("truncated"))
+    }
+
+    @Test
+    fun `oversized structured result is omitted without serializing it into trace`() {
+        val mapped = mapMcpToolResult(
+            "call-large-json",
+            CallToolResult(
+                content = emptyList(),
+                structuredContent = buildJsonObject { put("payload", "x".repeat(1024 * 1024)) }
+            )
+        )
+
+        assertEquals("MCP tool returned no model-compatible content.", (mapped.content as ToolResultContent.Text).text)
+        val trace = (mapped.traceContent as ToolResultContent.Text).text
+        assertTrue(trace.contains("structured JSON omitted"))
+        assertTrue(trace.length < 512)
+    }
+}

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/network/NetworkClientTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/network/NetworkClientTest.kt
@@ -21,6 +21,8 @@ class NetworkClientTest {
         assertTrue(NetworkClient.isSensitiveHeader("X-Goog-Api-Key"))
         assertTrue(NetworkClient.isSensitiveHeader("x-api-key"))
         assertTrue(NetworkClient.isSensitiveHeader("X-API-KEY"))
+        assertTrue(NetworkClient.isSensitiveHeader("Mcp-Session-Id"))
+        assertTrue(NetworkClient.isSensitiveHeader("mcp-session-id"))
         assertFalse(NetworkClient.isSensitiveHeader("Content-Type"))
     }
 

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImplTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImplTest.kt
@@ -2,6 +2,9 @@ package dev.chungjungsoo.gptmobile.data.repository
 
 import android.content.ContextWrapper
 import dev.chungjungsoo.gptmobile.data.agent.tool.AgentToolResolver
+import dev.chungjungsoo.gptmobile.data.agent.tool.McpClientManager
+import dev.chungjungsoo.gptmobile.data.agent.tool.McpOAuthClient
+import dev.chungjungsoo.gptmobile.data.agent.tool.McpOAuthCoordinator
 import dev.chungjungsoo.gptmobile.data.context.ContextBuilder
 import dev.chungjungsoo.gptmobile.data.database.dao.AgentToolBindingWithConnection
 import dev.chungjungsoo.gptmobile.data.database.dao.ToolConnectionDao
@@ -398,7 +401,7 @@ class ChatRepositoryImplTest {
         )
         val repository = createRepository(
             openAIAPI = openAIAPI,
-            agentToolResolver = AgentToolResolver(ToolConnectionRepository(toolDao, vault), vault, NetworkClient(CIO)),
+            agentToolResolver = toolResolver(toolDao, vault),
             toolEventRecorder = ToolEventRecorder(traceDao.asDao())
         )
 
@@ -452,7 +455,20 @@ class ChatRepositoryImplTest {
 
     private fun emptyToolResolver(): AgentToolResolver {
         val vault = MapSecretVault(emptyMap())
-        return AgentToolResolver(ToolConnectionRepository(SingleToolConnectionDao(), vault), vault, NetworkClient(CIO))
+        return toolResolver(SingleToolConnectionDao(), vault)
+    }
+
+    private fun toolResolver(toolDao: ToolConnectionDao, vault: SecretVault): AgentToolResolver {
+        val repository = ToolConnectionRepository(toolDao, vault)
+        val networkClient = NetworkClient(CIO)
+        val manager = McpClientManager(networkClient())
+        return AgentToolResolver(
+            repository,
+            vault,
+            networkClient,
+            manager,
+            McpOAuthCoordinator(McpOAuthClient(networkClient()), repository, vault, manager)
+        )
     }
 
     private fun groqPlatform(reasoning: Boolean, model: String) = PlatformV2(

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/ToolConnectionRepositoryTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/ToolConnectionRepositoryTest.kt
@@ -170,7 +170,10 @@ class ToolConnectionRepositoryTest {
 
         assertNull(dao.connections["alpha"])
         assertNull(vault.values["connection_alpha"])
-        assertEquals(listOf("dao.delete:alpha", "vault.delete:connection_alpha"), events)
+        assertEquals(
+            listOf("dao.delete:alpha", "vault.delete:connection_alpha", "vault.delete:mcp_oauth_pending_alpha"),
+            events
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/ToolEventRecorderTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/ToolEventRecorderTest.kt
@@ -138,6 +138,24 @@ class ToolEventRecorderTest {
     }
 
     @Test
+    fun finishTool_persistsTraceOnlyContentWithoutChangingModelContent() = runBlocking {
+        val event = recorder.startTool("run-1", 0, "call-trace", "image", "image", buildJsonObject {}, startedAt = 100L)
+
+        recorder.finishTool(
+            eventId = event.eventId,
+            result = AgentToolResult(
+                callId = "call-trace",
+                content = ToolResultContent.Text("safe model result"),
+                isError = false,
+                traceContent = ToolResultContent.Text("image/png omitted from model context")
+            ),
+            completedAt = 110L
+        )
+
+        assertEquals("image/png omitted from model context", dao.rows.single().result)
+    }
+
+    @Test
     fun finishTool_callIdMismatchReturnsNullAndDoesNotWrite() = runBlocking {
         val event = recorder.startTool("run-1", 0, "call-expected", "echo", "echo", buildJsonObject {}, startedAt = 100L)
 

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingViewModelTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingViewModelTest.kt
@@ -118,6 +118,21 @@ class PlatformSettingViewModelTest {
         assertEquals(setOf("web_search", "read_url"), viewModel.toolBindingState.value.selectedMcpTools.map { it.toolName }.toSet())
     }
 
+    @Test
+    fun `closing MCP tools dialog cancels discovery loading state`() = runTest {
+        val dao = FakeToolConnectionDao(
+            connections = mutableMapOf("mcp-1" to testConnection("mcp-1", ToolConnectionType.MCP))
+        )
+        val viewModel = testViewModel(dao)
+
+        viewModel.loadToolBindings()
+        viewModel.openMcpToolsDialog()
+        viewModel.closeMcpToolsDialog()
+
+        assertFalse(viewModel.toolBindingState.value.isMcpToolsDialogOpen)
+        assertFalse(viewModel.toolBindingState.value.isMcpToolsLoading)
+    }
+
     private fun testViewModel(dao: FakeToolConnectionDao): PlatformSettingViewModel {
         val vault = FakeSecretVault()
         val repository = ToolConnectionRepository(dao, vault)

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingViewModelTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingViewModelTest.kt
@@ -1,6 +1,10 @@
 package dev.chungjungsoo.gptmobile.presentation.ui.setting
 
 import androidx.lifecycle.SavedStateHandle
+import dev.chungjungsoo.gptmobile.data.agent.tool.AgentToolResolver
+import dev.chungjungsoo.gptmobile.data.agent.tool.McpClientManager
+import dev.chungjungsoo.gptmobile.data.agent.tool.McpOAuthClient
+import dev.chungjungsoo.gptmobile.data.agent.tool.McpOAuthCoordinator
 import dev.chungjungsoo.gptmobile.data.database.dao.AgentToolBindingWithConnection
 import dev.chungjungsoo.gptmobile.data.database.dao.ToolConnectionDao
 import dev.chungjungsoo.gptmobile.data.database.entity.AgentToolBinding
@@ -11,9 +15,12 @@ import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnectionType
 import dev.chungjungsoo.gptmobile.data.dto.Platform
 import dev.chungjungsoo.gptmobile.data.dto.ThemeSetting
 import dev.chungjungsoo.gptmobile.data.model.ClientType
+import dev.chungjungsoo.gptmobile.data.network.NetworkClient
 import dev.chungjungsoo.gptmobile.data.repository.SecretMigrationError
 import dev.chungjungsoo.gptmobile.data.repository.SettingRepository
+import dev.chungjungsoo.gptmobile.data.repository.ToolConnectionRepository
 import dev.chungjungsoo.gptmobile.data.security.SecretVault
+import io.ktor.client.engine.cio.CIO
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -76,18 +83,70 @@ class PlatformSettingViewModelTest {
         assertEquals("search-2", viewModel.toolBindingState.value.selectedSearchConnectionUid)
     }
 
-    private fun testViewModel(dao: FakeToolConnectionDao): PlatformSettingViewModel = PlatformSettingViewModel(
-        settingRepository = FakeSettingRepository(),
-        toolConnectionDao = dao,
-        secretVault = FakeSecretVault(),
-        savedStateHandle = SavedStateHandle(mapOf("platformUid" to "profile-1"))
-    )
+    @Test
+    fun `saving MCP tool selection binds only selected server tool`() = runTest {
+        val dao = FakeToolConnectionDao(
+            connections = mutableMapOf("mcp-1" to testConnection("mcp-1", ToolConnectionType.MCP))
+        )
+        val viewModel = testViewModel(dao)
 
-    private fun testConnection(connectionUid: String): ToolConnection = ToolConnection(
+        viewModel.loadToolBindings()
+        viewModel.toggleMcpTool("mcp-1", "echo")
+        viewModel.saveMcpTools()
+
+        assertEquals(
+            listOf("mcp-1:echo"),
+            dao.listBindingsByProfile("profile-1").map { "${it.connectionUid}:${it.toolName}" }
+        )
+    }
+
+    @Test
+    fun `MCP tools named like builtins do not enable builtin bindings`() = runTest {
+        val dao = FakeToolConnectionDao(
+            connections = mutableMapOf("mcp-1" to testConnection("mcp-1", ToolConnectionType.MCP)),
+            bindings = mutableListOf(
+                AgentToolBinding("mcp-web", "profile-1", "mcp-1", "web_search"),
+                AgentToolBinding("mcp-read", "profile-1", "mcp-1", "read_url")
+            )
+        )
+        val viewModel = testViewModel(dao)
+
+        viewModel.loadToolBindings()
+
+        assertNull(viewModel.toolBindingState.value.selectedSearchConnectionUid)
+        assertFalse(viewModel.toolBindingState.value.readUrlEnabled)
+        assertEquals(setOf("web_search", "read_url"), viewModel.toolBindingState.value.selectedMcpTools.map { it.toolName }.toSet())
+    }
+
+    private fun testViewModel(dao: FakeToolConnectionDao): PlatformSettingViewModel {
+        val vault = FakeSecretVault()
+        val repository = ToolConnectionRepository(dao, vault)
+        val networkClient = NetworkClient(CIO)
+        val manager = McpClientManager(networkClient())
+        val resolver = AgentToolResolver(
+            repository,
+            vault,
+            networkClient,
+            manager,
+            McpOAuthCoordinator(McpOAuthClient(networkClient()), repository, vault, manager)
+        )
+        return PlatformSettingViewModel(
+            settingRepository = FakeSettingRepository(),
+            toolConnectionDao = dao,
+            secretVault = vault,
+            agentToolResolver = resolver,
+            savedStateHandle = SavedStateHandle(mapOf("platformUid" to "profile-1"))
+        )
+    }
+
+    private fun testConnection(
+        connectionUid: String,
+        type: String = ToolConnectionType.FIRECRAWL
+    ): ToolConnection = ToolConnection(
         connectionUid = connectionUid,
         name = connectionUid,
         alias = connectionUid.replace("-", "_"),
-        type = ToolConnectionType.FIRECRAWL,
+        type = type,
         endpointUrl = "https://example.com",
         authType = ToolConnectionAuthType.BEARER,
         secretRef = null,
@@ -102,7 +161,7 @@ class PlatformSettingViewModelTest {
     )
 }
 
-private class FakeToolConnectionDao(
+internal class FakeToolConnectionDao(
     val connections: MutableMap<String, ToolConnection> = mutableMapOf(),
     val bindings: MutableList<AgentToolBinding> = mutableListOf()
 ) : ToolConnectionDao {
@@ -156,10 +215,18 @@ private class FakeToolConnectionDao(
     }
 }
 
-private class FakeSecretVault : SecretVault {
-    override suspend fun put(secretRef: String, secret: ByteArray) = Unit
-    override suspend fun read(secretRef: String): ByteArray? = null
-    override suspend fun delete(secretRef: String) = Unit
+internal class FakeSecretVault : SecretVault {
+    val values = mutableMapOf<String, ByteArray>()
+
+    override suspend fun put(secretRef: String, secret: ByteArray) {
+        values[secretRef] = secret.copyOf()
+    }
+
+    override suspend fun read(secretRef: String): ByteArray? = values[secretRef]?.copyOf()
+
+    override suspend fun delete(secretRef: String) {
+        values.remove(secretRef)?.fill(0)
+    }
 }
 
 private class FakeSettingRepository : SettingRepository {

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsViewModelTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsViewModelTest.kt
@@ -116,6 +116,13 @@ class ToolConnectionsViewModelTest {
     }
 
     @Test
+    fun `MCP endpoint schemes are case insensitive`() {
+        assertTrue(ToolConnectionsViewModel.isValidMcpEndpoint("HTTPS://example.com/mcp", allowCleartext = false))
+        assertTrue(ToolConnectionsViewModel.isValidMcpEndpoint("HTTP://example.com/mcp", allowCleartext = true))
+        assertFalse(ToolConnectionsViewModel.isValidMcpEndpoint("HTTP://example.com/mcp", allowCleartext = false))
+    }
+
+    @Test
     fun `OAuth launch and callback persist credential and refresh connection state`() = runTest {
         McpOAuthClientTest.OAuthFixtureServer().use { server ->
             val dao = FakeToolConnectionDao()
@@ -164,6 +171,41 @@ class ToolConnectionsViewModelTest {
             assertEquals("access-1", credential.accessToken)
             assertNull(viewModel.uiState.value.errorMessage)
             assertTrue(viewModel.uiState.value.connections.any { it.connectionUid == "connection-1" && it.secretRef != null })
+            manager.closeAll()
+            networkClient().close()
+        }
+    }
+
+    @Test
+    fun `OAuth launch is single flight`() = runTest {
+        McpOAuthClientTest.OAuthFixtureServer().use { server ->
+            val dao = FakeToolConnectionDao()
+            val vault = FakeSecretVault()
+            val repository = ToolConnectionRepository(dao, vault)
+            val networkClient = NetworkClient(CIO)
+            val manager = McpClientManager(networkClient())
+            val coordinator = McpOAuthCoordinator(McpOAuthClient(networkClient()), repository, vault, manager)
+            dao.upsertConnection(
+                ToolConnection(
+                    connectionUid = "connection-1",
+                    name = "OAuth MCP",
+                    alias = "oauth_mcp",
+                    type = ToolConnectionType.MCP,
+                    endpointUrl = server.mcpUrl,
+                    authType = ToolConnectionAuthType.OAUTH,
+                    secretRef = null,
+                    oauthClientId = null,
+                    allowCleartext = true
+                )
+            )
+            val viewModel = ToolConnectionsViewModel(dao, vault, coordinator, manager)
+            val launch = async(start = CoroutineStart.UNDISPATCHED) { viewModel.oauthLaunches.first() }
+
+            viewModel.startOAuth("connection-1")
+            viewModel.startOAuth("connection-1")
+            launch.await()
+
+            assertEquals(1, server.protectedResourceRequests.get())
             manager.closeAll()
             networkClient().close()
         }

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsViewModelTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsViewModelTest.kt
@@ -123,6 +123,37 @@ class ToolConnectionsViewModelTest {
     }
 
     @Test
+    fun `save completion runs after persistence succeeds`() = runTest {
+        val dao = FakeToolConnectionDao()
+        val vault = FakeSecretVault()
+        val networkClient = NetworkClient(CIO)
+        val manager = McpClientManager(networkClient())
+        val repository = ToolConnectionRepository(dao, vault)
+        val coordinator = McpOAuthCoordinator(McpOAuthClient(networkClient()), repository, vault, manager)
+        val viewModel = ToolConnectionsViewModel(dao, vault, coordinator, manager)
+        var completed = false
+
+        viewModel.saveConnection(
+            existing = null,
+            provider = ToolConnectionsViewModel.providers.first { it.type == ToolConnectionType.FIRECRAWL },
+            name = "Search",
+            alias = "search",
+            endpointUrl = "",
+            authType = ToolConnectionAuthType.BEARER,
+            credential = "key",
+            oauthClientId = "",
+            allowCleartext = false,
+            clearCredential = false,
+            onSuccess = { completed = true }
+        )
+
+        assertTrue(completed)
+        assertEquals(1, dao.listConnections().size)
+        manager.closeAll()
+        networkClient().close()
+    }
+
+    @Test
     fun `OAuth launch and callback persist credential and refresh connection state`() = runTest {
         McpOAuthClientTest.OAuthFixtureServer().use { server ->
             val dao = FakeToolConnectionDao()

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsViewModelTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsViewModelTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -154,7 +155,66 @@ class ToolConnectionsViewModelTest {
     }
 
     @Test
-    fun `OAuth launch and callback persist credential and refresh connection state`() = runTest {
+    fun `browser launch failure surfaces OAuth error`() = runTest {
+        val dao = FakeToolConnectionDao()
+        val vault = FakeSecretVault()
+        val networkClient = NetworkClient(CIO)
+        val manager = McpClientManager(networkClient())
+        val repository = ToolConnectionRepository(dao, vault)
+        val coordinator = McpOAuthCoordinator(McpOAuthClient(networkClient()), repository, vault, manager)
+        val viewModel = ToolConnectionsViewModel(dao, vault, coordinator, manager)
+
+        viewModel.failOAuthLaunch()
+
+        assertFalse(viewModel.uiState.value.isOAuthBusy)
+        assertTrue(viewModel.uiState.value.errorMessage!!.contains("browser"))
+        manager.closeAll()
+        networkClient().close()
+    }
+
+    @Test
+    fun `blank credential is cleared when saved metadata changes`() = runTest {
+        val dao = FakeToolConnectionDao()
+        val vault = FakeSecretVault()
+        val networkClient = NetworkClient(CIO)
+        val manager = McpClientManager(networkClient())
+        val repository = ToolConnectionRepository(dao, vault)
+        val coordinator = McpOAuthCoordinator(McpOAuthClient(networkClient()), repository, vault, manager)
+        val existing = ToolConnection(
+            connectionUid = "search-1",
+            name = "Search",
+            alias = "search",
+            type = ToolConnectionType.FIRECRAWL,
+            endpointUrl = "https://api.firecrawl.dev/v2/search",
+            authType = ToolConnectionAuthType.BEARER,
+            secretRef = "connection_search-1",
+            oauthClientId = null
+        )
+        dao.upsertConnection(existing)
+        vault.put("connection_search-1", "old-key".encodeToByteArray())
+        val viewModel = ToolConnectionsViewModel(dao, vault, coordinator, manager)
+
+        viewModel.saveConnection(
+            existing = existing,
+            provider = ToolConnectionsViewModel.providers.first { it.type == ToolConnectionType.PERPLEXITY },
+            name = "Search",
+            alias = "search",
+            endpointUrl = "",
+            authType = ToolConnectionAuthType.BEARER,
+            credential = " ",
+            oauthClientId = "",
+            allowCleartext = false,
+            clearCredential = false
+        )
+
+        assertNull(dao.getConnection("search-1")!!.secretRef)
+        assertNull(vault.read("connection_search-1"))
+        manager.closeAll()
+        networkClient().close()
+    }
+
+    @Test
+    fun `OAuth launch and callback persist credential and refresh connection state`() = runBlocking {
         McpOAuthClientTest.OAuthFixtureServer().use { server ->
             val dao = FakeToolConnectionDao()
             val vault = FakeSecretVault()
@@ -208,7 +268,7 @@ class ToolConnectionsViewModelTest {
     }
 
     @Test
-    fun `OAuth launch is single flight`() = runTest {
+    fun `OAuth launch is single flight`() = runBlocking {
         McpOAuthClientTest.OAuthFixtureServer().use { server ->
             val dao = FakeToolConnectionDao()
             val vault = FakeSecretVault()
@@ -235,6 +295,7 @@ class ToolConnectionsViewModelTest {
             viewModel.startOAuth("connection-1")
             viewModel.startOAuth("connection-1")
             launch.await()
+            viewModel.uiState.first { !it.isOAuthBusy }
 
             assertEquals(1, server.protectedResourceRequests.get())
             manager.closeAll()

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsViewModelTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsViewModelTest.kt
@@ -1,15 +1,51 @@
 package dev.chungjungsoo.gptmobile.presentation.ui.setting
 
+import dev.chungjungsoo.gptmobile.data.agent.tool.MCP_OAUTH_SCHEME
+import dev.chungjungsoo.gptmobile.data.agent.tool.McpClientManager
+import dev.chungjungsoo.gptmobile.data.agent.tool.McpOAuthClient
+import dev.chungjungsoo.gptmobile.data.agent.tool.McpOAuthClientTest
+import dev.chungjungsoo.gptmobile.data.agent.tool.McpOAuthCoordinator
+import dev.chungjungsoo.gptmobile.data.agent.tool.McpOAuthCredential
+import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnection
 import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnectionAuthType
 import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnectionType
+import dev.chungjungsoo.gptmobile.data.network.NetworkClient
+import dev.chungjungsoo.gptmobile.data.repository.ToolConnectionRepository
+import io.ktor.client.engine.cio.CIO
+import java.net.URI
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 import java.util.Locale
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.decodeFromString
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ToolConnectionsViewModelTest {
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
     @Test
     fun `provider metadata records the credential transport`() {
         val providers = ToolConnectionsViewModel.providers.associateBy { it.type }
@@ -17,6 +53,7 @@ class ToolConnectionsViewModelTest {
         assertEquals(ToolConnectionAuthType.BEARER, providers.getValue(ToolConnectionType.FIRECRAWL).authType)
         assertEquals(ToolConnectionAuthType.BEARER, providers.getValue(ToolConnectionType.PERPLEXITY).authType)
         assertEquals(ToolConnectionAuthType.API_KEY, providers.getValue(ToolConnectionType.EXA).authType)
+        assertEquals(ToolConnectionAuthType.NONE, providers.getValue(ToolConnectionType.MCP).authType)
     }
 
     @Test
@@ -56,7 +93,7 @@ class ToolConnectionsViewModelTest {
             ToolConnectionsViewModel.shouldClearCredential(
                 existingType = ToolConnectionType.FIRECRAWL,
                 providerType = ToolConnectionType.EXA,
-                apiKey = " ",
+                credential = " ",
                 clearCredential = false
             )
         )
@@ -64,7 +101,7 @@ class ToolConnectionsViewModelTest {
             ToolConnectionsViewModel.shouldClearCredential(
                 existingType = ToolConnectionType.FIRECRAWL,
                 providerType = ToolConnectionType.EXA,
-                apiKey = "new-key",
+                credential = "new-key",
                 clearCredential = false
             )
         )
@@ -72,9 +109,71 @@ class ToolConnectionsViewModelTest {
             ToolConnectionsViewModel.shouldClearCredential(
                 existingType = ToolConnectionType.FIRECRAWL,
                 providerType = ToolConnectionType.FIRECRAWL,
-                apiKey = " ",
+                credential = " ",
                 clearCredential = false
             )
         )
     }
+
+    @Test
+    fun `OAuth launch and callback persist credential and refresh connection state`() = runTest {
+        McpOAuthClientTest.OAuthFixtureServer().use { server ->
+            val dao = FakeToolConnectionDao()
+            val vault = FakeSecretVault()
+            val repository = ToolConnectionRepository(dao, vault)
+            val networkClient = NetworkClient(CIO)
+            val manager = McpClientManager(networkClient())
+            val coordinator = McpOAuthCoordinator(McpOAuthClient(networkClient()), repository, vault, manager)
+            dao.upsertConnection(
+                ToolConnection(
+                    connectionUid = "connection-1",
+                    name = "OAuth MCP",
+                    alias = "oauth_mcp",
+                    type = ToolConnectionType.MCP,
+                    endpointUrl = server.mcpUrl,
+                    authType = ToolConnectionAuthType.OAUTH,
+                    secretRef = null,
+                    oauthClientId = null,
+                    allowCleartext = true
+                )
+            )
+            val viewModel = ToolConnectionsViewModel(dao, vault, coordinator, manager)
+            val launch = async(start = CoroutineStart.UNDISPATCHED) { viewModel.oauthLaunches.first() }
+
+            viewModel.startOAuth("connection-1")
+            val authorizationUri = launch.await()
+            val state = URI(authorizationUri).rawQuery.formValues().getValue("state")
+            val completion = async(start = CoroutineStart.UNDISPATCHED) {
+                viewModel.uiState.first { uiState ->
+                    !uiState.isOAuthBusy && uiState.connections.any { it.connectionUid == "connection-1" && it.secretRef != null }
+                }
+            }
+            viewModel.completeOAuthCallback(
+                "$MCP_OAUTH_SCHEME://oauth/mcp/connection-1?code=auth-code&state=$state"
+            )
+            completion.await()
+
+            val saved = dao.getConnection("connection-1")!!
+            val credentialBytes = vault.read(checkNotNull(saved.secretRef))!!
+            val credential = try {
+                NetworkClient.json.decodeFromString<McpOAuthCredential>(credentialBytes.decodeToString())
+            } finally {
+                credentialBytes.fill(0)
+            }
+            assertEquals("fixture-client", saved.oauthClientId)
+            assertEquals("access-1", credential.accessToken)
+            assertNull(viewModel.uiState.value.errorMessage)
+            assertTrue(viewModel.uiState.value.connections.any { it.connectionUid == "connection-1" && it.secretRef != null })
+            manager.closeAll()
+            networkClient().close()
+        }
+    }
 }
+
+private fun String.formValues(): Map<String, String> = split('&')
+    .filter(String::isNotBlank)
+    .associate { item ->
+        val parts = item.split('=', limit = 2)
+        URLDecoder.decode(parts[0], StandardCharsets.UTF_8) to
+            URLDecoder.decode(parts.getOrElse(1) { "" }, StandardCharsets.UTF_8)
+    }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ composeBom = "2026.06.00"
 datastore = "1.2.1"
 hilt = "2.59.2"
 ksp = "2.3.4" # Also change with Kotlin version
-ktor = "3.5.0"
+ktor = "3.5.1"
 material3 = "1.4.0"
 androidxHilt = "1.3.0"
 navigation = "2.9.8"
@@ -21,6 +21,8 @@ serialization = "1.11.0" # Should not update due to kotlin version
 splashscreen = "1.2.0"
 room = "2.8.4"
 coroutines = "1.11.0"
+mcpKotlinSdk = "0.15.0"
+browser = "1.9.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -62,6 +64,8 @@ room-compiler = { group = "androidx.room", name = "room-compiler", version.ref =
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
+mcp-kotlin-sdk-client = { group = "io.modelcontextprotocol", name = "kotlin-sdk-client", version.ref = "mcpKotlinSdk" }
+androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
 androidx-lifecycle-runtime-compose-android = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose-android", version.ref = "lifecycleRuntime" }
 
 [plugins]


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP tool connections with remote tool discovery and execution.
  * Added bearer-token and OAuth authentication, including browser-based authorization and token refresh.
  * Added MCP endpoint, credential, and cleartext HTTP configuration.
  * Added MCP tool selection and assignment in platform settings.
  * Improved tool result handling for text, structured data, resources, and errors.
* **Bug Fixes**
  * Sensitive MCP session headers are now hidden from network logs.
  * Deleting a connection also removes pending OAuth credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->