### PR TITLE
fix: repair broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For translations, we are using [Hosted Weblate](https://hosted.weblate.org/engag
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Taewan-P/gpt_mobile&type=Timeline)](https://star-history.com/#Taewan-P/gpt_mobile&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Taewan-P/gpt_mobile&type=Timeline)](https://star-history.dera.page/#Taewan-P/gpt_mobile&Timeline)
 
 
 ## License


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions that limit the star-history.com service. This change points the chart to star-history.dera.page, which uses an alternative data source that needs no API token and serves both the image and the page on the same domain, restoring the chart as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Star History chart image and link to use the new Star History website address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->