### PR TITLE
Fix chat auto-follow during streaming

### DIFF
--- a/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBottomAutoScrollerInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBottomAutoScrollerInstrumentedTest.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
+import androidx.test.platform.app.InstrumentationRegistry
+import dev.chungjungsoo.gptmobile.R
 import kotlinx.coroutines.launch
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -37,7 +39,7 @@ class ChatBottomAutoScrollerInstrumentedTest {
 
             Box(Modifier.size(width = 320.dp, height = 280.dp)) {
                 GrowingChatList(listState, additionalHeight)
-                ChatBottomAutoScroller(listState, enabled = true)
+                ChatBottomAutoScroller(listState, isEnabled = true)
             }
         }
 
@@ -54,7 +56,8 @@ class ChatBottomAutoScrollerInstrumentedTest {
     fun bottomButton_reenablesFollowingForLateContentGrowth() {
         lateinit var listState: LazyListState
         var additionalHeight by mutableStateOf(0.dp)
-        var followBottom by mutableStateOf(false)
+        var isFollowingBottom by mutableStateOf(false)
+        val scrollToBottomDescription = InstrumentationRegistry.getInstrumentation().targetContext.getString(R.string.scroll_to_bottom_icon)
 
         composeRule.setContent {
             listState = rememberLazyListState()
@@ -62,11 +65,11 @@ class ChatBottomAutoScrollerInstrumentedTest {
 
             Box(Modifier.size(width = 320.dp, height = 280.dp)) {
                 GrowingChatList(listState, additionalHeight)
-                ChatBottomAutoScroller(listState, enabled = followBottom)
+                ChatBottomAutoScroller(listState, isEnabled = isFollowingBottom)
                 ScrollToBottomButton {
                     scope.launch {
                         listState.animateScrollToLatestChatMessage()
-                        followBottom = true
+                        isFollowingBottom = true
                     }
                 }
             }
@@ -75,7 +78,7 @@ class ChatBottomAutoScrollerInstrumentedTest {
         composeRule.waitForIdle()
         composeRule.runOnIdle { assertTrue(listState.canScrollForward) }
 
-        composeRule.onNodeWithContentDescription("Scroll to bottom icon").performClick()
+        composeRule.onNodeWithContentDescription(scrollToBottomDescription).performClick()
         composeRule.waitForIdle()
         composeRule.runOnIdle { assertFalse(listState.canScrollForward) }
 

--- a/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBottomAutoScrollerInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBottomAutoScrollerInstrumentedTest.kt
@@ -1,0 +1,102 @@
+package dev.chungjungsoo.gptmobile.presentation.ui.chat
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class ChatBottomAutoScrollerInstrumentedTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun growingContentWhileFollowing_keepsTheTrueBottomVisible() {
+        lateinit var listState: LazyListState
+        var additionalHeight by mutableStateOf(0.dp)
+
+        composeRule.setContent {
+            listState = rememberLazyListState()
+
+            Box(Modifier.size(width = 320.dp, height = 280.dp)) {
+                GrowingChatList(listState, additionalHeight)
+                ChatBottomAutoScroller(listState, enabled = true)
+            }
+        }
+
+        composeRule.waitForIdle()
+        composeRule.runOnIdle { assertFalse(listState.canScrollForward) }
+
+        composeRule.runOnIdle { additionalHeight = 480.dp }
+        composeRule.waitForIdle()
+
+        composeRule.runOnIdle { assertFalse(listState.canScrollForward) }
+    }
+
+    @Test
+    fun bottomButton_reenablesFollowingForLateContentGrowth() {
+        lateinit var listState: LazyListState
+        var additionalHeight by mutableStateOf(0.dp)
+        var followBottom by mutableStateOf(false)
+
+        composeRule.setContent {
+            listState = rememberLazyListState()
+            val scope = rememberCoroutineScope()
+
+            Box(Modifier.size(width = 320.dp, height = 280.dp)) {
+                GrowingChatList(listState, additionalHeight)
+                ChatBottomAutoScroller(listState, enabled = followBottom)
+                ScrollToBottomButton {
+                    scope.launch {
+                        listState.animateScrollToLatestChatMessage()
+                        followBottom = true
+                    }
+                }
+            }
+        }
+
+        composeRule.waitForIdle()
+        composeRule.runOnIdle { assertTrue(listState.canScrollForward) }
+
+        composeRule.onNodeWithContentDescription("Scroll to bottom icon").performClick()
+        composeRule.waitForIdle()
+        composeRule.runOnIdle { assertFalse(listState.canScrollForward) }
+
+        composeRule.runOnIdle { additionalHeight = 480.dp }
+        composeRule.waitForIdle()
+
+        composeRule.runOnIdle { assertFalse(listState.canScrollForward) }
+    }
+}
+
+@androidx.compose.runtime.Composable
+private fun GrowingChatList(
+    listState: LazyListState,
+    additionalHeight: androidx.compose.ui.unit.Dp
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        state = listState
+    ) {
+        item { Spacer(Modifier.height(420.dp)) }
+        item { Spacer(Modifier.height(320.dp + additionalHeight)) }
+        item(key = "chat-bottom-anchor") { Spacer(Modifier.height(1.dp)) }
+    }
+}

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -22,7 +23,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
@@ -72,6 +73,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -111,7 +113,7 @@ import dev.chungjungsoo.gptmobile.data.database.entity.effectiveTimeline
 import dev.chungjungsoo.gptmobile.util.isAssistantErrorMessage
 import java.io.File
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -130,6 +132,8 @@ fun ChatScreen(
     val maximumUserChatBubbleWidth = (screenWidthDp - systemChatMargin) * 0.8F
     val maximumOpponentChatBubbleWidth = screenWidthDp - systemChatMargin
     val listState = rememberLazyListState()
+    val isUserDragging by listState.interactionSource.collectIsDraggedAsState()
+    var followBottom by remember { mutableStateOf(true) }
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     val chatRoom by chatViewModel.chatRoom.collectAsStateWithLifecycle()
@@ -143,7 +147,6 @@ fun ChatScreen(
     val isChatModelDialogOpen by chatViewModel.isChatModelDialogOpen.collectAsStateWithLifecycle()
     val messageEditSession by chatViewModel.messageEditSession.collectAsStateWithLifecycle()
     val isSelectTextSheetOpen by chatViewModel.isSelectTextSheetOpen.collectAsStateWithLifecycle()
-    val isLoaded by chatViewModel.isLoaded.collectAsStateWithLifecycle()
     val selectedAttachments by chatViewModel.selectedAttachments.collectAsStateWithLifecycle()
     val attachmentNotice by chatViewModel.attachmentNotice.collectAsStateWithLifecycle()
     val needsLocalNetworkAccess by chatViewModel.needsLocalNetworkAccess.collectAsStateWithLifecycle()
@@ -195,34 +198,33 @@ fun ChatScreen(
         chatViewModel.refreshLocalNetworkRequirement()
     }
 
-    suspend fun animateScrollToLatestMessage() {
-        val latestItemIndex = listState.layoutInfo.totalItemsCount - 1
-        if (latestItemIndex >= 0) {
-            listState.animateScrollToItem(latestItemIndex)
-        }
+    LaunchedEffect(isUserDragging, listState.isScrollInProgress, listState.canScrollForward, listState.lastScrolledBackward) {
+        followBottom = nextFollowBottom(
+            isFollowing = followBottom,
+            isUserScrolling = isUserDragging || listState.isScrollInProgress,
+            isScrollingAway = listState.lastScrolledBackward,
+            canScrollForward = listState.canScrollForward
+        )
     }
 
-    LaunchedEffect(isIdle) {
-        animateScrollToLatestMessage()
+    LaunchedEffect(lastMessageIndex) {
+        followBottom = true
     }
 
-    LaunchedEffect(isLoaded) {
-        animateScrollToLatestMessage()
-    }
+    ChatBottomAutoScroller(
+        listState = listState,
+        enabled = shouldAutoScrollToBottom(
+            isFollowing = followBottom,
+            isUserDragging = isUserDragging,
+            isScrollInProgress = listState.isScrollInProgress,
+            isScrollingAway = listState.lastScrolledBackward
+        )
+    )
 
     LaunchedEffect(attachmentNotice) {
         attachmentNotice?.let { notice ->
             Toast.makeText(context, notice, Toast.LENGTH_SHORT).show()
             chatViewModel.consumeAttachmentNotice()
-        }
-    }
-
-    // Auto-scroll to bottom when keyboard opens
-    val imeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
-    LaunchedEffect(imeVisible) {
-        if (imeVisible) {
-            delay(100) // Small delay to let keyboard animation start
-            animateScrollToLatestMessage()
         }
     }
 
@@ -303,7 +305,7 @@ fun ChatScreen(
                     }
                 }
 
-                if (listState.canScrollForward) {
+                if (!followBottom && listState.canScrollForward) {
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -312,7 +314,8 @@ fun ChatScreen(
                     ) {
                         ScrollToBottomButton {
                             scope.launch {
-                                animateScrollToLatestMessage()
+                                listState.animateScrollToLatestChatMessage()
+                                followBottom = true
                             }
                         }
                     }
@@ -578,6 +581,51 @@ private fun chatMessagePairKey(message: MessageV2, index: Int): String = if (mes
     "message-${message.id}"
 } else {
     "message-${message.createdAt}-$index"
+}
+
+internal fun nextFollowBottom(
+    isFollowing: Boolean,
+    isUserScrolling: Boolean,
+    isScrollingAway: Boolean,
+    canScrollForward: Boolean
+): Boolean = when {
+    !canScrollForward -> true
+    isUserScrolling && isScrollingAway -> false
+    else -> isFollowing
+}
+
+internal fun shouldAutoScrollToBottom(
+    isFollowing: Boolean,
+    isUserDragging: Boolean,
+    isScrollInProgress: Boolean,
+    isScrollingAway: Boolean
+): Boolean = isFollowing &&
+    !isUserDragging &&
+    !(isScrollInProgress && isScrollingAway)
+
+@Composable
+internal fun ChatBottomAutoScroller(
+    listState: LazyListState,
+    enabled: Boolean
+) {
+    LaunchedEffect(listState, enabled) {
+        if (!enabled) return@LaunchedEffect
+
+        snapshotFlow { listState.layoutInfo }
+            .collectLatest { layoutInfo ->
+                val latestItemIndex = layoutInfo.totalItemsCount - 1
+                if (latestItemIndex >= 0 && listState.canScrollForward) {
+                    listState.requestScrollToItem(latestItemIndex)
+                }
+            }
+    }
+}
+
+internal suspend fun LazyListState.animateScrollToLatestChatMessage() {
+    val latestItemIndex = layoutInfo.totalItemsCount - 1
+    if (latestItemIndex >= 0) {
+        animateScrollToItem(latestItemIndex)
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
@@ -133,7 +133,7 @@ fun ChatScreen(
     val maximumOpponentChatBubbleWidth = screenWidthDp - systemChatMargin
     val listState = rememberLazyListState()
     val isUserDragging by listState.interactionSource.collectIsDraggedAsState()
-    var followBottom by remember { mutableStateOf(true) }
+    var isFollowingBottom by remember { mutableStateOf(true) }
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     val chatRoom by chatViewModel.chatRoom.collectAsStateWithLifecycle()
@@ -199,8 +199,8 @@ fun ChatScreen(
     }
 
     LaunchedEffect(isUserDragging, listState.isScrollInProgress, listState.canScrollForward, listState.lastScrolledBackward) {
-        followBottom = nextFollowBottom(
-            isFollowing = followBottom,
+        isFollowingBottom = nextFollowBottom(
+            isFollowing = isFollowingBottom,
             isUserScrolling = isUserDragging || listState.isScrollInProgress,
             isScrollingAway = listState.lastScrolledBackward,
             canScrollForward = listState.canScrollForward
@@ -208,13 +208,13 @@ fun ChatScreen(
     }
 
     LaunchedEffect(lastMessageIndex) {
-        followBottom = true
+        isFollowingBottom = true
     }
 
     ChatBottomAutoScroller(
         listState = listState,
-        enabled = shouldAutoScrollToBottom(
-            isFollowing = followBottom,
+        isEnabled = shouldAutoScrollToBottom(
+            isFollowing = isFollowingBottom,
             isUserDragging = isUserDragging,
             isScrollInProgress = listState.isScrollInProgress,
             isScrollingAway = listState.lastScrolledBackward
@@ -305,7 +305,7 @@ fun ChatScreen(
                     }
                 }
 
-                if (!followBottom && listState.canScrollForward) {
+                if (!isFollowingBottom && listState.canScrollForward) {
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -315,7 +315,7 @@ fun ChatScreen(
                         ScrollToBottomButton {
                             scope.launch {
                                 listState.animateScrollToLatestChatMessage()
-                                followBottom = true
+                                isFollowingBottom = true
                             }
                         }
                     }
@@ -606,10 +606,10 @@ internal fun shouldAutoScrollToBottom(
 @Composable
 internal fun ChatBottomAutoScroller(
     listState: LazyListState,
-    enabled: Boolean
+    isEnabled: Boolean
 ) {
-    LaunchedEffect(listState, enabled) {
-        if (!enabled) return@LaunchedEffect
+    LaunchedEffect(listState, isEnabled) {
+        if (!isEnabled) return@LaunchedEffect
 
         snapshotFlow { listState.layoutInfo }
             .collectLatest { layoutInfo ->

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBottomFollowTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBottomFollowTest.kt
@@ -1,0 +1,91 @@
+package dev.chungjungsoo.gptmobile.presentation.ui.chat
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatBottomFollowTest {
+    @Test
+    fun contentGrowthWhileFollowing_keepsFollowEnabled() {
+        assertTrue(
+            nextFollowBottom(
+                isFollowing = true,
+                isUserScrolling = false,
+                isScrollingAway = false,
+                canScrollForward = true
+            )
+        )
+    }
+
+    @Test
+    fun userDragAwayFromBottom_disablesFollowing() {
+        assertFalse(
+            nextFollowBottom(
+                isFollowing = true,
+                isUserScrolling = true,
+                isScrollingAway = true,
+                canScrollForward = true
+            )
+        )
+    }
+
+    @Test
+    fun reachingBottom_reenablesFollowing() {
+        assertTrue(
+            nextFollowBottom(
+                isFollowing = false,
+                isUserScrolling = false,
+                isScrollingAway = false,
+                canScrollForward = false
+            )
+        )
+    }
+
+    @Test
+    fun userDragTowardBottomBeforeReachingIt_keepsFollowingDisabled() {
+        assertFalse(
+            nextFollowBottom(
+                isFollowing = false,
+                isUserScrolling = true,
+                isScrollingAway = false,
+                canScrollForward = true
+            )
+        )
+    }
+
+    @Test
+    fun backwardFlingAfterPointerUp_disablesFollowing() {
+        assertFalse(
+            nextFollowBottom(
+                isFollowing = true,
+                isUserScrolling = true,
+                isScrollingAway = true,
+                canScrollForward = true
+            )
+        )
+    }
+
+    @Test
+    fun backwardFlingInProgress_blocksAutoScroll() {
+        assertFalse(
+            shouldAutoScrollToBottom(
+                isFollowing = true,
+                isUserDragging = false,
+                isScrollInProgress = true,
+                isScrollingAway = true
+            )
+        )
+    }
+
+    @Test
+    fun idleContentGrowthWhileFollowing_allowsAutoScroll() {
+        assertTrue(
+            shouldAutoScrollToBottom(
+                isFollowing = true,
+                isUserDragging = false,
+                isScrollInProgress = false,
+                isScrollingAway = false
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- keep the chat transcript pinned to the true bottom while assistant content and delayed layouts grow
- pause following when the user drags or flings away, then resume when they return to the bottom
- make the scroll-to-bottom button re-enter follow mode and correct later layout growth

## Testing

- ANDROID_HOME=/Users/taewanpark/Library/Android/sdk ANDROID_SDK_ROOT=/Users/taewanpark/Library/Android/sdk ./gradlew :app:testDebugUnitTest :app:lintDebug :app:compileDebugAndroidTestKotlin
- ktlint on all three changed Kotlin files
- ANDROID_HOME=/Users/taewanpark/Library/Android/sdk ANDROID_SDK_ROOT=/Users/taewanpark/Library/Android/sdk ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.chungjungsoo.gptmobile.presentation.ui.chat.ChatBottomAutoScrollerInstrumentedTest (2 tests on Pixel 7 API 37)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat scrolling to keep the latest message visible as new content arrives.
  - Chat no longer automatically scrolls away from the user’s position when they scroll upward or browse earlier messages.
  - Added a scroll-to-bottom button when newer content is available.
  - Selecting the button returns to the latest message and resumes automatic following.

- **Tests**
  - Added coverage for chat scrolling during content growth, user scrolling, and returning to the bottom.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->