### PR TITLE
feat: run agents with persistent tool traces

### DIFF
--- a/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/database/AgentPersistenceDaoInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/database/AgentPersistenceDaoInstrumentedTest.kt
@@ -89,14 +89,73 @@ class AgentPersistenceDaoInstrumentedTest {
                 chatPlatformModels = mapOf("profile-1" to "gpt-5")
             )
         )
-        database.agentRunDao().updateStatus("run-1", AgentRunStatus.RUNNING, 200L, null, null)
+        assertEquals(1, database.agentRunDao().markRunning("run-1", 200L))
+        database.openHelper.writableDatabase.execSQL(
+            """
+            INSERT INTO tool_events (
+                event_id, run_id, sequence, call_id, connection_uid_snapshot,
+                connection_name_snapshot, tool_name, model_tool_name, arguments,
+                result, result_type, status, is_error, started_at, completed_at, error
+            ) VALUES (
+                'event-active', 'run-1', 0, 'call-active', NULL, NULL,
+                'read_url', 'read_url', '{}', NULL, NULL, 'RUNNING', 0, 201, NULL, NULL
+            )
+            """.trimIndent()
+        )
 
         val interrupted = database.agentRunDao().interruptActiveRuns(completedAt = 300L)
+        database.agentPersistenceDao().cancelInterruptedToolEvents(completedAt = 300L)
+        val lateCompletion = database.agentRunDao().finishRunning(
+            runId = "run-1",
+            status = AgentRunStatus.COMPLETED,
+            completedAt = 301L,
+            terminalError = null
+        )
 
         assertEquals(1, interrupted)
+        assertEquals(0, lateCompletion)
         assertEquals(AgentRunStatus.INTERRUPTED, database.agentRunDao().getById("run-1")?.status)
         assertEquals(300L, database.agentRunDao().getById("run-1")?.completedAt)
         assertEquals(persisted.chatRoom.id, database.agentRunDao().getById("run-1")?.chatId)
+        database.openHelper.writableDatabase.query(
+            "SELECT status, completed_at, error FROM tool_events WHERE event_id = 'event-active'"
+        ).use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("CANCELED", cursor.getString(0))
+            assertEquals(300L, cursor.getLong(1))
+            assertEquals("Interrupted when the app stopped.", cursor.getString(2))
+        }
+    }
+
+    @Test
+    fun finishActiveRun_terminalizesRunningRunBeforeLateCompletion() = runBlocking {
+        database.agentPersistenceDao().persistAgentTurn(
+            PersistAgentTurnRequest(
+                chatRoom = ChatRoomV2(title = "Chat", enabledPlatform = listOf("profile-1")),
+                userMessage = MessageV2(content = "Question", platformType = null),
+                runs = listOf(AgentRunDraft("run-1", "profile-1", "OPENAI", "gpt-5")),
+                chatPlatformModels = mapOf("profile-1" to "gpt-5")
+            )
+        )
+        assertEquals(1, database.agentRunDao().markRunning("run-1", 200L))
+
+        val canceled = database.agentRunDao().finishActive(
+            runId = "run-1",
+            status = AgentRunStatus.CANCELED,
+            completedAt = 300L,
+            terminalError = null
+        )
+        val lateCompletion = database.agentRunDao().finishRunning(
+            runId = "run-1",
+            status = AgentRunStatus.COMPLETED,
+            completedAt = 301L,
+            terminalError = null
+        )
+
+        assertEquals(1, canceled)
+        assertEquals(0, lateCompletion)
+        assertEquals(AgentRunStatus.CANCELED, database.agentRunDao().getById("run-1")?.status)
+        assertEquals(300L, database.agentRunDao().getById("run-1")?.completedAt)
     }
 
     @Test

--- a/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/database/AgentPersistenceDaoInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/data/database/AgentPersistenceDaoInstrumentedTest.kt
@@ -12,6 +12,7 @@ import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
 import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentRetryRequest
 import dev.chungjungsoo.gptmobile.data.database.entity.PersistAgentTurnRequest
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
+import dev.chungjungsoo.gptmobile.data.database.entity.ToolEventError
 import dev.chungjungsoo.gptmobile.data.model.ChatAttachment
 import dev.chungjungsoo.gptmobile.data.model.ClientType
 import kotlinx.coroutines.runBlocking
@@ -123,7 +124,7 @@ class AgentPersistenceDaoInstrumentedTest {
             assertTrue(cursor.moveToFirst())
             assertEquals("CANCELED", cursor.getString(0))
             assertEquals(300L, cursor.getLong(1))
-            assertEquals("Interrupted when the app stopped.", cursor.getString(2))
+            assertEquals(ToolEventError.INTERRUPTED_APP_STOPPED, cursor.getString(2))
         }
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
 
     <queries>
         <package android:name="com.google.android.aicore" />
@@ -53,6 +57,11 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+        <service
+            android:name=".presentation.service.AgentRunForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync"
+            android:stopWithTask="false" />
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/AgentRunCoordinator.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/AgentRunCoordinator.kt
@@ -1,0 +1,291 @@
+package dev.chungjungsoo.gptmobile.data.agent
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRunStatus
+import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
+import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
+import dev.chungjungsoo.gptmobile.data.database.entity.resetActiveRevision
+import dev.chungjungsoo.gptmobile.data.repository.ChatRepository
+import dev.chungjungsoo.gptmobile.presentation.service.AgentRunForegroundService
+import dev.chungjungsoo.gptmobile.util.ApiStateFlowOutcome
+import dev.chungjungsoo.gptmobile.util.buildAssistantErrorContent
+import dev.chungjungsoo.gptmobile.util.collectApiStateUpdates
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+data class AgentRunRequest(
+    val runId: String,
+    val chatId: Int,
+    val assistantMessage: MessageV2,
+    val platform: PlatformV2,
+    val userMessages: List<MessageV2>,
+    val assistantMessages: List<List<MessageV2>>
+)
+
+data class ActiveAgentRun(
+    val runId: String,
+    val chatId: Int,
+    val profileUid: String
+)
+
+data class AgentRunNotice(val chatId: Int, val message: String)
+
+@Singleton
+class AgentRunCoordinator @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val chatRepository: ChatRepository
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val jobs = ConcurrentHashMap<String, Job>()
+    private val interruptingRunIds = ConcurrentHashMap.newKeySet<String>()
+    private val _activeRuns = MutableStateFlow<Map<String, ActiveAgentRun>>(emptyMap())
+    private val _notices = MutableSharedFlow<AgentRunNotice>(extraBufferCapacity = 8)
+
+    val activeRuns = _activeRuns.asStateFlow()
+    val notices = _notices.asSharedFlow()
+
+    fun start(requests: List<AgentRunRequest>) {
+        val pending = requests.distinctBy(AgentRunRequest::runId).mapNotNull { request ->
+            val job = scope.launch(start = CoroutineStart.LAZY) {
+                try {
+                    execute(request)
+                } finally {
+                    jobs.remove(request.runId)
+                    interruptingRunIds.remove(request.runId)
+                    _activeRuns.update { it - request.runId }
+                }
+            }
+            if (jobs.putIfAbsent(request.runId, job) == null) {
+                request to job
+            } else {
+                job.cancel()
+                null
+            }
+        }
+        if (pending.isEmpty()) return
+
+        _activeRuns.update { active ->
+            active + pending.associate { (request, _) ->
+                request.runId to ActiveAgentRun(request.runId, request.chatId, request.platform.uid)
+            }
+        }
+        try {
+            AgentRunForegroundService.start(context)
+        } catch (error: RuntimeException) {
+            pending.forEach { (request, job) ->
+                jobs.remove(request.runId)
+                job.cancel()
+            }
+            _activeRuns.update { active -> active - pending.map { it.first.runId }.toSet() }
+            failQueuedStarts(pending.map { it.first }, error)
+            return
+        }
+        pending.forEach { (_, job) -> job.start() }
+    }
+
+    fun cancelChat(chatId: Int) {
+        val runIds = _activeRuns.value.values
+            .filter { it.chatId == chatId }
+            .mapTo(mutableSetOf(), ActiveAgentRun::runId)
+        requestCancellation(runIds, isInterrupted = false)
+    }
+
+    fun cancelAll() {
+        requestCancellation(jobs.keys.toSet(), isInterrupted = false)
+    }
+
+    fun interruptAll() {
+        requestCancellation(jobs.keys.toSet(), isInterrupted = true)
+    }
+
+    suspend fun cancelChatAndJoin(chatId: Int) {
+        val runIds = _activeRuns.value.values
+            .filter { it.chatId == chatId }
+            .mapTo(mutableSetOf(), ActiveAgentRun::runId)
+        val chatJobs = runIds.mapNotNull(jobs::get)
+        withContext(NonCancellable) {
+            terminalizeAndCancel(runIds, isInterrupted = false)
+        }
+        chatJobs.joinAll()
+    }
+
+    fun hasActiveRuns(chatId: Int): Boolean = _activeRuns.value.values.any { it.chatId == chatId }
+
+    private fun requestCancellation(runIds: Set<String>, isInterrupted: Boolean) {
+        if (runIds.isEmpty()) return
+        scope.launch {
+            terminalizeAndCancel(runIds, isInterrupted)
+        }
+    }
+
+    private suspend fun terminalizeAndCancel(runIds: Set<String>, isInterrupted: Boolean) {
+        if (runIds.isEmpty()) return
+        if (isInterrupted) interruptingRunIds += runIds
+        val completedAt = currentEpochSeconds()
+        runIds.forEach { runId ->
+            try {
+                chatRepository.finishActiveAgentRun(
+                    runId = runId,
+                    status = if (isInterrupted) AgentRunStatus.INTERRUPTED else AgentRunStatus.CANCELED,
+                    completedAt = completedAt,
+                    terminalError = if (isInterrupted) "Foreground agent service stopped." else null
+                )
+            } catch (_: Exception) {
+            } finally {
+                jobs[runId]?.cancel()
+            }
+        }
+    }
+
+    private fun failQueuedStarts(requests: List<AgentRunRequest>, error: RuntimeException) {
+        scope.launch {
+            val completedAt = currentEpochSeconds()
+            val message = error.message?.takeIf { it.isNotBlank() }
+                ?: "Android did not allow the foreground agent service to start."
+            requests.forEach { request ->
+                runCatching {
+                    chatRepository.updateAgentMessage(
+                        request.assistantMessage.copy(
+                            content = buildAssistantErrorContent(request.assistantMessage.content, message),
+                            createdAt = completedAt
+                        ).resetActiveRevision()
+                    )
+                }
+                runCatching {
+                    chatRepository.finishQueuedAgentRun(
+                        request.runId,
+                        AgentRunStatus.FAILED,
+                        completedAt,
+                        message
+                    )
+                }
+            }
+        }
+    }
+
+    private suspend fun execute(request: AgentRunRequest) {
+        val startedAt = currentEpochSeconds()
+        var assistantMessage = request.assistantMessage
+        try {
+            if (!withContext(NonCancellable) { chatRepository.markAgentRunRunning(request.runId, startedAt) }) return
+            val outcome = chatRepository.completeChat(
+                request.userMessages,
+                request.assistantMessages,
+                request.platform,
+                request.runId
+            ).collectApiStateUpdates(
+                onUpdate = { content, thoughts ->
+                    assistantMessage = assistantMessage.copy(content = content, thoughts = thoughts)
+                    chatRepository.updateAgentMessage(assistantMessage)
+                },
+                onNotice = { notice -> _notices.tryEmit(AgentRunNotice(request.chatId, notice)) },
+                publishIntervalMillis = 250L
+            )
+            val terminal = outcome.toTerminalUpdate()
+            val completedAt = currentEpochSeconds()
+            val terminalMessage = assistantMessage.copy(
+                content = terminal.error
+                    ?.let { buildAssistantErrorContent(assistantMessage.content, it) }
+                    ?: assistantMessage.content,
+                createdAt = completedAt
+            ).resetActiveRevision()
+            commitTerminalAgentRun(
+                finishRun = {
+                    chatRepository.finishAgentRun(
+                        request.runId,
+                        terminal.status,
+                        completedAt,
+                        terminal.error
+                    )
+                },
+                persistMessage = { chatRepository.updateAgentMessage(terminalMessage) }
+            )
+        } catch (error: CancellationException) {
+            withContext(NonCancellable) {
+                val completedAt = currentEpochSeconds()
+                runCatching {
+                    val isInterrupted = interruptingRunIds.remove(request.runId)
+                    commitTerminalAgentRun(
+                        finishRun = {
+                            chatRepository.finishAgentRun(
+                                request.runId,
+                                if (isInterrupted) AgentRunStatus.INTERRUPTED else AgentRunStatus.CANCELED,
+                                completedAt,
+                                if (isInterrupted) "Foreground agent service stopped." else null
+                            )
+                        },
+                        persistMessage = {
+                            chatRepository.updateAgentMessage(
+                                assistantMessage.copy(createdAt = completedAt).resetActiveRevision()
+                            )
+                        }
+                    )
+                }
+            }
+            throw error
+        } catch (error: Throwable) {
+            withContext(NonCancellable) {
+                val completedAt = currentEpochSeconds()
+                val message = error.message ?: "Unknown provider error."
+                runCatching {
+                    val terminalMessage = assistantMessage.copy(
+                        content = buildAssistantErrorContent(assistantMessage.content, message),
+                        createdAt = completedAt
+                    ).resetActiveRevision()
+                    commitTerminalAgentRun(
+                        finishRun = {
+                            chatRepository.finishAgentRun(
+                                request.runId,
+                                AgentRunStatus.FAILED,
+                                completedAt,
+                                message
+                            )
+                        },
+                        persistMessage = { chatRepository.updateAgentMessage(terminalMessage) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+internal data class AgentRunTerminalUpdate(val status: String, val error: String?)
+
+internal fun ApiStateFlowOutcome.toTerminalUpdate(): AgentRunTerminalUpdate = when (this) {
+    ApiStateFlowOutcome.Completed -> AgentRunTerminalUpdate(AgentRunStatus.COMPLETED, null)
+
+    is ApiStateFlowOutcome.Failed -> AgentRunTerminalUpdate(AgentRunStatus.FAILED, message)
+
+    ApiStateFlowOutcome.Incomplete -> AgentRunTerminalUpdate(
+        AgentRunStatus.FAILED,
+        "Provider stream ended without completion."
+    )
+}
+
+internal suspend fun commitTerminalAgentRun(
+    finishRun: suspend () -> Boolean,
+    persistMessage: suspend () -> Unit
+): Boolean = withContext(NonCancellable) {
+    if (!finishRun()) return@withContext false
+    persistMessage()
+    true
+}
+
+private fun currentEpochSeconds(): Long = System.currentTimeMillis() / 1000

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/AgentRunCoordinator.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/AgentRunCoordinator.kt
@@ -3,6 +3,7 @@ package dev.chungjungsoo.gptmobile.data.agent
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.chungjungsoo.gptmobile.data.database.entity.AgentRunStatus
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRunTerminalError
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
 import dev.chungjungsoo.gptmobile.data.database.entity.resetActiveRevision
@@ -28,6 +29,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withContext
 
 data class AgentRunRequest(
@@ -54,6 +56,7 @@ class AgentRunCoordinator @Inject constructor(
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val jobs = ConcurrentHashMap<String, Job>()
+    private val chatLocks = ConcurrentHashMap<Int, Mutex>()
     private val interruptingRunIds = ConcurrentHashMap.newKeySet<String>()
     private val _activeRuns = MutableStateFlow<Map<String, ActiveAgentRun>>(emptyMap())
     private val _notices = MutableSharedFlow<AgentRunNotice>(extraBufferCapacity = 8)
@@ -62,17 +65,26 @@ class AgentRunCoordinator @Inject constructor(
     val notices = _notices.asSharedFlow()
 
     fun start(requests: List<AgentRunRequest>) {
+        scope.launch {
+            withChatGate(requests.map { it.chatId }) {
+                startUnlocked(requests)
+            }
+        }
+    }
+
+    private fun startUnlocked(requests: List<AgentRunRequest>) {
         val pending = requests.distinctBy(AgentRunRequest::runId).mapNotNull { request ->
             val job = scope.launch(start = CoroutineStart.LAZY) {
-                try {
-                    execute(request)
-                } finally {
-                    jobs.remove(request.runId)
-                    interruptingRunIds.remove(request.runId)
-                    _activeRuns.update { it - request.runId }
-                }
+                execute(request)
             }
             if (jobs.putIfAbsent(request.runId, job) == null) {
+                job.invokeOnCompletionCleanup {
+                    runCatching {
+                        jobs.remove(request.runId)
+                        interruptingRunIds.remove(request.runId)
+                        _activeRuns.update { it - request.runId }
+                    }
+                }
                 request to job
             } else {
                 job.cancel()
@@ -126,6 +138,20 @@ class AgentRunCoordinator @Inject constructor(
 
     fun hasActiveRuns(chatId: Int): Boolean = _activeRuns.value.values.any { it.chatId == chatId }
 
+    suspend fun <T> withChatGate(chatId: Int, block: suspend () -> T): T = withChatGate(listOf(chatId), block)
+
+    suspend fun <T> withChatGate(chatIds: List<Int>, block: suspend () -> T): T {
+        val locks = locksFor(chatIds)
+        locks.forEach { it.lock() }
+        return try {
+            block()
+        } finally {
+            locks.asReversed().forEach { it.unlock() }
+        }
+    }
+
+    private fun locksFor(chatIds: List<Int>): List<Mutex> = chatIds.distinct().sorted().map { chatLocks.computeIfAbsent(it) { Mutex() } }
+
     private fun requestCancellation(runIds: Set<String>, isInterrupted: Boolean) {
         if (runIds.isEmpty()) return
         scope.launch {
@@ -144,7 +170,7 @@ class AgentRunCoordinator @Inject constructor(
                         runId = runId,
                         status = if (isInterrupted) AgentRunStatus.INTERRUPTED else AgentRunStatus.CANCELED,
                         completedAt = completedAt,
-                        terminalError = if (isInterrupted) "Foreground agent service stopped." else null
+                        terminalError = if (isInterrupted) AgentRunTerminalError.SERVICE_STOPPED else null
                     )
                 }
             }
@@ -225,7 +251,7 @@ class AgentRunCoordinator @Inject constructor(
                                 request.runId,
                                 if (isInterrupted) AgentRunStatus.INTERRUPTED else AgentRunStatus.CANCELED,
                                 completedAt,
-                                if (isInterrupted) "Foreground agent service stopped." else null
+                                if (isInterrupted) AgentRunTerminalError.SERVICE_STOPPED else null
                             )
                         },
                         persistMessage = {
@@ -288,6 +314,10 @@ internal suspend fun commitTerminalAgentRun(
 internal suspend fun cancelAndJoinAgentRun(job: Job?, finishActiveRun: suspend () -> Unit) {
     job?.cancelAndJoin()
     finishActiveRun()
+}
+
+internal fun Job.invokeOnCompletionCleanup(cleanup: () -> Unit) {
+    invokeOnCompletion { cleanup() }
 }
 
 private fun currentEpochSeconds(): Long = System.currentTimeMillis() / 1000

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/AgentRunCoordinator.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/AgentRunCoordinator.kt
@@ -21,12 +21,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -119,11 +119,9 @@ class AgentRunCoordinator @Inject constructor(
         val runIds = _activeRuns.value.values
             .filter { it.chatId == chatId }
             .mapTo(mutableSetOf(), ActiveAgentRun::runId)
-        val chatJobs = runIds.mapNotNull(jobs::get)
         withContext(NonCancellable) {
             terminalizeAndCancel(runIds, isInterrupted = false)
         }
-        chatJobs.joinAll()
     }
 
     fun hasActiveRuns(chatId: Int): Boolean = _activeRuns.value.values.any { it.chatId == chatId }
@@ -140,16 +138,15 @@ class AgentRunCoordinator @Inject constructor(
         if (isInterrupted) interruptingRunIds += runIds
         val completedAt = currentEpochSeconds()
         runIds.forEach { runId ->
-            try {
-                chatRepository.finishActiveAgentRun(
-                    runId = runId,
-                    status = if (isInterrupted) AgentRunStatus.INTERRUPTED else AgentRunStatus.CANCELED,
-                    completedAt = completedAt,
-                    terminalError = if (isInterrupted) "Foreground agent service stopped." else null
-                )
-            } catch (_: Exception) {
-            } finally {
-                jobs[runId]?.cancel()
+            runCatching {
+                cancelAndJoinAgentRun(jobs[runId]) {
+                    chatRepository.finishActiveAgentRun(
+                        runId = runId,
+                        status = if (isInterrupted) AgentRunStatus.INTERRUPTED else AgentRunStatus.CANCELED,
+                        completedAt = completedAt,
+                        terminalError = if (isInterrupted) "Foreground agent service stopped." else null
+                    )
+                }
             }
         }
     }
@@ -286,6 +283,11 @@ internal suspend fun commitTerminalAgentRun(
     if (!finishRun()) return@withContext false
     persistMessage()
     true
+}
+
+internal suspend fun cancelAndJoinAgentRun(job: Job?, finishActiveRun: suspend () -> Unit) {
+    job?.cancelAndJoin()
+    finishActiveRun()
 }
 
 private fun currentEpochSeconds(): Long = System.currentTimeMillis() / 1000

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/dao/AgentPersistenceDao.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/dao/AgentPersistenceDao.kt
@@ -109,7 +109,7 @@ interface AgentPersistenceDao {
         UPDATE tool_events
         SET status = 'CANCELED',
             completed_at = :completedAt,
-            error = COALESCE(error, 'Interrupted when the app stopped.')
+            error = COALESCE(error, 'INTERRUPTED_APP_STOPPED')
         WHERE status IN ('PENDING', 'RUNNING')
             AND run_id IN (SELECT run_id FROM agent_runs WHERE status = 'INTERRUPTED')
         """

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/dao/AgentPersistenceDao.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/dao/AgentPersistenceDao.kt
@@ -104,6 +104,18 @@ interface AgentPersistenceDao {
     @Query("UPDATE tool_events SET status = 'CANCELED', completed_at = :completedAt WHERE run_id = :runId AND status IN ('PENDING', 'RUNNING')")
     suspend fun cancelActiveToolEvents(runId: String, completedAt: Long)
 
+    @Query(
+        """
+        UPDATE tool_events
+        SET status = 'CANCELED',
+            completed_at = :completedAt,
+            error = COALESCE(error, 'Interrupted when the app stopped.')
+        WHERE status IN ('PENDING', 'RUNNING')
+            AND run_id IN (SELECT run_id FROM agent_runs WHERE status = 'INTERRUPTED')
+        """
+    )
+    suspend fun cancelInterruptedToolEvents(completedAt: Long)
+
     @Transaction
     suspend fun persistAgentTurn(request: PersistAgentTurnRequest): PersistAgentTurnResult {
         val chatRoom = if (request.chatRoom.id == 0) {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/dao/AgentRunDao.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/dao/AgentRunDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Upsert
 import dev.chungjungsoo.gptmobile.data.database.entity.AgentRun
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface AgentRunDao {
@@ -16,6 +17,9 @@ interface AgentRunDao {
     @Query("SELECT * FROM agent_runs WHERE chat_id = :chatId ORDER BY created_at, run_id")
     suspend fun getByChatId(chatId: Int): List<AgentRun>
 
+    @Query("SELECT * FROM agent_runs WHERE chat_id = :chatId ORDER BY created_at, run_id")
+    fun observeByChatId(chatId: Int): Flow<List<AgentRun>>
+
     @Query(
         "UPDATE agent_runs SET status = :status, started_at = :startedAt, " +
             "completed_at = :completedAt, terminal_error = :terminalError WHERE run_id = :runId"
@@ -27,6 +31,45 @@ interface AgentRunDao {
         completedAt: Long?,
         terminalError: String?
     )
+
+    @Query(
+        "UPDATE agent_runs SET status = 'RUNNING', started_at = :startedAt, " +
+            "completed_at = NULL, terminal_error = NULL WHERE run_id = :runId AND status = 'QUEUED'"
+    )
+    suspend fun markRunning(runId: String, startedAt: Long): Int
+
+    @Query(
+        "UPDATE agent_runs SET status = :status, completed_at = :completedAt, terminal_error = :terminalError " +
+            "WHERE run_id = :runId AND status = 'RUNNING'"
+    )
+    suspend fun finishRunning(
+        runId: String,
+        status: String,
+        completedAt: Long,
+        terminalError: String?
+    ): Int
+
+    @Query(
+        "UPDATE agent_runs SET status = :status, completed_at = :completedAt, terminal_error = :terminalError " +
+            "WHERE run_id = :runId AND status = 'QUEUED'"
+    )
+    suspend fun finishQueued(
+        runId: String,
+        status: String,
+        completedAt: Long,
+        terminalError: String?
+    ): Int
+
+    @Query(
+        "UPDATE agent_runs SET status = :status, completed_at = :completedAt, terminal_error = :terminalError " +
+            "WHERE run_id = :runId AND status IN ('QUEUED', 'RUNNING')"
+    )
+    suspend fun finishActive(
+        runId: String,
+        status: String,
+        completedAt: Long,
+        terminalError: String?
+    ): Int
 
     @Query(
         "UPDATE agent_runs SET status = 'INTERRUPTED', completed_at = :completedAt " +

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/dao/MessageV2Dao.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/dao/MessageV2Dao.kt
@@ -6,12 +6,16 @@ import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Update
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface MessageV2Dao {
 
     @Query("SELECT * FROM messages_v2 WHERE chat_id=:chatInt")
     suspend fun loadMessages(chatInt: Int): List<MessageV2>
+
+    @Query("SELECT * FROM messages_v2 WHERE chat_id = :chatId ORDER BY created_at, message_id")
+    fun observeMessages(chatId: Int): Flow<List<MessageV2>>
 
     @Query(
         "SELECT DISTINCT chat_id FROM messages_v2 " +

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/AgentRun.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/AgentRun.kt
@@ -115,3 +115,7 @@ object AgentRunStatus {
     const val CANCELED = "CANCELED"
     const val INTERRUPTED = "INTERRUPTED"
 }
+
+object AgentRunTerminalError {
+    const val SERVICE_STOPPED = "SERVICE_STOPPED"
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/ToolEvent.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/database/entity/ToolEvent.kt
@@ -86,3 +86,7 @@ object ToolEventResultType {
     const val RESOURCE_LINKS = "RESOURCE_LINKS"
     const val UNSUPPORTED = "UNSUPPORTED"
 }
+
+object ToolEventError {
+    const val INTERRUPTED_APP_STOPPED = "INTERRUPTED_APP_STOPPED"
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepository.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepository.kt
@@ -1,5 +1,6 @@
 package dev.chungjungsoo.gptmobile.data.repository
 
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRun
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoom
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoomV2
 import dev.chungjungsoo.gptmobile.data.database.entity.Message
@@ -21,6 +22,8 @@ interface ChatRepository {
         platform: PlatformV2,
         runId: String
     ): Flow<ApiState>
+    fun observeMessagesV2(chatId: Int): Flow<List<MessageV2>>
+    fun observeAgentRuns(chatId: Int): Flow<List<AgentRun>>
     fun observeToolEvents(chatId: Int): Flow<List<ToolEvent>>
     suspend fun fetchChatList(): List<ChatRoom>
     suspend fun fetchChatListV2(): List<ChatRoomV2>
@@ -31,21 +34,11 @@ interface ChatRepository {
     suspend fun saveChatPlatformModels(chatId: Int, models: Map<String, String>)
     suspend fun persistAgentTurn(request: PersistAgentTurnRequest): PersistAgentTurnResult
     suspend fun persistAgentRetry(request: PersistAgentRetryRequest): PersistAgentRetryResult
-    suspend fun updateAgentRunStatus(
-        runId: String,
-        status: String,
-        startedAt: Long?,
-        completedAt: Long?,
-        terminalError: String?
-    )
-    suspend fun finishAgentRun(
-        assistantMessage: MessageV2,
-        runId: String,
-        status: String,
-        startedAt: Long?,
-        completedAt: Long?,
-        terminalError: String?
-    )
+    suspend fun markAgentRunRunning(runId: String, startedAt: Long): Boolean
+    suspend fun finishAgentRun(runId: String, status: String, completedAt: Long, terminalError: String?): Boolean
+    suspend fun finishQueuedAgentRun(runId: String, status: String, completedAt: Long, terminalError: String?): Boolean
+    suspend fun finishActiveAgentRun(runId: String, status: String, completedAt: Long, terminalError: String?): Boolean
+    suspend fun updateAgentMessage(message: MessageV2)
     suspend fun interruptActiveAgentRuns(completedAt: Long): Int
     suspend fun migrateToChatRoomV2MessageV2()
     fun generateDefaultChatTitle(messages: List<MessageV2>): String?

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImpl.kt
@@ -46,6 +46,7 @@ import dev.chungjungsoo.gptmobile.data.network.OpenAIAPI
 import dev.chungjungsoo.gptmobile.util.stripAssistantErrorNote
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
@@ -121,7 +122,9 @@ class ChatRepositoryImpl @Inject constructor(
                 }
             }
         } finally {
-            toolEventRecorder.cancelRun(runId, currentEpochSeconds())
+            withContext(NonCancellable) {
+                toolEventRecorder.cancelRun(runId, currentEpochSeconds())
+            }
         }
     }.catch { error ->
         emit(ApiState.Error(error.message ?: "Failed to complete chat"))
@@ -206,6 +209,10 @@ class ChatRepositoryImpl @Inject constructor(
 
     override suspend fun fetchMessagesV2(chatId: Int): List<MessageV2> = messageV2Dao.loadMessages(chatId)
 
+    override fun observeMessagesV2(chatId: Int): Flow<List<MessageV2>> = messageV2Dao.observeMessages(chatId)
+
+    override fun observeAgentRuns(chatId: Int) = agentRunDao.observeByChatId(chatId)
+
     override fun observeToolEvents(chatId: Int): Flow<List<ToolEvent>> = toolEventRecorder.observeChat(chatId)
 
     override suspend fun fetchChatPlatformModels(chatId: Int): Map<String, String> = chatPlatformModelV2Dao.getByChatId(chatId).associate {
@@ -232,31 +239,32 @@ class ChatRepositoryImpl @Inject constructor(
 
     override suspend fun persistAgentRetry(request: PersistAgentRetryRequest): PersistAgentRetryResult = agentPersistenceDao.persistAgentRetry(request)
 
-    override suspend fun updateAgentRunStatus(
-        runId: String,
-        status: String,
-        startedAt: Long?,
-        completedAt: Long?,
-        terminalError: String?
-    ) {
-        agentRunDao.updateStatus(runId, status, startedAt, completedAt, terminalError)
-    }
+    override suspend fun markAgentRunRunning(runId: String, startedAt: Long): Boolean = agentRunDao.markRunning(runId, startedAt) == 1
 
     override suspend fun finishAgentRun(
-        assistantMessage: MessageV2,
         runId: String,
         status: String,
-        startedAt: Long?,
-        completedAt: Long?,
+        completedAt: Long,
         terminalError: String?
-    ) = agentPersistenceDao.finishAgentRun(
-        assistantMessage,
-        runId,
-        status,
-        startedAt,
-        completedAt,
-        terminalError
-    )
+    ): Boolean = agentRunDao.finishRunning(runId, status, completedAt, terminalError) == 1
+
+    override suspend fun finishQueuedAgentRun(
+        runId: String,
+        status: String,
+        completedAt: Long,
+        terminalError: String?
+    ): Boolean = agentRunDao.finishQueued(runId, status, completedAt, terminalError) == 1
+
+    override suspend fun finishActiveAgentRun(
+        runId: String,
+        status: String,
+        completedAt: Long,
+        terminalError: String?
+    ): Boolean = agentRunDao.finishActive(runId, status, completedAt, terminalError) == 1
+
+    override suspend fun updateAgentMessage(message: MessageV2) {
+        messageV2Dao.editMessages(message)
+    }
 
     override suspend fun interruptActiveAgentRuns(completedAt: Long): Int = agentRunDao.interruptActiveRuns(completedAt)
 

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/AppForegroundTracker.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/AppForegroundTracker.kt
@@ -1,0 +1,31 @@
+package dev.chungjungsoo.gptmobile.presentation
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import kotlin.math.max
+
+object AppForegroundTracker : Application.ActivityLifecycleCallbacks {
+    private var startedActivities = 0
+
+    val isBackgrounded: Boolean
+        get() = startedActivities == 0
+
+    override fun onActivityStarted(activity: Activity) {
+        startedActivities += 1
+    }
+
+    override fun onActivityStopped(activity: Activity) {
+        startedActivities = max(0, startedActivities - 1)
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+
+    override fun onActivityResumed(activity: Activity) = Unit
+
+    override fun onActivityPaused(activity: Activity) = Unit
+
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+
+    override fun onActivityDestroyed(activity: Activity) = Unit
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileApp.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileApp.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.chungjungsoo.gptmobile.R
 import dev.chungjungsoo.gptmobile.data.backup.SanitizedChatBackup
+import dev.chungjungsoo.gptmobile.data.database.dao.AgentPersistenceDao
 import dev.chungjungsoo.gptmobile.data.database.dao.AgentRunDao
 import dev.chungjungsoo.gptmobile.data.repository.SecretMigrationError
 import dev.chungjungsoo.gptmobile.data.repository.SettingRepository
@@ -16,6 +17,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
 @HiltAndroidApp
@@ -29,6 +31,9 @@ class GPTMobileApp : Application() {
     lateinit var agentRunDao: AgentRunDao
 
     @Inject
+    lateinit var agentPersistenceDao: AgentPersistenceDao
+
+    @Inject
     lateinit var settingRepository: SettingRepository
 
     @Volatile
@@ -40,12 +45,10 @@ class GPTMobileApp : Application() {
     override fun onCreate() {
         SanitizedChatBackup.restoreIfPresent(this)
         super.onCreate()
-        applicationScope.launch {
-            runCatching {
-                agentRunDao.interruptActiveRuns(System.currentTimeMillis() / 1000)
-            }.onFailure { error ->
-                Log.e(TAG, "Unable to mark active agent runs as interrupted.", error)
-            }
+        runBlocking(Dispatchers.IO) {
+            val interruptedAt = System.currentTimeMillis() / 1000
+            agentRunDao.interruptActiveRuns(interruptedAt)
+            agentPersistenceDao.cancelInterruptedToolEvents(interruptedAt)
         }
         applicationScope.launch {
             secretMigrationErrors = try {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileApp.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileApp.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
 @HiltAndroidApp
@@ -45,17 +44,15 @@ class GPTMobileApp : Application() {
     override fun onCreate() {
         SanitizedChatBackup.restoreIfPresent(this)
         super.onCreate()
-        runBlocking(Dispatchers.IO) {
-            val interruptedAt = System.currentTimeMillis() / 1000
-            agentRunDao.interruptActiveRuns(interruptedAt)
-            agentPersistenceDao.cancelInterruptedToolEvents(interruptedAt)
-        }
         applicationScope.launch {
-            secretMigrationErrors = try {
-                settingRepository.migrateSecrets()
-            } catch (error: Exception) {
-                listOf(SecretMigrationError("startup", error.message ?: "Credential migration failed."))
-            }
+            secretMigrationErrors = runStartupMaintenance(
+                interruptPersistedWork = {
+                    val interruptedAt = System.currentTimeMillis() / 1000
+                    agentRunDao.interruptActiveRuns(interruptedAt)
+                    agentPersistenceDao.cancelInterruptedToolEvents(interruptedAt)
+                },
+                migrateSecrets = settingRepository::migrateSecrets
+            )
             if (secretMigrationErrors.isNotEmpty()) {
                 runCatching {
                     withContext(Dispatchers.Main) {
@@ -74,5 +71,17 @@ class GPTMobileApp : Application() {
 
     private companion object {
         const val TAG = "GPTMobileApp"
+    }
+}
+
+internal suspend fun runStartupMaintenance(
+    interruptPersistedWork: suspend () -> Unit,
+    migrateSecrets: suspend () -> List<SecretMigrationError>
+): List<SecretMigrationError> {
+    interruptPersistedWork()
+    return try {
+        migrateSecrets()
+    } catch (error: Exception) {
+        listOf(SecretMigrationError("startup", error.message ?: "Credential migration failed."))
     }
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileApp.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileApp.kt
@@ -44,6 +44,7 @@ class GPTMobileApp : Application() {
     override fun onCreate() {
         SanitizedChatBackup.restoreIfPresent(this)
         super.onCreate()
+        registerActivityLifecycleCallbacks(AppForegroundTracker)
         applicationScope.launch {
             secretMigrationErrors = runStartupMaintenance(
                 interruptPersistedWork = {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileApp.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileApp.kt
@@ -15,6 +15,7 @@ import dev.chungjungsoo.gptmobile.data.repository.SettingRepository
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -45,7 +46,7 @@ class GPTMobileApp : Application() {
         SanitizedChatBackup.restoreIfPresent(this)
         super.onCreate()
         registerActivityLifecycleCallbacks(AppForegroundTracker)
-        applicationScope.launch {
+        StartupRecoveryGate.start(applicationScope) {
             secretMigrationErrors = runStartupMaintenance(
                 interruptPersistedWork = {
                     val interruptedAt = System.currentTimeMillis() / 1000
@@ -72,6 +73,19 @@ class GPTMobileApp : Application() {
 
     private companion object {
         const val TAG = "GPTMobileApp"
+    }
+}
+
+object StartupRecoveryGate {
+    @Volatile
+    private var job: Job? = null
+
+    fun start(scope: CoroutineScope, block: suspend () -> Unit) {
+        job = scope.launch { block() }
+    }
+
+    suspend fun await() {
+        job?.join()
     }
 }
 

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/service/AgentRunForegroundService.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/service/AgentRunForegroundService.kt
@@ -15,6 +15,7 @@ import androidx.core.content.ContextCompat
 import dagger.hilt.android.AndroidEntryPoint
 import dev.chungjungsoo.gptmobile.R
 import dev.chungjungsoo.gptmobile.data.agent.AgentRunCoordinator
+import dev.chungjungsoo.gptmobile.presentation.AppForegroundTracker
 import dev.chungjungsoo.gptmobile.presentation.ui.main.MainActivity
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
@@ -34,15 +35,21 @@ class AgentRunForegroundService : Service() {
     override fun onCreate() {
         super.onCreate()
         createNotificationChannel()
+        var wasActive = coordinator.activeRuns.value.isNotEmpty()
         showNotification(coordinator.activeRuns.value.size)
         serviceScope.launch {
             coordinator.activeRuns.collectLatest { activeRuns ->
-                if (activeRuns.isEmpty()) {
+                val isActive = activeRuns.isNotEmpty()
+                if (!isActive) {
                     ServiceCompat.stopForeground(this@AgentRunForegroundService, ServiceCompat.STOP_FOREGROUND_REMOVE)
+                    if (shouldNotifyAgentRunsCompleted(wasActive, isActive, AppForegroundTracker.isBackgrounded)) {
+                        showCompletionNotification()
+                    }
                     stopSelf()
                 } else {
                     showNotification(activeRuns.size)
                 }
+                wasActive = isActive
             }
         }
     }
@@ -78,15 +85,7 @@ class AgentRunForegroundService : Service() {
     }
 
     private fun buildNotification(activeCount: Int): Notification {
-        val openAppIntent = Intent(this, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
-        }
-        val openApp = PendingIntent.getActivity(
-            this,
-            0,
-            openAppIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
+        val openApp = buildOpenAppPendingIntent(0)
         val cancelRuns = PendingIntent.getService(
             this,
             1,
@@ -104,6 +103,32 @@ class AgentRunForegroundService : Service() {
             .setProgress(0, 0, true)
             .addAction(0, getString(R.string.cancel_agent_runs), cancelRuns)
             .build()
+    }
+
+    private fun showCompletionNotification() {
+        val manager = getSystemService(NotificationManager::class.java)
+        manager.notify(NOTIFICATION_ID, buildCompletionNotification())
+    }
+
+    private fun buildCompletionNotification(): Notification = NotificationCompat.Builder(this, CHANNEL_ID)
+        .setSmallIcon(R.drawable.ic_gpt_mobile_monochrome_foreground)
+        .setContentTitle(getString(R.string.agent_completion_notification_title))
+        .setContentText(getString(R.string.agent_completion_notification_text))
+        .setContentIntent(buildOpenAppPendingIntent(2))
+        .setAutoCancel(true)
+        .setCategory(NotificationCompat.CATEGORY_STATUS)
+        .build()
+
+    private fun buildOpenAppPendingIntent(requestCode: Int): PendingIntent {
+        val openAppIntent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        return PendingIntent.getActivity(
+            this,
+            requestCode,
+            openAppIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
     }
 
     private fun createNotificationChannel() {
@@ -130,3 +155,9 @@ class AgentRunForegroundService : Service() {
         }
     }
 }
+
+internal fun shouldNotifyAgentRunsCompleted(
+    wasActive: Boolean,
+    isActive: Boolean,
+    isAppBackground: Boolean
+): Boolean = wasActive && !isActive && isAppBackground

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/service/AgentRunForegroundService.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/service/AgentRunForegroundService.kt
@@ -31,23 +31,32 @@ class AgentRunForegroundService : Service() {
     lateinit var coordinator: AgentRunCoordinator
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var stoppedBecauseInactive = false
 
     override fun onCreate() {
         super.onCreate()
         createNotificationChannel()
         var wasActive = coordinator.activeRuns.value.isNotEmpty()
-        showNotification(coordinator.activeRuns.value.size)
+        if (!showNotification(coordinator.activeRuns.value.size)) {
+            coordinator.interruptAll()
+            stopSelf()
+            return
+        }
         serviceScope.launch {
             coordinator.activeRuns.collectLatest { activeRuns ->
                 val isActive = activeRuns.isNotEmpty()
                 if (!isActive) {
+                    stoppedBecauseInactive = true
                     ServiceCompat.stopForeground(this@AgentRunForegroundService, ServiceCompat.STOP_FOREGROUND_REMOVE)
                     if (shouldNotifyAgentRunsCompleted(wasActive, isActive, AppForegroundTracker.isBackgrounded)) {
                         showCompletionNotification()
                     }
                     stopSelf()
                 } else {
-                    showNotification(activeRuns.size)
+                    if (!showNotification(activeRuns.size)) {
+                        coordinator.interruptAll()
+                        stopSelf()
+                    }
                 }
                 wasActive = isActive
             }
@@ -62,7 +71,9 @@ class AgentRunForegroundService : Service() {
     }
 
     override fun onDestroy() {
-        coordinator.interruptAll()
+        if (shouldInterruptAgentRunsOnDestroy(stoppedBecauseInactive, coordinator.activeRuns.value.isNotEmpty())) {
+            coordinator.interruptAll()
+        }
         serviceScope.cancel()
         super.onDestroy()
     }
@@ -75,14 +86,14 @@ class AgentRunForegroundService : Service() {
 
     override fun onBind(intent: Intent?): IBinder? = null
 
-    private fun showNotification(activeCount: Int) {
+    private fun showNotification(activeCount: Int): Boolean = runCatching {
         ServiceCompat.startForeground(
             this,
             NOTIFICATION_ID,
             buildNotification(activeCount.coerceAtLeast(1)),
             ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
         )
-    }
+    }.isSuccess
 
     private fun buildNotification(activeCount: Int): Notification {
         val openApp = buildOpenAppPendingIntent(0)
@@ -120,7 +131,7 @@ class AgentRunForegroundService : Service() {
         .build()
 
     private fun buildOpenAppPendingIntent(requestCode: Int): PendingIntent {
-        val openAppIntent = Intent(this, MainActivity::class.java).apply {
+        val openAppIntent = Intent().setClass(this, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
         }
         return PendingIntent.getActivity(
@@ -161,3 +172,5 @@ internal fun shouldNotifyAgentRunsCompleted(
     isActive: Boolean,
     isAppBackground: Boolean
 ): Boolean = wasActive && !isActive && isAppBackground
+
+internal fun shouldInterruptAgentRunsOnDestroy(stoppedBecauseInactive: Boolean, hasActiveRuns: Boolean): Boolean = !stoppedBecauseInactive && hasActiveRuns

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/service/AgentRunForegroundService.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/service/AgentRunForegroundService.kt
@@ -1,0 +1,132 @@
+package dev.chungjungsoo.gptmobile.presentation.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import androidx.core.content.ContextCompat
+import dagger.hilt.android.AndroidEntryPoint
+import dev.chungjungsoo.gptmobile.R
+import dev.chungjungsoo.gptmobile.data.agent.AgentRunCoordinator
+import dev.chungjungsoo.gptmobile.presentation.ui.main.MainActivity
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class AgentRunForegroundService : Service() {
+    @Inject
+    lateinit var coordinator: AgentRunCoordinator
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+        showNotification(coordinator.activeRuns.value.size)
+        serviceScope.launch {
+            coordinator.activeRuns.collectLatest { activeRuns ->
+                if (activeRuns.isEmpty()) {
+                    ServiceCompat.stopForeground(this@AgentRunForegroundService, ServiceCompat.STOP_FOREGROUND_REMOVE)
+                    stopSelf()
+                } else {
+                    showNotification(activeRuns.size)
+                }
+            }
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_CANCEL_ALL) {
+            coordinator.cancelAll()
+        }
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        coordinator.interruptAll()
+        serviceScope.cancel()
+        super.onDestroy()
+    }
+
+    override fun onTimeout(startId: Int, fgsType: Int) {
+        coordinator.interruptAll()
+        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
+        stopSelf(startId)
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun showNotification(activeCount: Int) {
+        ServiceCompat.startForeground(
+            this,
+            NOTIFICATION_ID,
+            buildNotification(activeCount.coerceAtLeast(1)),
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+        )
+    }
+
+    private fun buildNotification(activeCount: Int): Notification {
+        val openAppIntent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        val openApp = PendingIntent.getActivity(
+            this,
+            0,
+            openAppIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val cancelRuns = PendingIntent.getService(
+            this,
+            1,
+            Intent(this, AgentRunForegroundService::class.java).setAction(ACTION_CANCEL_ALL),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_gpt_mobile_monochrome_foreground)
+            .setContentTitle(getString(R.string.agent_notification_title))
+            .setContentText(resources.getQuantityString(R.plurals.agent_runs_active, activeCount, activeCount))
+            .setContentIntent(openApp)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+            .setProgress(0, 0, true)
+            .addAction(0, getString(R.string.cancel_agent_runs), cancelRuns)
+            .build()
+    }
+
+    private fun createNotificationChannel() {
+        val manager = getSystemService(NotificationManager::class.java)
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.agent_notification_channel),
+                NotificationManager.IMPORTANCE_LOW
+            )
+        )
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "agent_runs"
+        private const val NOTIFICATION_ID = 8001
+        private const val ACTION_CANCEL_ALL = "dev.chungjungsoo.gptmobile.action.CANCEL_AGENT_RUNS"
+
+        fun start(context: Context) {
+            ContextCompat.startForegroundService(
+                context,
+                Intent(context, AgentRunForegroundService::class.java)
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/AgentRunStatusBlock.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/AgentRunStatusBlock.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -22,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import dev.chungjungsoo.gptmobile.R
 import dev.chungjungsoo.gptmobile.data.database.entity.AgentRun
 import dev.chungjungsoo.gptmobile.data.database.entity.AgentRunStatus
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRunTerminalError
 
 @Composable
 fun AgentRunStatusBlock(run: AgentRun?, modifier: Modifier = Modifier) {
@@ -34,10 +36,15 @@ fun AgentRunStatusBlock(run: AgentRun?, modifier: Modifier = Modifier) {
         AgentRunStatus.INTERRUPTED -> stringResource(R.string.agent_run_interrupted)
         else -> stringResource(R.string.agent_run_failed)
     }
-    val duration = agentRunDurationSeconds(run)?.let { " · ${it}s" }.orEmpty()
+    val duration = agentRunDurationSeconds(run)
+        ?.let { " · ${pluralStringResource(R.plurals.duration_seconds, it.toInt(), it)}" }
+        .orEmpty()
+    val terminalError = run.terminalError
+        ?.takeIf { it.isNotBlank() }
+        ?.let { agentRunTerminalErrorText(it) }
 
     Card(
-        modifier = modifier.semantics { contentDescription = status },
+        modifier = modifier.semantics { contentDescription = listOfNotNull(status + duration, terminalError).joinToString(". ") },
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
@@ -52,7 +59,7 @@ fun AgentRunStatusBlock(run: AgentRun?, modifier: Modifier = Modifier) {
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
-            run.terminalError?.takeIf { it.isNotBlank() }?.let { error ->
+            terminalError?.let { error ->
                 Text(
                     text = error,
                     style = MaterialTheme.typography.bodySmall,
@@ -64,6 +71,12 @@ fun AgentRunStatusBlock(run: AgentRun?, modifier: Modifier = Modifier) {
             }
         }
     }
+}
+
+@Composable
+private fun agentRunTerminalErrorText(error: String): String = when (error) {
+    AgentRunTerminalError.SERVICE_STOPPED -> stringResource(R.string.agent_run_error_service_stopped)
+    else -> error
 }
 
 internal fun agentRunDurationSeconds(run: AgentRun): Long? {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/AgentRunStatusBlock.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/AgentRunStatusBlock.kt
@@ -1,0 +1,73 @@
+package dev.chungjungsoo.gptmobile.presentation.ui.chat
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dev.chungjungsoo.gptmobile.R
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRun
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRunStatus
+
+@Composable
+fun AgentRunStatusBlock(run: AgentRun?, modifier: Modifier = Modifier) {
+    if (run == null || run.status == AgentRunStatus.COMPLETED) return
+
+    val status = when (run.status) {
+        AgentRunStatus.QUEUED -> stringResource(R.string.agent_run_queued)
+        AgentRunStatus.RUNNING -> stringResource(R.string.agent_run_running)
+        AgentRunStatus.CANCELED -> stringResource(R.string.agent_run_canceled)
+        AgentRunStatus.INTERRUPTED -> stringResource(R.string.agent_run_interrupted)
+        else -> stringResource(R.string.agent_run_failed)
+    }
+    val duration = agentRunDurationSeconds(run)?.let { " · ${it}s" }.orEmpty()
+
+    Card(
+        modifier = modifier.semantics { contentDescription = status },
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (run.status == AgentRunStatus.QUEUED || run.status == AgentRunStatus.RUNNING) {
+                    CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                Text(
+                    text = status + duration,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            run.terminalError?.takeIf { it.isNotBlank() }?.let { error ->
+                Text(
+                    text = error,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+            }
+        }
+    }
+}
+
+internal fun agentRunDurationSeconds(run: AgentRun): Long? {
+    val startedAt = run.startedAt ?: return null
+    val completedAt = run.completedAt ?: return null
+    return (completedAt - startedAt).coerceAtLeast(0)
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dev.chungjungsoo.gptmobile.R
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRun
 import dev.chungjungsoo.gptmobile.data.database.entity.ToolEvent
 import dev.chungjungsoo.gptmobile.presentation.theme.GPTMobileTheme
 import java.io.File
@@ -93,6 +94,7 @@ fun OpponentChatBubble(
     text: String,
     thoughts: String = "",
     attachments: List<String> = emptyList(),
+    agentRun: AgentRun? = null,
     toolEvents: List<ToolEvent> = emptyList(),
     contentIdentity: Any = text,
     canEdit: Boolean = false,
@@ -117,6 +119,11 @@ fun OpponentChatBubble(
     val isThinking = isLoading && thoughts.isNotBlank() && text.isBlank()
 
     Column(modifier = modifier) {
+        AgentRunStatusBlock(
+            run = agentRun,
+            modifier = Modifier.padding(top = 8.dp, start = 8.dp, end = 8.dp)
+        )
+
         // Thinking block (collapsed by default)
         if (thoughts.isNotBlank()) {
             ThinkingBlock(
@@ -173,6 +180,14 @@ fun OpponentChatBubble(
                         Spacer(modifier = Modifier.width(8.dp))
                         RetryIcon(onRetryClick)
                     }
+                }
+                if (canRetry) {
+                    Text(
+                        text = stringResource(R.string.retry_tools_warning),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(start = 16.dp, top = 4.dp)
+                    )
                 }
 
                 revisionIndexLabel?.let { label ->

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
@@ -69,6 +69,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -92,6 +93,8 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider.getUriForFile
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.chungjungsoo.gptmobile.R
 import dev.chungjungsoo.gptmobile.data.database.entity.ACTIVE_REVISION_LATEST
@@ -148,11 +151,9 @@ fun ChatScreen(
     val isIdle = loadingStates.all { it == ChatViewModel.LoadingState.Idle }
     val context = LocalContext.current
     val lastMessageIndex = groupedMessages.userMessages.lastIndex
-    var requestedNotificationPermission by remember { mutableStateOf(false) }
-    var sendAfterLocalNetworkPermission by remember { mutableStateOf(false) }
-    val notificationPermissionLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.RequestPermission()
-    ) { requestedNotificationPermission = true }
+    var requestedNotificationPermission by rememberSaveable { mutableStateOf(false) }
+    var sendAfterNotificationPermission by rememberSaveable { mutableStateOf(false) }
+    var sendAfterLocalNetworkPermission by rememberSaveable { mutableStateOf(false) }
     val localNetworkPermissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { granted ->
@@ -164,8 +165,30 @@ fun ChatScreen(
         }
         sendAfterLocalNetworkPermission = false
     }
+    val notificationPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) {
+        requestedNotificationPermission = true
+        if (sendAfterNotificationPermission) {
+            if (needsLocalNetworkAccess &&
+                Build.VERSION.SDK_INT >= 37 &&
+                ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_LOCAL_NETWORK) != PackageManager.PERMISSION_GRANTED
+            ) {
+                sendAfterLocalNetworkPermission = true
+                localNetworkPermissionLauncher.launch(Manifest.permission.ACCESS_LOCAL_NETWORK)
+            } else {
+                chatViewModel.askQuestion()
+                focusManager.clearFocus()
+            }
+        }
+        sendAfterNotificationPermission = false
+    }
 
     val scope = rememberCoroutineScope()
+
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        chatViewModel.refreshLocalNetworkRequirement()
+    }
 
     suspend fun animateScrollToLatestMessage() {
         if (lastMessageIndex >= 0) {
@@ -185,16 +208,6 @@ fun ChatScreen(
         attachmentNotice?.let { notice ->
             Toast.makeText(context, notice, Toast.LENGTH_SHORT).show()
             chatViewModel.consumeAttachmentNotice()
-        }
-    }
-
-    LaunchedEffect(isIdle) {
-        if (!isIdle &&
-            !requestedNotificationPermission &&
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
-        ) {
-            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
     }
 
@@ -343,7 +356,13 @@ fun ChatScreen(
                 onFileRemoved = { filePath -> chatViewModel.removeSelectedFile(filePath) },
                 onCancelButtonClick = chatViewModel::cancelActiveRuns
             ) {
-                if (needsLocalNetworkAccess &&
+                if (!requestedNotificationPermission &&
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                    ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+                ) {
+                    sendAfterNotificationPermission = true
+                    notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                } else if (needsLocalNetworkAccess &&
                     Build.VERSION.SDK_INT >= 37 &&
                     ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_LOCAL_NETWORK) != PackageManager.PERMISSION_GRANTED
                 ) {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
@@ -1,9 +1,11 @@
 package dev.chungjungsoo.gptmobile.presentation.ui.chat
 
+import android.Manifest
 import android.content.ClipData
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.os.Build
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -42,6 +44,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.rounded.KeyboardArrowDown
 import androidx.compose.material3.CircularProgressIndicator
@@ -86,17 +89,21 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider.getUriForFile
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.chungjungsoo.gptmobile.R
 import dev.chungjungsoo.gptmobile.data.database.entity.ACTIVE_REVISION_LATEST
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRun
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRunStatus
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
 import dev.chungjungsoo.gptmobile.data.database.entity.ToolEvent
 import dev.chungjungsoo.gptmobile.data.database.entity.effectiveContent
 import dev.chungjungsoo.gptmobile.data.database.entity.effectiveRunId
 import dev.chungjungsoo.gptmobile.data.database.entity.effectiveThoughts
+import dev.chungjungsoo.gptmobile.util.isAssistantErrorMessage
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -121,6 +128,7 @@ fun ChatScreen(
 
     val chatRoom by chatViewModel.chatRoom.collectAsStateWithLifecycle()
     val groupedMessages by chatViewModel.groupedMessages.collectAsStateWithLifecycle()
+    val agentRunsById by chatViewModel.agentRunsById.collectAsStateWithLifecycle()
     val toolEventsByRun by chatViewModel.toolEventsByRun.collectAsStateWithLifecycle()
     val indexStates by chatViewModel.indexStates.collectAsStateWithLifecycle()
     val loadingStates by chatViewModel.loadingStates.collectAsStateWithLifecycle()
@@ -131,6 +139,7 @@ fun ChatScreen(
     val isLoaded by chatViewModel.isLoaded.collectAsStateWithLifecycle()
     val selectedAttachments by chatViewModel.selectedAttachments.collectAsStateWithLifecycle()
     val attachmentNotice by chatViewModel.attachmentNotice.collectAsStateWithLifecycle()
+    val needsLocalNetworkAccess by chatViewModel.needsLocalNetworkAccess.collectAsStateWithLifecycle()
     val appEnabledPlatforms by chatViewModel.enabledPlatformsInApp.collectAsStateWithLifecycle()
     val appAllPlatforms by chatViewModel.platformsInApp.collectAsStateWithLifecycle()
     val chatPlatformModels by chatViewModel.chatPlatformModels.collectAsStateWithLifecycle()
@@ -139,6 +148,22 @@ fun ChatScreen(
     val isIdle = loadingStates.all { it == ChatViewModel.LoadingState.Idle }
     val context = LocalContext.current
     val lastMessageIndex = groupedMessages.userMessages.lastIndex
+    var requestedNotificationPermission by remember { mutableStateOf(false) }
+    var sendAfterLocalNetworkPermission by remember { mutableStateOf(false) }
+    val notificationPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { requestedNotificationPermission = true }
+    val localNetworkPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted && sendAfterLocalNetworkPermission) {
+            chatViewModel.askQuestion()
+            focusManager.clearFocus()
+        } else if (!granted) {
+            Toast.makeText(context, R.string.local_network_permission_required, Toast.LENGTH_SHORT).show()
+        }
+        sendAfterLocalNetworkPermission = false
+    }
 
     val scope = rememberCoroutineScope()
 
@@ -160,6 +185,16 @@ fun ChatScreen(
         attachmentNotice?.let { notice ->
             Toast.makeText(context, notice, Toast.LENGTH_SHORT).show()
             chatViewModel.consumeAttachmentNotice()
+        }
+    }
+
+    LaunchedEffect(isIdle) {
+        if (!isIdle &&
+            !requestedNotificationPermission &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+        ) {
+            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
     }
 
@@ -218,6 +253,7 @@ fun ChatScreen(
                             messageIndex = index,
                             message = groupedMessages.userMessages[index],
                             assistantMessages = groupedMessages.assistantMessages.getOrNull(index) ?: emptyList(),
+                            agentRunsById = agentRunsById,
                             toolEventsByRun = toolEventsByRun,
                             platformIndexState = indexStates.getOrElse(index) { 0 },
                             loadingStates = loadingStates,
@@ -249,6 +285,7 @@ fun ChatScreen(
                                 messageIndex = lastMessageIndex,
                                 message = groupedMessages.userMessages[lastMessageIndex],
                                 assistantMessages = groupedMessages.assistantMessages.getOrNull(lastMessageIndex) ?: emptyList(),
+                                agentRunsById = agentRunsById,
                                 toolEventsByRun = toolEventsByRun,
                                 platformIndexState = indexStates.getOrElse(lastMessageIndex) { 0 },
                                 loadingStates = loadingStates,
@@ -300,12 +337,22 @@ fun ChatScreen(
                 inputState = chatViewModel.question,
                 chatEnabled = canUseChat,
                 sendButtonEnabled = isIdle,
+                isRunning = !isIdle,
                 selectedAttachments = selectedAttachments,
                 onFileSelected = { filePath -> chatViewModel.addSelectedFile(filePath) },
-                onFileRemoved = { filePath -> chatViewModel.removeSelectedFile(filePath) }
+                onFileRemoved = { filePath -> chatViewModel.removeSelectedFile(filePath) },
+                onCancelButtonClick = chatViewModel::cancelActiveRuns
             ) {
-                chatViewModel.askQuestion()
-                focusManager.clearFocus()
+                if (needsLocalNetworkAccess &&
+                    Build.VERSION.SDK_INT >= 37 &&
+                    ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_LOCAL_NETWORK) != PackageManager.PERMISSION_GRANTED
+                ) {
+                    sendAfterLocalNetworkPermission = true
+                    localNetworkPermissionLauncher.launch(Manifest.permission.ACCESS_LOCAL_NETWORK)
+                } else {
+                    chatViewModel.askQuestion()
+                    focusManager.clearFocus()
+                }
             }
         }
 
@@ -391,6 +438,7 @@ private fun ChatMessagePair(
     messageIndex: Int,
     message: MessageV2,
     assistantMessages: List<MessageV2>,
+    agentRunsById: Map<String, AgentRun>,
     toolEventsByRun: Map<String, List<ToolEvent>>,
     platformIndexState: Int,
     loadingStates: List<ChatViewModel.LoadingState>,
@@ -413,9 +461,9 @@ private fun ChatMessagePair(
     val selectedAssistantMessage = assistantMessages.getOrNull(platformIndexState)
     val assistantContent = selectedAssistantMessage?.effectiveContent() ?: ""
     val assistantThoughts = selectedAssistantMessage?.effectiveThoughts() ?: ""
-    val toolEvents = selectedAssistantMessage?.effectiveRunId()
-        ?.let(toolEventsByRun::get)
-        .orEmpty()
+    val selectedRunId = selectedAssistantMessage?.effectiveRunId()
+    val agentRun = selectedRunId?.let(agentRunsById::get)
+    val toolEvents = selectedRunId?.let(toolEventsByRun::get).orEmpty()
     val canShowPreviousRevision = selectedAssistantMessage?.let { assistantMessage ->
         assistantMessage.revisions.isNotEmpty() &&
             assistantMessage.activeRevisionIndex < assistantMessage.revisions.lastIndex
@@ -492,11 +540,13 @@ private fun ChatMessagePair(
                 canEdit = canUseChat && isIdle,
                 canRetry = canUseChat && isActiveMessage && !isCurrentPlatformLoading,
                 isLoading = isActiveMessage && isCurrentPlatformLoading,
+                isError = agentRun?.status == AgentRunStatus.FAILED && isAssistantErrorMessage(assistantContent),
                 text = assistantContent,
                 thoughts = assistantThoughts,
                 attachments = selectedAssistantMessage?.attachments.orEmpty().map { it.filePathForDisplay },
+                agentRun = agentRun,
                 toolEvents = toolEvents,
-                contentIdentity = "$messageIndex:$selectedPlatformUid",
+                contentIdentity = "$messageIndex:$selectedPlatformUid:${selectedRunId.orEmpty()}:${selectedAssistantMessage?.activeRevisionIndex}",
                 revisionIndexLabel = selectedAssistantMessage?.let { assistantMessage ->
                     val totalRevisions = assistantMessage.revisions.size + 1
                     if (assistantMessage.activeRevisionIndex == ACTIVE_REVISION_LATEST) {
@@ -715,9 +765,11 @@ fun ChatInputBox(
     inputState: TextFieldState = rememberTextFieldState(),
     chatEnabled: Boolean = true,
     sendButtonEnabled: Boolean = true,
+    isRunning: Boolean = false,
     selectedAttachments: List<ChatAttachmentDraft> = emptyList(),
     onFileSelected: (String) -> Unit = {},
     onFileRemoved: (String) -> Unit = {},
+    onCancelButtonClick: () -> Unit = {},
     onSendButtonClick: () -> Unit = {}
 ) {
     val localStyle = LocalTextStyle.current
@@ -792,10 +844,20 @@ fun ChatInputBox(
                         }
                     }
                     IconButton(
-                        enabled = chatEnabled && sendButtonEnabled && hasQuestionText,
-                        onClick = onSendButtonClick
+                        enabled = isRunning || (chatEnabled && sendButtonEnabled && hasQuestionText),
+                        onClick = if (isRunning) onCancelButtonClick else onSendButtonClick
                     ) {
-                        Icon(imageVector = ImageVector.vectorResource(id = R.drawable.ic_send), contentDescription = stringResource(R.string.send))
+                        if (isRunning) {
+                            Icon(
+                                imageVector = Icons.Filled.Stop,
+                                contentDescription = stringResource(R.string.cancel_active_runs)
+                            )
+                        } else {
+                            Icon(
+                                imageVector = ImageVector.vectorResource(id = R.drawable.ic_send),
+                                contentDescription = stringResource(R.string.send)
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModel.kt
@@ -32,6 +32,7 @@ import dev.chungjungsoo.gptmobile.data.repository.AttachmentUploadCoordinator
 import dev.chungjungsoo.gptmobile.data.repository.ChatRepository
 import dev.chungjungsoo.gptmobile.data.repository.SettingRepository
 import dev.chungjungsoo.gptmobile.data.repository.ToolConnectionRepository
+import dev.chungjungsoo.gptmobile.presentation.StartupRecoveryGate
 import dev.chungjungsoo.gptmobile.util.AttachmentPayloadCache
 import dev.chungjungsoo.gptmobile.util.FileUtils
 import dev.chungjungsoo.gptmobile.util.buildAssistantErrorContent
@@ -206,6 +207,10 @@ class ChatViewModel @Inject constructor(
 
     fun cancelActiveRuns() {
         _chatRoom.value.id.takeIf { it > 0 }?.let(agentRunCoordinator::cancelChat)
+    }
+
+    fun refreshLocalNetworkRequirement() {
+        fetchEnabledPlatformsInApp()
     }
 
     override fun onCleared() {
@@ -668,92 +673,6 @@ class ChatViewModel @Inject constructor(
         }
     }
 
-    private fun launchProviderRun(
-        runId: String,
-        turnIndex: Int,
-        platformIndex: Int,
-        platform: PlatformV2,
-        contextMessages: GroupedMessages
-    ) {
-        viewModelScope.launch {
-            val startedAt = currentTimeStamp
-            try {
-                chatRepository.updateAgentRunStatus(
-                    runId,
-                    AgentRunStatus.RUNNING,
-                    startedAt,
-                    null,
-                    null
-                )
-                val outcome = chatRepository.completeChat(
-                    contextMessages.userMessages,
-                    contextMessages.assistantMessages,
-                    platform,
-                    runId
-                ).handleStates(
-                    messageFlow = _groupedMessages,
-                    turnIndex = turnIndex,
-                    platformIdx = platformIndex,
-                    onLoadingComplete = {},
-                    onNotice = { notice -> _attachmentNotice.update { notice } }
-                )
-                val terminal = outcome.toAgentRunTerminalUpdate()
-                chatRepository.finishAgentRun(
-                    assistantMessage = _groupedMessages.value.assistantMessages[turnIndex][platformIndex],
-                    runId = runId,
-                    status = terminal.status,
-                    startedAt = startedAt,
-                    completedAt = currentTimeStamp,
-                    terminalError = terminal.error
-                )
-            } catch (error: CancellationException) {
-                withContext(NonCancellable) {
-                    runCatching {
-                        chatRepository.updateAgentRunStatus(
-                            runId,
-                            AgentRunStatus.CANCELED,
-                            startedAt,
-                            currentTimeStamp,
-                            null
-                        )
-                    }
-                    runCatching {
-                        chatRepository.saveChat(
-                            chatRoom = _chatRoom.value,
-                            messages = persistableMessages(_groupedMessages.value),
-                            chatPlatformModels = _chatPlatformModels.value
-                        )
-                    }
-                }
-                throw error
-            } catch (error: Throwable) {
-                val message = error.message ?: "Unknown provider error."
-                _groupedMessages.update { groupedMessages ->
-                    updateAssistantSlot(groupedMessages, turnIndex, platformIndex) { assistantMessage ->
-                        assistantMessage.copy(
-                            content = buildAssistantErrorContent(assistantMessage.content, message),
-                            createdAt = currentTimeStamp
-                        )
-                    }
-                }
-                runCatching {
-                    chatRepository.finishAgentRun(
-                        assistantMessage = _groupedMessages.value.assistantMessages[turnIndex][platformIndex],
-                        runId = runId,
-                        status = AgentRunStatus.FAILED,
-                        startedAt = startedAt,
-                        completedAt = currentTimeStamp,
-                        terminalError = message
-                    )
-                }
-            } finally {
-                _loadingStates.update { states ->
-                    states.toMutableList().apply { this[platformIndex] = LoadingState.Idle }
-                }
-            }
-        }
-    }
-
     private fun showPersistenceFailure(turnIndex: Int, platformIndexes: List<Int>, error: Throwable) {
         val message = error.message ?: "Failed to save this turn."
         _groupedMessages.update { groupedMessages ->
@@ -1094,6 +1013,7 @@ class ChatViewModel @Inject constructor(
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun observePersistedMessages() {
         viewModelScope.launch {
+            StartupRecoveryGate.await()
             _chatRoom
                 .map { it.id }
                 .distinctUntilChanged()
@@ -1120,6 +1040,7 @@ class ChatViewModel @Inject constructor(
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun observeAgentRuns() {
         viewModelScope.launch {
+            StartupRecoveryGate.await()
             _chatRoom
                 .map { it.id }
                 .distinctUntilChanged()
@@ -1165,6 +1086,7 @@ class ChatViewModel @Inject constructor(
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun observeToolEvents() {
         viewModelScope.launch {
+            StartupRecoveryGate.await()
             _chatRoom
                 .map { it.id }
                 .distinctUntilChanged()

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModel.kt
@@ -9,7 +9,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.chungjungsoo.gptmobile.R
+import dev.chungjungsoo.gptmobile.data.agent.AgentRunCoordinator
+import dev.chungjungsoo.gptmobile.data.agent.AgentRunRequest
 import dev.chungjungsoo.gptmobile.data.database.entity.ACTIVE_REVISION_LATEST
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRun
 import dev.chungjungsoo.gptmobile.data.database.entity.AgentRunDraft
 import dev.chungjungsoo.gptmobile.data.database.entity.AgentRunStatus
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoomV2
@@ -27,18 +31,18 @@ import dev.chungjungsoo.gptmobile.data.database.entity.snapshotLatestAssistantRe
 import dev.chungjungsoo.gptmobile.data.repository.AttachmentUploadCoordinator
 import dev.chungjungsoo.gptmobile.data.repository.ChatRepository
 import dev.chungjungsoo.gptmobile.data.repository.SettingRepository
-import dev.chungjungsoo.gptmobile.util.ApiStateFlowOutcome
+import dev.chungjungsoo.gptmobile.data.repository.ToolConnectionRepository
 import dev.chungjungsoo.gptmobile.util.AttachmentPayloadCache
 import dev.chungjungsoo.gptmobile.util.FileUtils
 import dev.chungjungsoo.gptmobile.util.buildAssistantErrorContent
+import dev.chungjungsoo.gptmobile.util.determineLocalNetworkAccessRequirement
 import dev.chungjungsoo.gptmobile.util.getPlatformName
-import dev.chungjungsoo.gptmobile.util.handleStates
+import dev.chungjungsoo.gptmobile.util.requiresLocalNetworkAccess
 import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -55,7 +59,9 @@ class ChatViewModel @Inject constructor(
     @param:ApplicationContext private val context: Context,
     private val chatRepository: ChatRepository,
     private val settingRepository: SettingRepository,
-    private val attachmentUploadCoordinator: AttachmentUploadCoordinator
+    private val attachmentUploadCoordinator: AttachmentUploadCoordinator,
+    private val agentRunCoordinator: AgentRunCoordinator,
+    private val toolConnectionRepository: ToolConnectionRepository
 ) : ViewModel() {
     sealed class LoadingState {
         data object Idle : LoadingState()
@@ -123,12 +129,18 @@ class ChatViewModel @Inject constructor(
     private val _attachmentNotice = MutableStateFlow<String?>(null)
     val attachmentNotice = _attachmentNotice.asStateFlow()
 
+    private val _needsLocalNetworkAccess = MutableStateFlow(false)
+    val needsLocalNetworkAccess = _needsLocalNetworkAccess.asStateFlow()
+
     // Chat messages currently in the chat room
     private val _groupedMessages = MutableStateFlow(GroupedMessages())
     val groupedMessages = _groupedMessages.asStateFlow()
 
     private val _toolEventsByRun = MutableStateFlow<Map<String, List<ToolEvent>>>(emptyMap())
     val toolEventsByRun = _toolEventsByRun.asStateFlow()
+
+    private val _agentRunsById = MutableStateFlow<Map<String, AgentRun>>(emptyMap())
+    val agentRunsById = _agentRunsById.asStateFlow()
 
     // Each chat states for assistant chat messages
     // Index of the currently shown message's platform - default is 0 (first platform)
@@ -153,8 +165,10 @@ class ChatViewModel @Inject constructor(
         fetchChatRoom()
         viewModelScope.launch { fetchMessages() }
         fetchEnabledPlatformsInApp()
-        observeStateChanges()
+        observePersistedMessages()
+        observeAgentRuns()
         observeToolEvents()
+        observeAgentNotices()
     }
 
     fun addMessage(userMessage: MessageV2) {
@@ -188,6 +202,10 @@ class ChatViewModel @Inject constructor(
         }
 
         sendQuestion(questionText, _selectedAttachments.value)
+    }
+
+    fun cancelActiveRuns() {
+        _chatRoom.value.id.takeIf { it > 0 }?.let(agentRunCoordinator::cancelChat)
     }
 
     override fun onCleared() {
@@ -302,12 +320,18 @@ class ChatViewModel @Inject constructor(
                     _groupedMessages.update { groupedMessages ->
                         updateAssistantSlot(groupedMessages, turnIndex, platformIndex) { persisted.assistantMessage }
                     }
-                    launchProviderRun(
-                        runId = runId,
-                        turnIndex = turnIndex,
-                        platformIndex = platformIndex,
-                        platform = platformWithChatModel,
-                        contextMessages = groupedMessagesThroughTurn(_groupedMessages.value, turnIndex)
+                    val contextMessages = groupedMessagesThroughTurn(_groupedMessages.value, turnIndex)
+                    agentRunCoordinator.start(
+                        listOf(
+                            AgentRunRequest(
+                                runId = runId,
+                                chatId = persisted.assistantMessage.chatId,
+                                assistantMessage = persisted.assistantMessage,
+                                platform = platformWithChatModel,
+                                userMessages = contextMessages.userMessages,
+                                assistantMessages = contextMessages.assistantMessages
+                            )
+                        )
                     )
                 },
                 onFailure = { error ->
@@ -624,15 +648,18 @@ class ChatViewModel @Inject constructor(
                         )
                     }
                     val contextMessages = _groupedMessages.value
-                    platforms.forEachIndexed { runIndex, (platformIndex, platform) ->
-                        launchProviderRun(
-                            runId = runs[runIndex].runId,
-                            turnIndex = turnIndex,
-                            platformIndex = platformIndex,
-                            platform = platform,
-                            contextMessages = contextMessages
-                        )
-                    }
+                    agentRunCoordinator.start(
+                        platforms.mapIndexed { runIndex, (_, platform) ->
+                            AgentRunRequest(
+                                runId = runs[runIndex].runId,
+                                chatId = persisted.chatRoom.id,
+                                assistantMessage = persisted.assistantMessages[runIndex],
+                                platform = platform,
+                                userMessages = contextMessages.userMessages,
+                                assistantMessages = contextMessages.assistantMessages
+                            )
+                        }
+                    )
                 },
                 onFailure = { error ->
                     showPersistenceFailure(turnIndex, platforms.map { it.index }, error)
@@ -986,7 +1013,6 @@ class ChatViewModel @Inject constructor(
             if (_groupedMessages.value.assistantMessages.size != _indexStates.value.size) {
                 _indexStates.update { List(_groupedMessages.value.assistantMessages.size) { 0 } }
             }
-            _loadingStates.update { List(enabledPlatformsInChat.size) { LoadingState.Idle } }
             _isLoaded.update { true } // Finish fetching
             return
         }
@@ -1000,28 +1026,7 @@ class ChatViewModel @Inject constructor(
 
     private suspend fun fetchGroupedMessages(chatId: Int): GroupedMessages {
         val messages = chatRepository.fetchMessagesV2(chatId).sortedBy { it.createdAt }
-
-        val userMessages = mutableListOf<MessageV2>()
-        val assistantMessages = mutableListOf<MutableList<MessageV2>>()
-
-        messages.forEach { message ->
-            if (message.platformType == null) {
-                userMessages.add(message)
-                assistantMessages.add(mutableListOf())
-            } else {
-                assistantMessages.last().add(message)
-            }
-        }
-
-        val normalizedAssistantMessages = assistantMessages.map { assistantMessage ->
-            normalizeAssistantRow(
-                assistantMessages = assistantMessage,
-                enabledPlatformsInChat = enabledPlatformsInChat,
-                chatId = chatId
-            )
-        }
-
-        return GroupedMessages(userMessages, normalizedAssistantMessages)
+        return groupPersistedMessages(messages, enabledPlatformsInChat, chatId)
     }
 
     private fun fetchChatRoom() {
@@ -1040,9 +1045,29 @@ class ChatViewModel @Inject constructor(
         viewModelScope.launch {
             val allPlatforms = settingRepository.fetchPlatformV2s()
             _platformsInApp.update { allPlatforms }
-            _enabledPlatformsInApp.update { allPlatforms.filter { it.enabled } }
             initializeChatPlatformModels(allPlatforms)
+            updateLocalNetworkRequirement(allPlatforms)
+            _enabledPlatformsInApp.update { allPlatforms.filter { it.enabled } }
         }
+    }
+
+    private suspend fun updateLocalNetworkRequirement(platforms: List<PlatformV2>) {
+        val selectedProfiles = platforms.filter { it.uid in enabledPlatformsInChat }
+        val providerNeedsAccess = selectedProfiles.any { requiresLocalNetworkAccess(it.apiUrl) }
+        val requiresAccess = determineLocalNetworkAccessRequirement(
+            providerNeedsAccess = providerNeedsAccess,
+            toolNeedsAccess = {
+                enabledPlatformsInChat.any { profileUid ->
+                    toolConnectionRepository.listBindingsWithConnections(profileUid).any { binding ->
+                        binding.connection?.endpointUrl?.let(::requiresLocalNetworkAccess) == true
+                    }
+                }
+            },
+            onLookupFailure = {
+                _attachmentNotice.update { context.getString(R.string.local_network_check_failed) }
+            }
+        )
+        _needsLocalNetworkAccess.update { requiresAccess }
     }
 
     private suspend fun initializeChatPlatformModels(platforms: List<PlatformV2>) {
@@ -1067,6 +1092,77 @@ class ChatViewModel @Inject constructor(
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
+    private fun observePersistedMessages() {
+        viewModelScope.launch {
+            _chatRoom
+                .map { it.id }
+                .distinctUntilChanged()
+                .flatMapLatest { chatId ->
+                    if (chatId > 0) {
+                        chatRepository.observeMessagesV2(chatId).map { messages -> chatId to messages }
+                    } else {
+                        flowOf(chatId to emptyList())
+                    }
+                }
+                .collect { (chatId, messages) ->
+                    if (chatId <= 0) return@collect
+                    val groupedMessages = groupPersistedMessages(messages, enabledPlatformsInChat, chatId)
+                    _groupedMessages.update { groupedMessages }
+                    _indexStates.update { current ->
+                        List(groupedMessages.assistantMessages.size) { index -> current.getOrElse(index) { 0 } }
+                    }
+                    syncLoadingStates(_agentRunsById.value.values.toList())
+                    _isLoaded.update { true }
+                }
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun observeAgentRuns() {
+        viewModelScope.launch {
+            _chatRoom
+                .map { it.id }
+                .distinctUntilChanged()
+                .flatMapLatest { chatId ->
+                    if (chatId > 0) chatRepository.observeAgentRuns(chatId) else flowOf(emptyList())
+                }
+                .collect { runs ->
+                    _agentRunsById.update { runs.associateBy(AgentRun::runId) }
+                    syncLoadingStates(runs)
+                }
+        }
+    }
+
+    private fun observeAgentNotices() {
+        viewModelScope.launch {
+            agentRunCoordinator.notices.collect { notice ->
+                if (notice.chatId == _chatRoom.value.id) {
+                    _attachmentNotice.update { notice.message }
+                }
+            }
+        }
+        viewModelScope.launch {
+            agentRunCoordinator.activeRuns.collect {
+                syncLoadingStates(_agentRunsById.value.values.toList())
+            }
+        }
+    }
+
+    private fun syncLoadingStates(runs: List<AgentRun>) {
+        val runsById = runs.associateBy(AgentRun::runId)
+        val activeRunIds = agentRunCoordinator.activeRuns.value.keys
+        val latestAssistantRow = _groupedMessages.value.assistantMessages.lastOrNull()
+        _loadingStates.update {
+            loadingStatesForLatestAssistant(
+                platformCount = enabledPlatformsInChat.size,
+                latestAssistantRow = latestAssistantRow,
+                runsById = runsById,
+                activeRunIds = activeRunIds
+            )
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
     private fun observeToolEvents() {
         viewModelScope.launch {
             _chatRoom
@@ -1078,40 +1174,6 @@ class ChatViewModel @Inject constructor(
                 .collect { events ->
                     _toolEventsByRun.update { events.groupBy(ToolEvent::runId) }
                 }
-        }
-    }
-
-    private fun observeStateChanges() {
-        viewModelScope.launch {
-            _loadingStates.collect { states ->
-                if (_chatRoom.value.id != -1 &&
-                    states.all { it == LoadingState.Idle } &&
-                    (_groupedMessages.value.userMessages.isNotEmpty() && _groupedMessages.value.assistantMessages.isNotEmpty()) &&
-                    (_groupedMessages.value.userMessages.size == _groupedMessages.value.assistantMessages.size)
-                ) {
-                    val chatRoom = _chatRoom.value
-                    val groupedMessages = _groupedMessages.value
-                    val chatPlatformModels = _chatPlatformModels.value
-
-                    val savedChatRoom = withContext(Dispatchers.IO) {
-                        chatRepository.saveChat(
-                            chatRoom = chatRoom,
-                            messages = persistableMessages(groupedMessages),
-                            chatPlatformModels = chatPlatformModels
-                        )
-                    }
-                    _chatRoom.update { currentChatRoom ->
-                        if (currentChatRoom.id == chatRoom.id && chatRoom.id == 0) {
-                            savedChatRoom
-                        } else {
-                            currentChatRoom
-                        }
-                    }
-
-                    // Sync message ids
-                    fetchMessages()
-                }
-            }
         }
     }
 
@@ -1141,6 +1203,44 @@ class ChatViewModel @Inject constructor(
     }
 }
 
+internal fun loadingStatesForLatestAssistant(
+    platformCount: Int,
+    latestAssistantRow: List<MessageV2>?,
+    runsById: Map<String, AgentRun>,
+    activeRunIds: Set<String>
+): List<ChatViewModel.LoadingState> = List(platformCount) { platformIndex ->
+    val runId = latestAssistantRow?.getOrNull(platformIndex)?.currentRunId
+    val status = runId?.let(runsById::get)?.status
+    if (runId in activeRunIds || status == AgentRunStatus.QUEUED || status == AgentRunStatus.RUNNING) {
+        ChatViewModel.LoadingState.Loading
+    } else {
+        ChatViewModel.LoadingState.Idle
+    }
+}
+
+internal fun groupPersistedMessages(
+    messages: List<MessageV2>,
+    enabledPlatformsInChat: List<String>,
+    chatId: Int
+): ChatViewModel.GroupedMessages {
+    val userMessages = mutableListOf<MessageV2>()
+    val assistantMessages = mutableListOf<MutableList<MessageV2>>()
+    messages.forEach { message ->
+        if (message.platformType == null) {
+            userMessages += message
+            assistantMessages += mutableListOf<MessageV2>()
+        } else {
+            assistantMessages.lastOrNull()?.add(message)
+        }
+    }
+    return ChatViewModel.GroupedMessages(
+        userMessages = userMessages,
+        assistantMessages = assistantMessages.map { row ->
+            normalizeAssistantRow(row, enabledPlatformsInChat, chatId)
+        }
+    )
+}
+
 internal fun groupedMessagesThroughTurn(
     groupedMessages: ChatViewModel.GroupedMessages,
     turnIndex: Int
@@ -1148,8 +1248,6 @@ internal fun groupedMessagesThroughTurn(
     userMessages = groupedMessages.userMessages.take(turnIndex + 1),
     assistantMessages = groupedMessages.assistantMessages.take(turnIndex + 1)
 )
-
-internal data class AgentRunTerminalUpdate(val status: String, val error: String?)
 
 internal fun resolveSelectedPlatforms(
     selectedProfileUids: List<String>,
@@ -1208,17 +1306,6 @@ internal fun formatAssistantExport(
         appendLine(it)
         appendLine()
     }
-}
-
-internal fun ApiStateFlowOutcome.toAgentRunTerminalUpdate(): AgentRunTerminalUpdate = when (this) {
-    ApiStateFlowOutcome.Completed -> AgentRunTerminalUpdate(AgentRunStatus.COMPLETED, null)
-
-    is ApiStateFlowOutcome.Failed -> AgentRunTerminalUpdate(AgentRunStatus.FAILED, message)
-
-    ApiStateFlowOutcome.Incomplete -> AgentRunTerminalUpdate(
-        AgentRunStatus.FAILED,
-        "Provider stream ended without completion."
-    )
 }
 
 internal fun persistableMessages(groupedMessages: ChatViewModel.GroupedMessages): List<MessageV2> {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ToolTraceBlock.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ToolTraceBlock.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
@@ -41,6 +42,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import dev.chungjungsoo.gptmobile.R
 import dev.chungjungsoo.gptmobile.data.database.entity.ToolEvent
+import dev.chungjungsoo.gptmobile.data.database.entity.ToolEventError
 import dev.chungjungsoo.gptmobile.data.database.entity.ToolEventStatus
 import java.time.Instant
 import java.util.Locale
@@ -189,8 +191,8 @@ private fun ToolTraceEventCard(event: ToolEvent, labels: ToolTraceLabels) {
             ToolTraceLine(labels.status, event.status)
             ToolTraceLine(labels.callId, event.callId)
             connectionLabel(event)?.let { ToolTraceLine(labels.connection, it) }
-            timingLabel(event, labels)?.let { ToolTraceLine(labels.timing, it) }
-            event.error?.takeIf { it.isNotBlank() }?.let { ToolTraceLine(labels.error, boundedText(it)) }
+            toolTimingLabel(event, labels)?.let { ToolTraceLine(labels.timing, it) }
+            event.error?.takeIf { it.isNotBlank() }?.let { ToolTraceLine(labels.error, toolEventErrorText(it)) }
             ToolTraceBlockText(labels.arguments, event.arguments)
             event.result?.takeIf { it.isNotBlank() }?.let { ToolTraceBlockText(labels.result, it) }
         }
@@ -241,7 +243,7 @@ internal fun filterToolEvents(events: List<ToolEvent>, query: String): List<Tool
             event.arguments,
             event.result,
             event.error,
-            timingLabel(event)
+            timingLabel(event, ToolTraceLabels.Default)
         ).any { normalizedQuery in it.lowercase(Locale.ROOT) }
     }
 }
@@ -266,9 +268,30 @@ internal fun toolTraceStatusSummary(events: List<ToolEvent>, labels: ToolTraceLa
 }
 
 internal fun formatToolDuration(event: ToolEvent): String? {
+    val seconds = toolDurationSeconds(event) ?: return null
+    return "$seconds s"
+}
+
+internal fun toolDurationSeconds(event: ToolEvent): Long? {
     val startedAt = event.startedAt ?: return null
     val completedAt = event.completedAt ?: return null
-    return "${(completedAt - startedAt).coerceAtLeast(0)} s"
+    return (completedAt - startedAt).coerceAtLeast(0)
+}
+
+@Composable
+private fun toolTimingLabel(event: ToolEvent, labels: ToolTraceLabels): String? {
+    val startedAt = event.startedAt
+    val completedAt = event.completedAt
+    return when {
+        startedAt != null && completedAt != null -> {
+            val seconds = toolDurationSeconds(event) ?: return null
+            "${Instant.ofEpochSecond(startedAt)} - ${Instant.ofEpochSecond(completedAt)} (${pluralStringResource(R.plurals.duration_seconds, seconds.toInt(), seconds)})"
+        }
+
+        startedAt != null -> "${labels.startedAt} ${Instant.ofEpochSecond(startedAt)}"
+
+        else -> null
+    }
 }
 
 internal fun formatToolTraceMarkdown(
@@ -310,6 +333,12 @@ private fun timingLabel(event: ToolEvent, labels: ToolTraceLabels): String? {
         startedAt != null -> "${labels.startedAt} ${Instant.ofEpochSecond(startedAt)}"
         else -> null
     }
+}
+
+@Composable
+private fun toolEventErrorText(error: String): String = when (error) {
+    ToolEventError.INTERRUPTED_APP_STOPPED -> stringResource(R.string.tool_event_error_interrupted_app_stopped)
+    else -> boundedText(error)
 }
 
 private fun connectionLabel(event: ToolEvent): String? {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ToolTraceBlock.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ToolTraceBlock.kt
@@ -64,6 +64,7 @@ fun ToolTraceBlock(
     )
     val summary = toolTraceStatusSummary(events, labels)
     val searchToolTrace = stringResource(R.string.search_tool_trace)
+    val noMatchingToolCalls = stringResource(R.string.no_matching_tool_calls)
     val traceBlockDescription = stringResource(R.string.tool_trace_block_content_description, summary)
 
     Column(
@@ -119,8 +120,15 @@ fun ToolTraceBlock(
                             .semantics { contentDescription = searchToolTrace }
                     )
                     Spacer(modifier = Modifier.height(8.dp))
-                    filterToolEvents(events, query).forEach { event ->
-                        ToolTraceEventCard(event, labels)
+                    val filteredEvents = filterToolEvents(events, query)
+                    if (filteredEvents.isEmpty()) {
+                        Text(
+                            text = noMatchingToolCalls,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    } else {
+                        filteredEvents.forEach { event -> ToolTraceEventCard(event, labels) }
                     }
                 }
             }
@@ -228,10 +236,12 @@ internal fun filterToolEvents(events: List<ToolEvent>, query: String): List<Tool
             event.connectionNameSnapshot,
             event.toolName,
             event.modelToolName,
+            event.status,
             event.callId,
             event.arguments,
             event.result,
-            event.error
+            event.error,
+            timingLabel(event)
         ).any { normalizedQuery in it.lowercase(Locale.ROOT) }
     }
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/home/HomeScreen.kt
@@ -90,11 +90,13 @@ fun HomeScreen(
     val showSelectModelDialog by homeViewModel.showSelectModelDialog.collectAsStateWithLifecycle()
     val showDeleteWarningDialog by homeViewModel.showDeleteWarningDialog.collectAsStateWithLifecycle()
     val platformState by homeViewModel.platformState.collectAsStateWithLifecycle()
+    val activeChatIds by homeViewModel.activeChatIds.collectAsStateWithLifecycle()
     val searchQuery by homeViewModel.searchQuery.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
     val lifecycleState by lifecycleOwner.lifecycle.currentStateFlow.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val selectedChatCount = chatListState.selectedChats.count { it }
+    val selectedChat = chatListState.chats.filterIndexed { index, _ -> chatListState.selectedChats.getOrElse(index) { false } }.singleOrNull()
     val duplicatedChatMessage = stringResource(R.string.duplicated_chat)
     val deletedChatsMessage = stringResource(R.string.deleted_chats, selectedChatCount)
 
@@ -120,6 +122,7 @@ fun HomeScreen(
                 isSelectionMode = chatListState.isSelectionMode,
                 isSearchMode = chatListState.isSearchMode,
                 selectedChats = selectedChatCount,
+                duplicateEnabled = selectedChat?.id !in activeChatIds,
                 scrollBehavior = scrollBehavior,
                 actionOnClick = {
                     if (chatListState.isSelectionMode) {
@@ -255,6 +258,7 @@ fun HomeTopAppBar(
     isSelectionMode: Boolean,
     isSearchMode: Boolean,
     selectedChats: Int,
+    duplicateEnabled: Boolean,
     scrollBehavior: TopAppBarScrollBehavior,
     actionOnClick: () -> Unit,
     duplicateOnClick: () -> Unit,
@@ -363,7 +367,7 @@ fun HomeTopAppBar(
                     if (selectedChats == 1) {
                         IconButton(
                             modifier = Modifier.padding(4.dp),
-                            enabled = true,
+                            enabled = duplicateEnabled,
                             onClick = duplicateOnClick
                         ) {
                             Icon(

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/home/HomeScreen.kt
@@ -122,7 +122,7 @@ fun HomeScreen(
                 isSelectionMode = chatListState.isSelectionMode,
                 isSearchMode = chatListState.isSearchMode,
                 selectedChats = selectedChatCount,
-                duplicateEnabled = selectedChat?.id !in activeChatIds,
+                duplicateEnabled = selectedChat != null && selectedChat.id !in activeChatIds,
                 scrollBehavior = scrollBehavior,
                 actionOnClick = {
                     if (chatListState.isSelectionMode) {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/home/HomeViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.chungjungsoo.gptmobile.data.agent.AgentRunCoordinator
 import dev.chungjungsoo.gptmobile.data.database.entity.ChatRoomV2
 import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
 import dev.chungjungsoo.gptmobile.data.repository.ChatRepository
@@ -24,7 +25,8 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val chatRepository: ChatRepository,
-    private val settingRepository: SettingRepository
+    private val settingRepository: SettingRepository,
+    private val agentRunCoordinator: AgentRunCoordinator
 ) : ViewModel() {
 
     companion object {
@@ -54,12 +56,18 @@ class HomeViewModel @Inject constructor(
     private val _showDeleteWarningDialog = MutableStateFlow(false)
     val showDeleteWarningDialog: StateFlow<Boolean> = _showDeleteWarningDialog.asStateFlow()
 
+    private val _activeChatIds = MutableStateFlow<Set<Int>>(emptySet())
+    val activeChatIds = _activeChatIds.asStateFlow()
+
     init {
         // Set up debounced search
         _searchQuery
             .debounce(SEARCH_DEBOUNCE_MS)
             .distinctUntilChanged()
             .onEach { query -> searchChats(query) }
+            .launchIn(viewModelScope)
+        agentRunCoordinator.activeRuns
+            .onEach { runs -> _activeChatIds.update { runs.values.mapTo(mutableSetOf()) { it.chatId } } }
             .launchIn(viewModelScope)
     }
 
@@ -120,6 +128,7 @@ class HomeViewModel @Inject constructor(
                 _chatListState.value.selectedChats[index]
             }
 
+            selectedChats.forEach { agentRunCoordinator.cancelChatAndJoin(it.id) }
             chatRepository.deleteChatsV2(selectedChats)
             _chatListState.update { it.copy(chats = chatRepository.fetchChatListV2()) }
             disableSelectionMode()
@@ -132,6 +141,7 @@ class HomeViewModel @Inject constructor(
                 _chatListState.value.selectedChats[index]
             }
             val selectedChat = selectedChats.singleOrNull() ?: return@launch
+            if (agentRunCoordinator.hasActiveRuns(selectedChat.id)) return@launch
 
             chatRepository.duplicateChatV2(selectedChat)
             _chatListState.update { it.copy(chats = chatRepository.fetchChatListV2()) }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/home/HomeViewModel.kt
@@ -125,12 +125,15 @@ class HomeViewModel @Inject constructor(
     fun deleteSelectedChats() {
         viewModelScope.launch {
             val selectedChats = _chatListState.value.chats.filterIndexed { index, _ ->
-                _chatListState.value.selectedChats[index]
+                _chatListState.value.selectedChats.getOrElse(index) { false }
             }
 
-            selectedChats.forEach { agentRunCoordinator.cancelChatAndJoin(it.id) }
-            chatRepository.deleteChatsV2(selectedChats)
-            _chatListState.update { it.copy(chats = chatRepository.fetchChatListV2()) }
+            val chats = agentRunCoordinator.withChatGate(selectedChats.map { it.id }) {
+                selectedChats.forEach { agentRunCoordinator.cancelChatAndJoin(it.id) }
+                chatRepository.deleteChatsV2(selectedChats)
+                chatRepository.fetchChatListV2()
+            }
+            _chatListState.update { it.copy(chats = chats) }
             disableSelectionMode()
         }
     }
@@ -138,13 +141,15 @@ class HomeViewModel @Inject constructor(
     fun duplicateSelectedChat() {
         viewModelScope.launch {
             val selectedChats = _chatListState.value.chats.filterIndexed { index, _ ->
-                _chatListState.value.selectedChats[index]
+                _chatListState.value.selectedChats.getOrElse(index) { false }
             }
             val selectedChat = selectedChats.singleOrNull() ?: return@launch
-            if (agentRunCoordinator.hasActiveRuns(selectedChat.id)) return@launch
-
-            chatRepository.duplicateChatV2(selectedChat)
-            _chatListState.update { it.copy(chats = chatRepository.fetchChatListV2()) }
+            val chats = agentRunCoordinator.withChatGate(selectedChat.id) {
+                if (agentRunCoordinator.hasActiveRuns(selectedChat.id)) return@withChatGate null
+                chatRepository.duplicateChatV2(selectedChat)
+                chatRepository.fetchChatListV2()
+            } ?: return@launch
+            _chatListState.update { it.copy(chats = chats) }
             disableSelectionMode()
         }
     }
@@ -201,7 +206,7 @@ class HomeViewModel @Inject constructor(
     }
 
     fun selectChat(chatRoomIdx: Int) {
-        if (chatRoomIdx < 0 || chatRoomIdx > _chatListState.value.chats.size) return
+        if (chatRoomIdx < 0 || chatRoomIdx >= _chatListState.value.chats.size) return
 
         _chatListState.update {
             it.copy(

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/PlatformSettingScreen.kt
@@ -1,5 +1,11 @@
 package dev.chungjungsoo.gptmobile.presentation.ui.setting
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -47,6 +53,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
@@ -54,6 +61,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.chungjungsoo.gptmobile.R
@@ -62,6 +70,7 @@ import dev.chungjungsoo.gptmobile.presentation.common.RadioItem
 import dev.chungjungsoo.gptmobile.presentation.common.SettingItem
 import dev.chungjungsoo.gptmobile.util.formatPlatformTimeout
 import dev.chungjungsoo.gptmobile.util.pinnedExitUntilCollapsedScrollBehavior
+import dev.chungjungsoo.gptmobile.util.requiresLocalNetworkAccess
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -78,6 +87,18 @@ fun PlatformSettingScreen(
     val dialogState by settingViewModel.dialogState.collectAsStateWithLifecycle()
     val isDeleted by settingViewModel.isDeleted.collectAsStateWithLifecycle()
     val toolBindingState by settingViewModel.toolBindingState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    var openMcpToolsAfterPermission by remember { mutableStateOf(false) }
+    val localNetworkPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted && openMcpToolsAfterPermission) {
+            settingViewModel.openMcpToolsDialog()
+        } else if (!granted) {
+            Toast.makeText(context, R.string.local_network_permission_required, Toast.LENGTH_SHORT).show()
+        }
+        openMcpToolsAfterPermission = false
+    }
 
     LaunchedEffect(isDeleted) {
         if (isDeleted) {
@@ -281,7 +302,20 @@ fun PlatformSettingScreen(
                     title = stringResource(R.string.mcp_tools),
                     description = stringResource(R.string.mcp_tools_assigned, toolBindingState.selectedMcpTools.size),
                     enabled = platformData.enabled,
-                    onItemClick = settingViewModel::openMcpToolsDialog,
+                    onItemClick = {
+                        val needsPermission = toolBindingState.mcpConnections.any { connection ->
+                            connection.endpointUrl?.let(::requiresLocalNetworkAccess) == true
+                        }
+                        if (needsPermission &&
+                            Build.VERSION.SDK_INT >= 37 &&
+                            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_LOCAL_NETWORK) != PackageManager.PERMISSION_GRANTED
+                        ) {
+                            openMcpToolsAfterPermission = true
+                            localNetworkPermissionLauncher.launch(Manifest.permission.ACCESS_LOCAL_NETWORK)
+                        } else {
+                            settingViewModel.openMcpToolsDialog()
+                        }
+                    },
                     showTrailingIcon = true,
                     showLeadingIcon = false
                 )

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/setting/ToolConnectionsScreen.kt
@@ -1,5 +1,11 @@
 package dev.chungjungsoo.gptmobile.presentation.ui.setting
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -37,6 +43,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.error
@@ -46,6 +53,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -57,6 +65,7 @@ import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnectionAuthType
 import dev.chungjungsoo.gptmobile.data.database.entity.ToolConnectionType
 import dev.chungjungsoo.gptmobile.presentation.common.RadioItem
 import dev.chungjungsoo.gptmobile.util.pinnedExitUntilCollapsedScrollBehavior
+import dev.chungjungsoo.gptmobile.util.requiresLocalNetworkAccess
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -74,7 +83,20 @@ fun ToolConnectionsScreen(
     )
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var deletingConnection by remember { mutableStateOf<ToolConnection?>(null) }
+    var pendingOAuthConnection by remember { mutableStateOf<ToolConnection?>(null) }
     val lifecycleOwner = LocalLifecycleOwner.current
+    val context = LocalContext.current
+    val localNetworkPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        val pending = pendingOAuthConnection
+        pendingOAuthConnection = null
+        if (granted && pending != null) {
+            viewModel.startOAuth(pending.connectionUid)
+        } else if (!granted) {
+            Toast.makeText(context, R.string.local_network_permission_required, Toast.LENGTH_SHORT).show()
+        }
+    }
 
     LaunchedEffect(viewModel) {
         viewModel.oauthLaunches.collect(onLaunchOAuth)
@@ -110,7 +132,18 @@ fun ToolConnectionsScreen(
                 ToolConnectionItem(
                     connection = connection,
                     onEditClick = { onEditConnectionClick(connection.connectionUid) },
-                    onOAuthClick = { viewModel.startOAuth(connection.connectionUid) },
+                    onOAuthClick = {
+                        val needsPermission = connection.endpointUrl?.let(::requiresLocalNetworkAccess) == true
+                        if (needsPermission &&
+                            Build.VERSION.SDK_INT >= 37 &&
+                            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_LOCAL_NETWORK) != PackageManager.PERMISSION_GRANTED
+                        ) {
+                            pendingOAuthConnection = connection
+                            localNetworkPermissionLauncher.launch(Manifest.permission.ACCESS_LOCAL_NETWORK)
+                        } else {
+                            viewModel.startOAuth(connection.connectionUid)
+                        }
+                    },
                     onDeleteClick = { deletingConnection = connection }
                 )
             }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensions.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensions.kt
@@ -27,7 +27,45 @@ suspend fun Flow<ApiState>.handleStates(
     currentTimeProvider: () -> Long = { System.currentTimeMillis() / 1000 },
     revisionToAppendOnSuccess: AssistantRevision? = null
 ): ApiStateFlowOutcome {
-    val buffer = StreamingMessageBuffer(nanoTimeProvider = nanoTimeProvider)
+    try {
+        val outcome = collectApiStateUpdates(
+            onUpdate = { content, thoughts ->
+                messageFlow.setBufferedText(turnIndex, platformIdx, content, thoughts)
+            },
+            onNotice = onNotice,
+            nanoTimeProvider = nanoTimeProvider
+        )
+        when (outcome) {
+            is ApiStateFlowOutcome.Failed -> messageFlow.setErrorMessage(
+                turnIndex = turnIndex,
+                platformIdx = platformIdx,
+                error = outcome.message,
+                currentTimeProvider = currentTimeProvider,
+                revisionToAppend = revisionToAppendOnSuccess
+            )
+
+            ApiStateFlowOutcome.Completed -> messageFlow.setTimestamp(
+                turnIndex = turnIndex,
+                platformIdx = platformIdx,
+                currentTimeProvider = currentTimeProvider,
+                revisionToAppend = revisionToAppendOnSuccess
+            )
+
+            ApiStateFlowOutcome.Incomplete -> Unit
+        }
+        return outcome
+    } finally {
+        onLoadingComplete()
+    }
+}
+
+internal suspend fun Flow<ApiState>.collectApiStateUpdates(
+    onUpdate: suspend (content: String, thoughts: String) -> Unit,
+    onNotice: (String) -> Unit = {},
+    nanoTimeProvider: () -> Long = System::nanoTime,
+    publishIntervalMillis: Long = STREAM_PUBLISH_INTERVAL_MILLIS
+): ApiStateFlowOutcome {
+    val buffer = StreamingMessageBuffer(nanoTimeProvider, publishIntervalMillis)
     var isCompletedSuccessfully = false
     var terminalError: String? = null
 
@@ -36,12 +74,12 @@ suspend fun Flow<ApiState>.handleStates(
             when (chunk) {
                 is ApiState.Thinking -> {
                     buffer.appendThought(chunk.thinkingChunk)
-                    buffer.publishIfDue(messageFlow, turnIndex, platformIdx)
+                    buffer.publishIfDue(onUpdate)
                 }
 
                 is ApiState.Success -> {
                     buffer.appendContent(chunk.textChunk)
-                    buffer.publishIfDue(messageFlow, turnIndex, platformIdx)
+                    buffer.publishIfDue(onUpdate)
                 }
 
                 is ApiState.Notice -> onNotice(chunk.message)
@@ -58,24 +96,7 @@ suspend fun Flow<ApiState>.handleStates(
             }
         }
     } finally {
-        buffer.flush(messageFlow, turnIndex, platformIdx)
-        when {
-            terminalError != null -> messageFlow.setErrorMessage(
-                turnIndex = turnIndex,
-                platformIdx = platformIdx,
-                error = terminalError,
-                currentTimeProvider = currentTimeProvider,
-                revisionToAppend = revisionToAppendOnSuccess
-            )
-
-            isCompletedSuccessfully -> messageFlow.setTimestamp(
-                turnIndex = turnIndex,
-                platformIdx = platformIdx,
-                currentTimeProvider = currentTimeProvider,
-                revisionToAppend = revisionToAppendOnSuccess
-            )
-        }
-        onLoadingComplete()
+        buffer.flush(onUpdate)
     }
 
     return when {
@@ -86,7 +107,8 @@ suspend fun Flow<ApiState>.handleStates(
 }
 
 private class StreamingMessageBuffer(
-    private val nanoTimeProvider: () -> Long
+    private val nanoTimeProvider: () -> Long,
+    private val publishIntervalMillis: Long
 ) {
     private val thoughts = StringBuilder()
     private val content = StringBuilder()
@@ -106,42 +128,27 @@ private class StreamingMessageBuffer(
         }
     }
 
-    fun publishIfDue(
-        messageFlow: MutableStateFlow<ChatViewModel.GroupedMessages>,
-        turnIndex: Int,
-        platformIdx: Int
-    ) {
+    suspend fun publishIfDue(onUpdate: suspend (content: String, thoughts: String) -> Unit) {
         if (!hasPendingChanges()) return
 
         val now = nanoTimeProvider()
         if (lastPublishedAtNanos == 0L ||
-            now - lastPublishedAtNanos >= STREAM_PUBLISH_INTERVAL_MILLIS * 1_000_000
+            now - lastPublishedAtNanos >= publishIntervalMillis * 1_000_000
         ) {
-            publish(messageFlow, turnIndex, platformIdx, now)
+            publish(onUpdate, now)
         }
     }
 
-    fun flush(
-        messageFlow: MutableStateFlow<ChatViewModel.GroupedMessages>,
-        turnIndex: Int,
-        platformIdx: Int
-    ) {
+    suspend fun flush(onUpdate: suspend (content: String, thoughts: String) -> Unit) {
         if (!hasPendingChanges()) return
-        publish(messageFlow, turnIndex, platformIdx, nanoTimeProvider())
+        publish(onUpdate, nanoTimeProvider())
     }
 
-    private fun publish(
-        messageFlow: MutableStateFlow<ChatViewModel.GroupedMessages>,
-        turnIndex: Int,
-        platformIdx: Int,
+    private suspend fun publish(
+        onUpdate: suspend (content: String, thoughts: String) -> Unit,
         publishedAtNanos: Long
     ) {
-        messageFlow.setBufferedText(
-            turnIndex = turnIndex,
-            platformIdx = platformIdx,
-            content = content.toString(),
-            thoughts = thoughts.toString()
-        )
+        onUpdate(content.toString(), thoughts.toString())
         publishedContentLength = content.length
         publishedThoughtLength = thoughts.length
         lastPublishedAtNanos = publishedAtNanos

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/LocalNetworkAccess.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/LocalNetworkAccess.kt
@@ -4,7 +4,7 @@ import java.net.URI
 import kotlinx.coroutines.CancellationException
 
 internal fun requiresLocalNetworkAccess(url: String): Boolean {
-    val host = runCatching { URI(url.trim()).host }
+    val host = runCatching { URI(normalizeEndpointForHostCheck(url)).host }
         .getOrNull()
         ?.trim('[', ']')
         ?.trimEnd('.')
@@ -33,6 +33,12 @@ internal fun requiresLocalNetworkAccess(url: String): Boolean {
         host.startsWith("feb") ||
         host.startsWith("fc") ||
         host.startsWith("fd")
+}
+
+private fun normalizeEndpointForHostCheck(url: String): String {
+    val trimmed = url.trim()
+    if ("://" in trimmed) return trimmed
+    return "http://$trimmed"
 }
 
 private fun parseIpv4(host: String): List<Int>? {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/LocalNetworkAccess.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/LocalNetworkAccess.kt
@@ -1,0 +1,57 @@
+package dev.chungjungsoo.gptmobile.util
+
+import java.net.URI
+import kotlinx.coroutines.CancellationException
+
+internal fun requiresLocalNetworkAccess(url: String): Boolean {
+    val host = runCatching { URI(url.trim()).host }
+        .getOrNull()
+        ?.trim('[', ']')
+        ?.trimEnd('.')
+        ?.lowercase()
+        ?: return false
+    if (host == "localhost" || host.endsWith(".local") || host.endsWith(".lan") || host.endsWith(".home")) return true
+    if ('.' !in host && ':' !in host) return true
+
+    parseIpv4(host)?.let { octets ->
+        val first = octets[0]
+        val second = octets[1]
+        return first == 0 ||
+            first == 10 ||
+            first == 127 ||
+            (first == 169 && second == 254) ||
+            (first == 172 && second in 16..31) ||
+            (first == 192 && second == 168) ||
+            (first == 100 && second in 64..127)
+    }
+
+    return host == "::1" ||
+        host.startsWith("fe8") ||
+        host.startsWith("fe9") ||
+        host.startsWith("fea") ||
+        host.startsWith("feb") ||
+        host.startsWith("fc") ||
+        host.startsWith("fd")
+}
+
+private fun parseIpv4(host: String): List<Int>? {
+    val octets = host.split('.')
+    if (octets.size != 4) return null
+    return octets.map { it.toIntOrNull()?.takeIf { value -> value in 0..255 } ?: return null }
+}
+
+internal suspend fun determineLocalNetworkAccessRequirement(
+    providerNeedsAccess: Boolean,
+    toolNeedsAccess: suspend () -> Boolean,
+    onLookupFailure: (Exception) -> Unit
+): Boolean {
+    if (providerNeedsAccess) return true
+    return try {
+        toolNeedsAccess()
+    } catch (error: CancellationException) {
+        throw error
+    } catch (error: Exception) {
+        onLookupFailure(error)
+        true
+    }
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/LocalNetworkAccess.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/util/LocalNetworkAccess.kt
@@ -24,6 +24,7 @@ internal fun requiresLocalNetworkAccess(url: String): Boolean {
             (first == 192 && second == 168) ||
             (first == 100 && second in 64..127)
     }
+    if (':' !in host) return false
 
     return host == "::1" ||
         host.startsWith("fe8") ||

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -298,8 +298,8 @@
     <string name="at_least_one_platform_required">Add at least one platform to continue</string>
     <string name="remove">Remove</string>
     <string name="revision_counter">Revision %1$d/%2$d</string>
-    <string name="previous_revision" translatable="false">Previous revision</string>
-    <string name="next_revision" translatable="false">Next revision</string>
+    <string name="previous_revision">Previous revision</string>
+    <string name="next_revision">Next revision</string>
     <string name="web_tools">Tool connections</string>
     <string name="tool_connections">Tool connections</string>
     <string name="web_tools_description">Web search and MCP connections</string>
@@ -372,4 +372,20 @@
     <string name="oauth_client_id">OAuth client ID</string>
     <string name="preregistered_client_id_optional">Pre-registered client ID (optional)</string>
     <string name="dynamic_client_registration_hint">Leave blank to use Dynamic Client Registration when advertised.</string>
+    <string name="agent_notification_channel">Agent runs</string>
+    <string name="agent_notification_title">GPT Mobile agent is working</string>
+    <string name="cancel_agent_runs">Cancel</string>
+    <plurals name="agent_runs_active">
+        <item quantity="one">%1$d profile running</item>
+        <item quantity="other">%1$d profiles running</item>
+    </plurals>
+    <string name="retry_tools_warning">Retry may run assigned tools again.</string>
+    <string name="cancel_active_runs">Cancel active runs</string>
+    <string name="agent_run_queued">Agent run queued</string>
+    <string name="agent_run_running">Agent run in progress</string>
+    <string name="agent_run_canceled">Agent run canceled — partial response kept</string>
+    <string name="agent_run_interrupted">Agent run interrupted — tools were not replayed</string>
+    <string name="agent_run_failed">Agent run failed</string>
+    <string name="local_network_permission_required">Local network access is required for this provider or MCP connection.</string>
+    <string name="local_network_check_failed">Could not check MCP network access. Local network permission will be requested as a precaution.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -380,6 +380,7 @@
         <item quantity="other">%1$d profiles running</item>
     </plurals>
     <string name="retry_tools_warning">Retry may run assigned tools again.</string>
+    <string name="no_matching_tool_calls">No matching tool calls.</string>
     <string name="cancel_active_runs">Cancel active runs</string>
     <string name="agent_run_queued">Agent run queued</string>
     <string name="agent_run_running">Agent run in progress</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -381,6 +381,10 @@
         <item quantity="one">%1$d profile running</item>
         <item quantity="other">%1$d profiles running</item>
     </plurals>
+    <plurals name="duration_seconds">
+        <item quantity="one">%1$d s</item>
+        <item quantity="other">%1$d s</item>
+    </plurals>
     <string name="retry_tools_warning">Retry may run assigned tools again.</string>
     <string name="no_matching_tool_calls">No matching tool calls.</string>
     <string name="cancel_active_runs">Cancel active runs</string>
@@ -389,6 +393,8 @@
     <string name="agent_run_canceled">Agent run canceled — partial response kept</string>
     <string name="agent_run_interrupted">Agent run interrupted — tools were not replayed</string>
     <string name="agent_run_failed">Agent run failed</string>
+    <string name="agent_run_error_service_stopped">Foreground agent service stopped.</string>
+    <string name="tool_event_error_interrupted_app_stopped">Interrupted when the app stopped.</string>
     <string name="local_network_permission_required">Local network access is required for this provider or MCP connection.</string>
     <string name="local_network_check_failed">Could not check MCP network access. Local network permission will be requested as a precaution.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -374,6 +374,8 @@
     <string name="dynamic_client_registration_hint">Leave blank to use Dynamic Client Registration when advertised.</string>
     <string name="agent_notification_channel">Agent runs</string>
     <string name="agent_notification_title">GPT Mobile agent is working</string>
+    <string name="agent_completion_notification_title">GPT Mobile agent finished</string>
+    <string name="agent_completion_notification_text">Tap to view the response.</string>
     <string name="cancel_agent_runs">Cancel</string>
     <plurals name="agent_runs_active">
         <item quantity="one">%1$d profile running</item>

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/AgentRunCoordinatorTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/AgentRunCoordinatorTest.kt
@@ -1,12 +1,33 @@
 package dev.chungjungsoo.gptmobile.data.agent
 
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AgentRunCoordinatorTest {
+    @Test
+    fun `cancellation joins the run before applying the terminal fallback`() = runTest {
+        val events = mutableListOf<String>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            try {
+                awaitCancellation()
+            } finally {
+                withContext(NonCancellable) { events += "persist partial message" }
+            }
+        }
+
+        cancelAndJoinAgentRun(job) { events += "terminal fallback" }
+
+        assertEquals(listOf("persist partial message", "terminal fallback"), events)
+    }
+
     @Test
     fun `terminal message is persisted only after the running transition wins`() = runTest {
         val rejectedEvents = mutableListOf<String>()

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/AgentRunCoordinatorTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/AgentRunCoordinatorTest.kt
@@ -1,0 +1,35 @@
+package dev.chungjungsoo.gptmobile.data.agent
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AgentRunCoordinatorTest {
+    @Test
+    fun `terminal message is persisted only after the running transition wins`() = runTest {
+        val rejectedEvents = mutableListOf<String>()
+        val rejected = commitTerminalAgentRun(
+            finishRun = {
+                rejectedEvents += "finish"
+                false
+            },
+            persistMessage = { rejectedEvents += "message" }
+        )
+
+        val acceptedEvents = mutableListOf<String>()
+        val accepted = commitTerminalAgentRun(
+            finishRun = {
+                acceptedEvents += "finish"
+                true
+            },
+            persistMessage = { acceptedEvents += "message" }
+        )
+
+        assertFalse(rejected)
+        assertEquals(listOf("finish"), rejectedEvents)
+        assertTrue(accepted)
+        assertEquals(listOf("finish", "message"), acceptedEvents)
+    }
+}

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/AgentRunCoordinatorTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/agent/AgentRunCoordinatorTest.kt
@@ -3,6 +3,7 @@ package dev.chungjungsoo.gptmobile.data.agent
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
@@ -12,6 +13,17 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AgentRunCoordinatorTest {
+    @Test
+    fun `lazy run cleanup fires when job is canceled before start`() = runTest {
+        val events = mutableListOf<String>()
+        val job = launch(start = CoroutineStart.LAZY) { events += "execute" }
+
+        job.invokeOnCompletionCleanup { events += "cleanup" }
+        job.cancel()
+
+        assertEquals(listOf("cleanup"), events)
+    }
+
     @Test
     fun `cancellation joins the run before applying the terminal fallback`() = runTest {
         val events = mutableListOf<String>()

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/ToolEventRecorderTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/ToolEventRecorderTest.kt
@@ -412,6 +412,8 @@ private class FakeAgentPersistenceDao : AgentPersistenceDao {
         }
     }
 
+    override suspend fun cancelInterruptedToolEvents(completedAt: Long) = Unit
+
     private fun <T> unused(): T = error("unused")
 }
 

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileAppTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileAppTest.kt
@@ -6,6 +6,17 @@ import org.junit.Test
 
 class GPTMobileAppTest {
     @Test
+    fun `startup recovery gate waits for current maintenance job`() = runTest {
+        val events = mutableListOf<String>()
+
+        StartupRecoveryGate.start(this) { events += "recover" }
+        StartupRecoveryGate.await()
+        events += "observe"
+
+        assertEquals(listOf("recover", "observe"), events)
+    }
+
+    @Test
     fun `startup interrupts persisted work before migrating credentials`() = runTest {
         val events = mutableListOf<String>()
 

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileAppTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/GPTMobileAppTest.kt
@@ -1,0 +1,22 @@
+package dev.chungjungsoo.gptmobile.presentation
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GPTMobileAppTest {
+    @Test
+    fun `startup interrupts persisted work before migrating credentials`() = runTest {
+        val events = mutableListOf<String>()
+
+        runStartupMaintenance(
+            interruptPersistedWork = { events += "interrupt" },
+            migrateSecrets = {
+                events += "migrate"
+                emptyList()
+            }
+        )
+
+        assertEquals(listOf("interrupt", "migrate"), events)
+    }
+}

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/service/AgentRunForegroundServiceTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/service/AgentRunForegroundServiceTest.kt
@@ -1,0 +1,19 @@
+package dev.chungjungsoo.gptmobile.presentation.service
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AgentRunForegroundServiceTest {
+    @Test
+    fun `completion notification posts only for background nonempty to empty transition`() {
+        assertTrue(shouldNotifyAgentRunsCompleted(wasActive = true, isActive = false, isAppBackground = true))
+    }
+
+    @Test
+    fun `completion notification skips initial empty and foreground completion`() {
+        assertFalse(shouldNotifyAgentRunsCompleted(wasActive = false, isActive = false, isAppBackground = true))
+        assertFalse(shouldNotifyAgentRunsCompleted(wasActive = true, isActive = false, isAppBackground = false))
+        assertFalse(shouldNotifyAgentRunsCompleted(wasActive = true, isActive = true, isAppBackground = true))
+    }
+}

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/service/AgentRunForegroundServiceTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/service/AgentRunForegroundServiceTest.kt
@@ -16,4 +16,11 @@ class AgentRunForegroundServiceTest {
         assertFalse(shouldNotifyAgentRunsCompleted(wasActive = true, isActive = false, isAppBackground = false))
         assertFalse(shouldNotifyAgentRunsCompleted(wasActive = true, isActive = true, isAppBackground = true))
     }
+
+    @Test
+    fun `destroy interrupts only while service still owns active runs`() {
+        assertTrue(shouldInterruptAgentRunsOnDestroy(stoppedBecauseInactive = false, hasActiveRuns = true))
+        assertFalse(shouldInterruptAgentRunsOnDestroy(stoppedBecauseInactive = true, hasActiveRuns = false))
+        assertFalse(shouldInterruptAgentRunsOnDestroy(stoppedBecauseInactive = false, hasActiveRuns = false))
+    }
 }

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/AgentRunStatusBlockTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/AgentRunStatusBlockTest.kt
@@ -1,0 +1,25 @@
+package dev.chungjungsoo.gptmobile.presentation.ui.chat
+
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRun
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AgentRunStatusBlockTest {
+    @Test
+    fun `duration clamps clock skew and requires terminal timing`() {
+        val run = AgentRun(
+            runId = "run-1",
+            chatId = 7,
+            userMessageId = 1,
+            assistantMessageId = 2,
+            profileUid = "profile-1",
+            providerSnapshot = "OPENAI",
+            modelSnapshot = "model",
+            startedAt = 20,
+            completedAt = 10
+        )
+
+        assertEquals(0L, agentRunDurationSeconds(run))
+        assertEquals(null, agentRunDurationSeconds(run.copy(completedAt = null)))
+    }
+}

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModelRetryTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModelRetryTest.kt
@@ -1,6 +1,9 @@
 package dev.chungjungsoo.gptmobile.presentation.ui.chat
 
+import dev.chungjungsoo.gptmobile.data.agent.AgentRunTerminalUpdate
+import dev.chungjungsoo.gptmobile.data.agent.toTerminalUpdate
 import dev.chungjungsoo.gptmobile.data.database.entity.ACTIVE_REVISION_LATEST
+import dev.chungjungsoo.gptmobile.data.database.entity.AgentRun
 import dev.chungjungsoo.gptmobile.data.database.entity.AgentRunStatus
 import dev.chungjungsoo.gptmobile.data.database.entity.AssistantRevision
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
@@ -27,6 +30,58 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ChatViewModelRetryTest {
+
+    @Test
+    fun `loading state reattaches to queued and running profile runs`() {
+        val latestRow = listOf(
+            MessageV2(id = 10, chatId = 7, content = "", platformType = "profile-1", currentRunId = "run-1"),
+            MessageV2(id = 11, chatId = 7, content = "", platformType = "profile-2", currentRunId = "run-2")
+        )
+        val runs = mapOf(
+            "run-1" to agentRun("run-1", 10, AgentRunStatus.RUNNING),
+            "run-2" to agentRun("run-2", 11, AgentRunStatus.CANCELED)
+        )
+
+        val states = loadingStatesForLatestAssistant(
+            platformCount = 2,
+            latestAssistantRow = latestRow,
+            runsById = runs,
+            activeRunIds = emptySet()
+        )
+
+        assertEquals(
+            listOf(ChatViewModel.LoadingState.Loading, ChatViewModel.LoadingState.Idle),
+            states
+        )
+        assertEquals(
+            listOf(ChatViewModel.LoadingState.Loading, ChatViewModel.LoadingState.Idle),
+            loadingStatesForLatestAssistant(
+                platformCount = 2,
+                latestAssistantRow = latestRow,
+                runsById = emptyMap(),
+                activeRunIds = setOf("run-1")
+            )
+        )
+    }
+
+    @Test
+    fun `persisted message observer rebuilds normalized comparison rows`() {
+        val grouped = groupPersistedMessages(
+            messages = listOf(
+                MessageV2(id = 1, chatId = 7, content = "First", platformType = null),
+                MessageV2(id = 2, chatId = 7, content = "Second profile", platformType = "profile-2"),
+                MessageV2(id = 3, chatId = 7, content = "First profile", platformType = "profile-1"),
+                MessageV2(id = 4, chatId = 7, content = "Again", platformType = null),
+                MessageV2(id = 5, chatId = 7, content = "Latest", platformType = "profile-1")
+            ),
+            enabledPlatformsInChat = listOf("profile-1", "profile-2"),
+            chatId = 7
+        )
+
+        assertEquals(listOf("First", "Again"), grouped.userMessages.map { it.content })
+        assertEquals(listOf("First profile", "Second profile"), grouped.assistantMessages[0].map { it.content })
+        assertEquals(listOf("Latest", ""), grouped.assistantMessages[1].map { it.content })
+    }
 
     @Test
     fun `selected profiles resolve from all configured profiles without losing slot indexes`() {
@@ -114,15 +169,15 @@ class ChatViewModelRetryTest {
     fun `agent run terminal updates preserve provider failure details`() {
         assertEquals(
             AgentRunTerminalUpdate(AgentRunStatus.COMPLETED, null),
-            ApiStateFlowOutcome.Completed.toAgentRunTerminalUpdate()
+            ApiStateFlowOutcome.Completed.toTerminalUpdate()
         )
         assertEquals(
             AgentRunTerminalUpdate(AgentRunStatus.FAILED, "provider failed"),
-            ApiStateFlowOutcome.Failed("provider failed").toAgentRunTerminalUpdate()
+            ApiStateFlowOutcome.Failed("provider failed").toTerminalUpdate()
         )
         assertEquals(
             AgentRunTerminalUpdate(AgentRunStatus.FAILED, "Provider stream ended without completion."),
-            ApiStateFlowOutcome.Incomplete.toAgentRunTerminalUpdate()
+            ApiStateFlowOutcome.Incomplete.toTerminalUpdate()
         )
     }
 
@@ -286,6 +341,17 @@ class ChatViewModelRetryTest {
         result = result,
         resultType = "TEXT",
         status = ToolEventStatus.COMPLETED
+    )
+
+    private fun agentRun(runId: String, assistantMessageId: Int, status: String) = AgentRun(
+        runId = runId,
+        chatId = 7,
+        userMessageId = 1,
+        assistantMessageId = assistantMessageId,
+        profileUid = "profile-$assistantMessageId",
+        providerSnapshot = "OPENAI",
+        modelSnapshot = "model",
+        status = status
     )
 
     @Test

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ToolTraceBlockTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ToolTraceBlockTest.kt
@@ -39,13 +39,21 @@ class ToolTraceBlockTest {
             toolName = "list_events",
             error = "permission denied"
         )
+        val running = event(
+            eventId = "running",
+            sequence = 4,
+            status = ToolEventStatus.RUNNING,
+            startedAt = 100L
+        )
 
-        assertEquals(listOf("early", "late", "error"), filterToolEvents(listOf(late, error, early), "").map { it.eventId })
+        assertEquals(listOf("early", "late", "error", "running"), filterToolEvents(listOf(late, error, running, early), "").map { it.eventId })
         assertEquals(listOf("early"), filterToolEvents(listOf(late, early, error), "conn-web").map { it.eventId })
         assertEquals(listOf("early"), filterToolEvents(listOf(late, early, error), "web__search").map { it.eventId })
         assertEquals(listOf("early"), filterToolEvents(listOf(late, early, error), "weather").map { it.eventId })
         assertEquals(listOf("late"), filterToolEvents(listOf(late, early, error), "contract").map { it.eventId })
         assertEquals(listOf("error"), filterToolEvents(listOf(late, early, error), "permission").map { it.eventId })
+        assertEquals(listOf("running"), filterToolEvents(listOf(running, early), "running").map { it.eventId })
+        assertEquals(listOf("running"), filterToolEvents(listOf(running, early), "started at").map { it.eventId })
     }
 
     @Test

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensionsTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/util/ApiStateFlowExtensionsTest.kt
@@ -5,6 +5,7 @@ import dev.chungjungsoo.gptmobile.data.database.entity.AssistantRevision
 import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
 import dev.chungjungsoo.gptmobile.data.dto.ApiState
 import dev.chungjungsoo.gptmobile.presentation.ui.chat.ChatViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -14,6 +15,46 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ApiStateFlowExtensionsTest {
+
+    @Test
+    fun `collectApiStateUpdates publishes provider text and thoughts without UI state`() = runBlocking {
+        val updates = mutableListOf<Pair<String, String>>()
+
+        val outcome = flowOf(
+            ApiState.Thinking("Checking"),
+            ApiState.Success("Final "),
+            ApiState.Success("answer"),
+            ApiState.Done
+        ).collectApiStateUpdates(
+            onUpdate = { content, thoughts -> updates += content to thoughts },
+            nanoTimeProvider = { 1L }
+        )
+
+        assertEquals(ApiStateFlowOutcome.Completed, outcome)
+        assertEquals("Final answer" to "Checking", updates.last())
+    }
+
+    @Test
+    fun `collectApiStateUpdates flushes partial text when canceled`() = runBlocking {
+        val updates = mutableListOf<Pair<String, String>>()
+        var wasCanceled = false
+
+        try {
+            flow {
+                emit(ApiState.Success("Partial "))
+                emit(ApiState.Success("answer"))
+                throw CancellationException("stop")
+            }.collectApiStateUpdates(
+                onUpdate = { content, thoughts -> updates += content to thoughts },
+                nanoTimeProvider = { 1L }
+            )
+        } catch (_: CancellationException) {
+            wasCanceled = true
+        }
+
+        assertTrue(wasCanceled)
+        assertEquals("Partial answer" to "", updates.last())
+    }
 
     @Test
     fun `handleStates surfaces nonterminal agent notices`() = runBlocking {

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/util/LocalNetworkAccessTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/util/LocalNetworkAccessTest.kt
@@ -1,0 +1,55 @@
+package dev.chungjungsoo.gptmobile.util
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class LocalNetworkAccessTest {
+    @Test
+    fun `local URLs require Android local network permission`() {
+        assertTrue(requiresLocalNetworkAccess("http://localhost:11434"))
+        assertTrue(requiresLocalNetworkAccess("http://10.0.2.2:8080/mcp"))
+        assertTrue(requiresLocalNetworkAccess("https://192.168.1.10/mcp"))
+        assertTrue(requiresLocalNetworkAccess("https://tools.local/mcp"))
+        assertTrue(requiresLocalNetworkAccess("https://ollama:11434"))
+    }
+
+    @Test
+    fun `public and malformed URLs do not request local network permission`() {
+        assertFalse(requiresLocalNetworkAccess("https://api.openai.com/v1"))
+        assertFalse(requiresLocalNetworkAccess("https://mcp.example.com"))
+        assertFalse(requiresLocalNetworkAccess("not a URL"))
+    }
+
+    @Test
+    fun `connection lookup failure requires permission and reports the failure`() = runTest {
+        val failure = IllegalStateException("database unavailable")
+        var reportedFailure: Exception? = null
+
+        val required = determineLocalNetworkAccessRequirement(
+            providerNeedsAccess = false,
+            toolNeedsAccess = { throw failure },
+            onLookupFailure = { reportedFailure = it }
+        )
+
+        assertTrue(required)
+        assertEquals(failure, reportedFailure)
+    }
+
+    @Test
+    fun `connection lookup preserves coroutine cancellation`() = runTest {
+        try {
+            determineLocalNetworkAccessRequirement(
+                providerNeedsAccess = false,
+                toolNeedsAccess = { throw CancellationException("stopped") },
+                onLookupFailure = { fail("Cancellation must not be reported as a lookup failure") }
+            )
+            fail("Expected cancellation")
+        } catch (_: CancellationException) {
+        }
+    }
+}

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/util/LocalNetworkAccessTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/util/LocalNetworkAccessTest.kt
@@ -22,7 +22,15 @@ class LocalNetworkAccessTest {
     fun `public and malformed URLs do not request local network permission`() {
         assertFalse(requiresLocalNetworkAccess("https://api.openai.com/v1"))
         assertFalse(requiresLocalNetworkAccess("https://mcp.example.com"))
+        assertFalse(requiresLocalNetworkAccess("https://fea.example.com"))
+        assertFalse(requiresLocalNetworkAccess("https://fd.example.com"))
         assertFalse(requiresLocalNetworkAccess("not a URL"))
+    }
+
+    @Test
+    fun `private IPv6 literals require Android local network permission`() {
+        assertTrue(requiresLocalNetworkAccess("http://[fe80::1]:8080/mcp"))
+        assertTrue(requiresLocalNetworkAccess("http://[fd00::1]:8080/mcp"))
     }
 
     @Test

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/util/LocalNetworkAccessTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/util/LocalNetworkAccessTest.kt
@@ -16,6 +16,8 @@ class LocalNetworkAccessTest {
         assertTrue(requiresLocalNetworkAccess("https://192.168.1.10/mcp"))
         assertTrue(requiresLocalNetworkAccess("https://tools.local/mcp"))
         assertTrue(requiresLocalNetworkAccess("https://ollama:11434"))
+        assertTrue(requiresLocalNetworkAccess("localhost:11434"))
+        assertTrue(requiresLocalNetworkAccess("192.168.1.10:11434"))
     }
 
     @Test


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reliable background processing for agent runs with progress notifications.
  - Added run status, duration, error, retry, and cancellation details to chat messages.
  - Added stop controls for active runs and safeguards when deleting or duplicating chats.
  - Added local-network permission handling for tools and OAuth connections.
  - Added notification and permission guidance for relevant actions.

- **Bug Fixes**
  - Improved interruption and cancellation handling, including pending tool activity.
  - Prevented late completions from overwriting finalized runs.
  - Preserved streamed content when runs complete or are canceled.
  - Improved tool-event search and empty-result messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->