### PR TITLE
chore: prepare v0.8.0 agent release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # GPT Mobile
 
-### Chat Assistant for Android that supports chatting with multiple models at once.
+### Multi-provider AI chat and optional on-device agents for Android.
 
 <p>
   <a href="https://mailchi.mp/kotlinweekly/kotlin-weekly-431"><img alt="Kotlin Weekly" src="https://img.shields.io/badge/Kotlin%20Weekly-%23431-blue"/></a>
@@ -46,19 +46,25 @@
     - Ollama
   - Can customize temperature, top p (Nucleus sampling), and system prompt
   - Custom API URLs, Custom Models are also supported
+- **Optional agent tools per provider profile**
+  - Native tool calling with OpenAI, OpenAI-compatible/Groq, Anthropic, and Gemini
+  - Firecrawl, Perplexity, or Exa web search and hardened URL reading
+  - MCP Streamable HTTP servers with public, bearer, or OAuth authentication
+  - Parallel runs, persistent traces, cancellation, and foreground progress
+  - Existing and newly migrated profiles remain chat-only until tools are assigned
 - Local chat history
   - Chat history is **only saved locally**
-  - Only sends to official API servers while chatting
+  - Credentials are encrypted with Android Keystore and excluded from backup/export
+  - Requests go only to providers and tools selected by the user
 - [Material You](https://m3.material.io/) style UI, Icons
   - Supports dark mode, system dynamic theming **without Activity restart**
 - Per app language setting for Android 13+
 - 100% Kotlin, Jetpack Compose, Single Activity, [Modern App Architecture](https://developer.android.com/topic/architecture#modern-app-architecture) in Android developers documentation
 
 
-## To be supported
+## Agent documentation
 
-- More platforms
-- Image, file support for multimodal models
+See [Agent tools, privacy, and security](docs/agent-tools.md) and the [0.8.0 release notes](docs/release-notes-v0.8.0.md).
 
 If you have any feature requests, please open an issue.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # GPT Mobile
 
-### Multi-provider AI chat and optional on-device agents for Android.
+## Multi-provider AI chat and optional on-device agents for Android.
 
 <p>
   <a href="https://mailchi.mp/kotlinweekly/kotlin-weekly-431"><img alt="Kotlin Weekly" src="https://img.shields.io/badge/Kotlin%20Weekly-%23431-blue"/></a>
@@ -55,7 +55,7 @@
 - Local chat history
   - Chat history is **only saved locally**
   - Credentials are encrypted with Android Keystore and excluded from backup/export
-  - Requests go only to providers and tools selected by the user
+  - During chats, requests go only to selected model providers and assigned tools. Opening a profile's Tools dialog may contact every saved MCP server for discovery and may include its bearer or OAuth credential.
 - [Material You](https://m3.material.io/) style UI, Icons
   - Supports dark mode, system dynamic theming **without Activity restart**
 - Per app language setting for Android 13+

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ extensions.configure<ApplicationExtension> {
         applicationId = "dev.chungjungsoo.gptmobile"
         minSdk = 31
         targetSdk = 37
-        versionCode = 22
-        versionName = "0.7.6"
+        versionCode = 23
+        versionName = "0.8.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/provider/ProviderAdapters.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/agent/provider/ProviderAdapters.kt
@@ -153,12 +153,17 @@ class OpenAICompatibleAdapter @Inject constructor(
                             ).forEach { state ->
                                 state.toProviderEvent()?.let { emit(it) }
                             }
-                            assembler.accept(
-                                content = null,
-                                reasoning = null,
-                                toolCalls = choice.delta?.toolCalls,
-                                finishReason = choice.finishReason
-                            ).forEach { emit(it) }
+                            if (choice.finishReason == "length") {
+                                failed = true
+                                emit(ProviderEvent.Failed(GROQ_OUTPUT_LIMIT_MESSAGE))
+                            } else {
+                                assembler.accept(
+                                    content = null,
+                                    reasoning = null,
+                                    toolCalls = choice.delta?.toolCalls,
+                                    finishReason = choice.finishReason
+                                ).forEach { emit(it) }
+                            }
                         }
                     }
                     reasoningParser.flush().forEach { state ->
@@ -436,6 +441,7 @@ private fun createGroqChatCompletionRequest(
         stream = platform.stream,
         temperature = platform.temperature,
         topP = platform.topP,
+        maxCompletionTokens = if (platform.reasoning) 8_192 else null,
         reasoningEffort = if (platform.reasoning && isGptOssModel) "medium" else null,
         reasoningFormat = when {
             platform.reasoning && !isGptOssModel -> "parsed"
@@ -449,3 +455,6 @@ private fun createGroqChatCompletionRequest(
         }
     )
 }
+
+private const val GROQ_OUTPUT_LIMIT_MESSAGE =
+    "Groq reached the model output limit before producing a final answer."

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/context/ContextBuilder.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/data/context/ContextBuilder.kt
@@ -18,12 +18,17 @@ class ContextBuilder @Inject constructor() {
         if (userMessages.isEmpty()) return emptyList()
 
         val rawTurns = userMessages.mapIndexed { index, userMessage ->
-            val assistantMessage = assistantMessages.getOrNull(index)
-                ?.firstValidAssistantCandidate(platform.uid)
+            val assistantCandidates = assistantMessages.getOrNull(index).orEmpty()
+                .filter { it.platformType == platform.uid }
+            val assistantMessage = assistantCandidates.firstValidAssistantCandidate(platform.uid)
 
             RawConversationTurn(
                 userMessage = userMessage,
                 assistantMessage = assistantMessage,
+                hasAssistantError = assistantMessage == null &&
+                    assistantCandidates.any { candidate ->
+                        isAssistantErrorMessage(sanitizeAssistantMessageForContext(candidate).content)
+                    },
                 isCurrentTurn = index == userMessages.lastIndex
             )
         }
@@ -31,8 +36,7 @@ class ContextBuilder @Inject constructor() {
         val filteredTurns = rawTurns.filter { turn ->
             when {
                 turn.isCurrentTurn -> true
-                turn.assistantMessage == null -> false
-                turn.assistantMessage.effectiveContent().isBlank() && turn.assistantMessage.attachments.isEmpty() -> false
+                turn.hasAssistantError -> false
                 else -> true
             }
         }
@@ -110,5 +114,6 @@ class ContextBuilder @Inject constructor() {
 private data class RawConversationTurn(
     val userMessage: MessageV2,
     val assistantMessage: MessageV2?,
+    val hasAssistantError: Boolean,
     val isCurrentTurn: Boolean
 )

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/context/ContextBuilderTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/context/ContextBuilderTest.kt
@@ -1,0 +1,39 @@
+package dev.chungjungsoo.gptmobile.data.context
+
+import dev.chungjungsoo.gptmobile.data.database.entity.MessageV2
+import dev.chungjungsoo.gptmobile.data.database.entity.PlatformV2
+import dev.chungjungsoo.gptmobile.data.model.ClientType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ContextBuilderTest {
+    @Test
+    fun `tool-only historical turn keeps its user message for follow-up context`() {
+        val platform = PlatformV2(
+            uid = "profile",
+            name = "Provider",
+            compatibleType = ClientType.CUSTOM,
+            apiUrl = "https://provider.example/v1",
+            model = "model"
+        )
+
+        val turns = ContextBuilder().build(
+            userMessages = listOf(
+                MessageV2(content = "What is the latest album of NMIXX?", platformType = null),
+                MessageV2(content = "Where's the result?", platformType = null)
+            ),
+            assistantMessages = listOf(
+                listOf(MessageV2(content = "", thoughts = "I searched for it.", platformType = platform.uid)),
+                listOf(MessageV2(content = "", platformType = platform.uid))
+            ),
+            platform = platform
+        )
+
+        assertEquals(
+            listOf("What is the latest album of NMIXX?", "Where's the result?"),
+            turns.map { it.userMessage.content }
+        )
+        assertNull(turns.first().assistantMessage)
+    }
+}

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImplTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/data/repository/ChatRepositoryImplTest.kt
@@ -137,6 +137,42 @@ class ChatRepositoryImplTest {
         )
         assertEquals(1, groqAPI.streamCalls)
         assertEquals(0, openAIAPI.streamChatCompletionCalls)
+        assertEquals(8_192, groqAPI.lastRequest?.maxCompletionTokens)
+    }
+
+    @Test
+    fun `groq token limit reports failure instead of completing with only thinking`() = runBlocking {
+        val groqAPI = FakeGroqAPI(
+            flowOf(
+                GroqChatCompletionChunk(
+                    choices = listOf(
+                        GroqChoice(
+                            index = 0,
+                            delta = GroqDelta(reasoning = "Still reasoning"),
+                            finishReason = "length"
+                        )
+                    )
+                )
+            )
+        )
+        val repository = createRepository(groqAPI = groqAPI)
+
+        val states = repository.completeChat(
+            userMessages = listOf(MessageV2(content = "Hi", platformType = null)),
+            assistantMessages = emptyList(),
+            platform = groqPlatform(reasoning = true, model = "qwen/qwen3.6-27b"),
+            runId = "test-run"
+        ).toList()
+
+        assertEquals(
+            listOf(
+                ApiState.Loading,
+                ApiState.Thinking("Still reasoning"),
+                ApiState.Error("Groq reached the model output limit before producing a final answer."),
+                ApiState.Done
+            ),
+            states
+        )
     }
 
     @Test

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -1,0 +1,40 @@
+# Agent tools
+
+GPT Mobile 0.8.0 upgrades each existing provider profile into an optional on-device agent profile. Existing profiles, models, system prompts, chats, attachments, revisions, and multi-provider selection continue to work. A migrated profile has no assigned tools, so it remains chat-only until you opt in.
+
+## Set up a profile
+
+1. Open **Settings → Tool connections**.
+2. Add a Firecrawl, Perplexity, or Exa search connection, or add an MCP server that uses Streamable HTTP.
+3. For MCP, choose public access, a bearer token, or OAuth. Cleartext HTTP is available for local/LAN servers only after its warning is accepted.
+4. Open a provider profile and select **Tools**. Assign one search backend, the built-in `read_url` tool, and any discovered MCP tools you want that profile to use.
+5. Start or continue a chat normally.
+
+Only assigned tools are sent to the model. Assigned tools execute without a confirmation prompt and remain visible in the chat timeline. Newly discovered MCP tools stay disabled until you assign them.
+
+When several profiles are selected, GPT Mobile runs one independent agent for each profile. You can leave the chat while they run, follow progress from the foreground notification, or cancel all active profile runs. Cancellation keeps partial text and the tool trace. A process restart marks unfinished runs as interrupted and never replays their tools.
+
+Retrying creates a new run and may invoke tools again. Prior tool results are shown in traces and exports, but are not replayed into later model turns.
+
+## Supported tools and limits
+
+- `web_search`: Firecrawl, Perplexity, or Exa; one search backend per profile.
+- `read_url`: HTTP(S) pages only, with private/loopback/metadata destinations blocked, up to five redirects, a 1 MiB download limit, and at most 64 KiB returned to the model.
+- MCP: current Streamable HTTP servers, including JSON and SSE responses, bearer auth, and OAuth 2.1/PKCE.
+
+Each profile run is limited to 15 minutes, eight model/tool rounds, 24 tool calls, and four concurrent tool calls. Individual calls time out after 60 seconds. Model-visible and persisted output is bounded to 64 KiB per tool call.
+
+Models or endpoints that reject native tool definitions fall back once to chat-only before any tool runs. GPT Mobile does not parse tool calls from prompt-generated JSON.
+
+## Privacy and credential security
+
+- Chats and tool traces are stored in the app's local Room database.
+- Provider, search, bearer, and OAuth credentials are encrypted with an Android Keystore AES-GCM key and stored under `noBackupFilesDir`. They are never included in chat export.
+- Existing plaintext provider keys are moved into the encrypted vault only after a verification read succeeds. A failed migration keeps the original value and displays a recoverable warning.
+- Android backup/transfer can restore chat history, but encrypted credentials intentionally require re-entry on another device.
+- Requests are sent to the selected model provider and, when invoked, the selected search API, URL, or MCP server. Review those services' privacy terms before assigning tools.
+- Deleting a connection removes its bindings and vault credential. Historical traces keep bounded connection/tool snapshots, not secrets.
+- Deleting a chat removes its runs and traces. Duplicating a chat copies completed history with regenerated IDs. Markdown export includes bounded traces and excludes credentials.
+- Credentials are not logged. Unsupported MCP binary/image blocks may be identified in the local trace but are not forwarded to the model.
+
+Google search, legacy MCP HTTP+SSE, stdio MCP, multimodal MCP output forwarding, code execution, browser automation, scheduled jobs, image generation, device control, cross-device sync, and a cloud agent backend are outside 0.8.0.

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -6,7 +6,7 @@ GPT Mobile 0.8.0 upgrades each existing provider profile into an optional on-dev
 
 1. Open **Settings → Tool connections**.
 2. Add a Firecrawl, Perplexity, or Exa search connection, or add an MCP server that uses Streamable HTTP.
-3. For MCP, choose public access, a bearer token, or OAuth. Cleartext HTTP is available for local/LAN servers only after its warning is accepted.
+3. For MCP, choose public access, a bearer token, or OAuth. Cleartext HTTP can be approved for any MCP endpoint; it is unencrypted, so credentials and tool data could be intercepted.
 4. Open a provider profile and select **Tools**. Assign one search backend, the built-in `read_url` tool, and any discovered MCP tools you want that profile to use.
 5. Start or continue a chat normally.
 
@@ -32,7 +32,7 @@ Models or endpoints that reject native tool definitions fall back once to chat-o
 - Provider, search, bearer, and OAuth credentials are encrypted with an Android Keystore AES-GCM key and stored under `noBackupFilesDir`. They are never included in chat export.
 - Existing plaintext provider keys are moved into the encrypted vault only after a verification read succeeds. A failed migration keeps the original value and displays a recoverable warning.
 - Android backup/transfer can restore chat history, but encrypted credentials intentionally require re-entry on another device.
-- Requests are sent to the selected model provider and, when invoked, the selected search API, URL, or MCP server. Review those services' privacy terms before assigning tools.
+- Requests are sent to the selected model provider. Opening a profile's Tools dialog contacts every saved MCP server to discover tools and may include its bearer or OAuth credential. During chats, requests are sent to the assigned search API, requested URL, or MCP server only when that tool is invoked.
 - Deleting a connection removes its bindings and vault credential. Historical traces keep bounded connection/tool snapshots, not secrets.
 - Deleting a chat removes its runs and traces. Duplicating a chat copies completed history with regenerated IDs. Markdown export includes bounded traces and excludes credentials.
 - Credentials are not logged. Unsupported MCP binary/image blocks may be identified in the local trace but are not forwarded to the model.

--- a/docs/release-notes-v0.8.0.md
+++ b/docs/release-notes-v0.8.0.md
@@ -1,0 +1,23 @@
+# GPT Mobile 0.8.0
+
+GPT Mobile profiles can now act as opt-in on-device agents while preserving the existing chat and multi-provider comparison experience.
+
+## Added
+
+- Native structured tool calling for OpenAI Responses, OpenAI-compatible/Groq, Anthropic Messages, and Gemini.
+- Independent parallel agent runs for selected profiles, with persisted status, bounded tool traces, cancellation, retry warnings, and foreground notification progress.
+- Firecrawl, Perplexity, and Exa behind one normalized `web_search` tool.
+- A hardened built-in `read_url` tool.
+- MCP Streamable HTTP discovery and calls with public, bearer-token, and OAuth 2.1/PKCE authentication.
+- Per-profile tool assignment. Profiles without bindings remain chat-only.
+- Android Keystore-backed credential storage and one-way migration of existing provider keys.
+
+## Compatibility and safety
+
+- The Room 6→7 migration preserves existing chat/profile/message IDs, prompts, models, attachments, and revisions. It also repairs early schema-v2 databases that were missing expected message or profile columns.
+- Tool results remain scoped to their run and are not added to later conversation history.
+- Canceling keeps partial text and traces. Interrupted runs are never resumed or replayed automatically.
+- Exports include bounded traces and exclude credentials.
+- Android 17 local-network access is requested only when a selected provider or MCP endpoint requires it.
+
+See [Agent tools](agent-tools.md) for setup, limits, privacy details, and deferred capabilities. Release evidence is recorded in [0.8.0 validation](release-validation-v0.8.0.md).

--- a/docs/release-validation-v0.8.0.md
+++ b/docs/release-validation-v0.8.0.md
@@ -1,0 +1,42 @@
+# GPT Mobile 0.8.0 validation
+
+This file records fixture, emulator, and opt-in live-smoke evidence without credentials. It was finalized before the stacked PRs were submitted for review.
+
+## Local gates
+
+| Gate | Result |
+| --- | --- |
+| `./gradlew :app:testDebugUnitTest :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin :app:lintDebug :app:assembleDebug` | Passed on the release branch |
+| `./gradlew :app:assembleRelease :app:bundleRelease` | Passed; release APK and signed AAB tasks completed |
+| `./gradlew :app:connectedDebugAndroidTest` on API 31 | Passed: 16 tests on `Pixel_6_API_31` |
+| `./gradlew :app:connectedDebugAndroidTest` on API 37 | Passed: 16 tests on `Pixel_7_API_37` |
+| `ktlint "app/src/**/*.kt"` | Passed |
+
+## Release journeys
+
+| Journey | Evidence |
+| --- | --- |
+| Upgrade seeded schema 6→7 and continue the chat | Passed on API 31 and 37 with `MigrationTestHelper`. Schema 6 and early broken-v2 fixtures preserve chats, profiles, prompts, messages, attachments, selected models, and plaintext keys for verified one-way vault migration. New tool/run tables start empty. |
+| No-tool multi-provider chat remains unchanged | Passed manually on API 37 with two unbound profiles and distinct deterministic OpenAI-compatible responses in the existing comparison tabs. |
+| Parallel agents, traces, cancellation, and retry | Passed through provider/runner/trace fixtures plus API 37 parallel profile runs. Partial output survived cancellation, the run became `CANCELED`, and retry displayed the tool side-effect warning. |
+| Firecrawl, Perplexity, Exa, and hardened URL reading | Passed deterministic adapter/security fixtures, including normalized output, malformed responses, redirect limits, private/metadata destinations, DNS lookup failure, and output/download bounds. |
+| Public, bearer, and OAuth MCP | Passed deterministic HTTP/SSE fixtures for initialization, session reuse, pagination, bearer auth, PKCE/state validation, registration, refresh/retry, namespacing, and text/JSON/resource-link results. The connection UI was inspected on API 37. |
+| Foreground notification, background reattachment, cancel, and timeout | Passed manually on API 37. The notification and cancel action remained visible in the shade while backgrounded, the UI reattached, and cancellation removed the service/notification while retaining partial output. Runner timeout fixtures cover the fixed 15-minute ceiling. |
+| Force-stop/relaunch marks interrupted without replay | Passed manually on API 37: a running fixture was force-stopped, relaunched as `INTERRUPTED`, retained partial text, and did not restart its service, notification, or tool work. |
+| Delete, duplicate, export, connection rotation, and vault cleanup | Export opened the Android share sheet; duplication created a copy; deleting the copy retained the original. Room and vault fixtures verify regenerated run/event IDs, ownership cascades, historical snapshots, connection-secret rotation, and deletion cleanup. |
+| Android 17 local-network permission | Passed manually on API 37. Denial preserved the unsent prompt; approval allowed the LAN request; failed local connection produced a persisted failed run with retry affordance. |
+
+## Optional live smoke tests
+
+Live credentials are never committed or printed. Missing credentials do not override deterministic fixture results.
+
+| Integration | Exercised |
+| --- | --- |
+| OpenAI | Attempted; the locally available key was rejected with HTTP 401 `invalid_api_key` |
+| Anthropic | Not exercised; no local credential was set |
+| Gemini | Not exercised; no local credential was set |
+| OpenAI-compatible/Groq | Deterministic local fixture exercised; no live credential was set |
+| Firecrawl | Not exercised live; no local credential was set |
+| Perplexity | Not exercised live; no local credential was set |
+| Exa | Not exercised live; no local credential was set |
+| MCP Streamable HTTP | Deterministic local server exercised; no live endpoint was configured |


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - GPT Mobile now documents support for multi-provider AI chat and optional on-device agents.
  - Agent capabilities include web search, URL reading, MCP integrations, parallel execution, cancellation, traces, and user-selected request routing.
  - Added guidance for secure credential handling, privacy, tool assignment, and chat-only fallback behavior.

- **Documentation**
  - Added agent-tool documentation, release notes, and release-validation guidance.
  - Updated the README with feature details and links to privacy, security, and release resources.

- **Chores**
  - Updated the app version to 0.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->