### PR TITLE
fix: render long chats at the bottom initially

### DIFF
--- a/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBottomAutoScrollerInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBottomAutoScrollerInstrumentedTest.kt
@@ -30,6 +30,33 @@ class ChatBottomAutoScrollerInstrumentedTest {
     val composeRule = createComposeRule()
 
     @Test
+    fun openingLoadedHistory_startsAtBottomWithoutAutoScroll() {
+        lateinit var listState: LazyListState
+        var isHistoryLoaded by mutableStateOf(false)
+
+        composeRule.setContent {
+            listState = rememberChatListState(messageCount = if (isHistoryLoaded) 2 else 0)
+
+            Box(Modifier.size(width = 320.dp, height = 280.dp)) {
+                GrowingChatList(
+                    listState = listState,
+                    additionalHeight = 480.dp,
+                    isContentVisible = isHistoryLoaded
+                )
+            }
+        }
+
+        composeRule.waitForIdle()
+        composeRule.runOnIdle { isHistoryLoaded = true }
+        composeRule.waitForIdle()
+
+        composeRule.runOnIdle {
+            assertTrue(listState.canScrollBackward)
+            assertFalse(listState.canScrollForward)
+        }
+    }
+
+    @Test
     fun growingContentWhileFollowing_keepsTheTrueBottomVisible() {
         lateinit var listState: LazyListState
         var additionalHeight by mutableStateOf(0.dp)
@@ -92,14 +119,17 @@ class ChatBottomAutoScrollerInstrumentedTest {
 @androidx.compose.runtime.Composable
 private fun GrowingChatList(
     listState: LazyListState,
-    additionalHeight: androidx.compose.ui.unit.Dp
+    additionalHeight: androidx.compose.ui.unit.Dp,
+    isContentVisible: Boolean = true
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         state = listState
     ) {
-        item { Spacer(Modifier.height(420.dp)) }
-        item { Spacer(Modifier.height(320.dp + additionalHeight)) }
-        item(key = "chat-bottom-anchor") { Spacer(Modifier.height(1.dp)) }
+        if (isContentVisible) {
+            item { Spacer(Modifier.height(420.dp)) }
+            item { Spacer(Modifier.height(320.dp + additionalHeight)) }
+            item(key = "chat-bottom-anchor") { Spacer(Modifier.height(1.dp)) }
+        }
     }
 }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
@@ -68,6 +68,7 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -131,13 +132,13 @@ fun ChatScreen(
     val systemChatMargin = 32.dp
     val maximumUserChatBubbleWidth = (screenWidthDp - systemChatMargin) * 0.8F
     val maximumOpponentChatBubbleWidth = screenWidthDp - systemChatMargin
-    val listState = rememberLazyListState()
-    val isUserDragging by listState.interactionSource.collectIsDraggedAsState()
-    var isFollowingBottom by remember { mutableStateOf(true) }
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     val chatRoom by chatViewModel.chatRoom.collectAsStateWithLifecycle()
     val groupedMessages by chatViewModel.groupedMessages.collectAsStateWithLifecycle()
+    val listState = rememberChatListState(groupedMessages.userMessages.size)
+    val isUserDragging by listState.interactionSource.collectIsDraggedAsState()
+    var isFollowingBottom by remember { mutableStateOf(true) }
     val agentRunsById by chatViewModel.agentRunsById.collectAsStateWithLifecycle()
     val runNoticesById by chatViewModel.runNoticesById.collectAsStateWithLifecycle()
     val toolEventsByRun by chatViewModel.toolEventsByRun.collectAsStateWithLifecycle()
@@ -581,6 +582,11 @@ private fun chatMessagePairKey(message: MessageV2, index: Int): String = if (mes
     "message-${message.id}"
 } else {
     "message-${message.createdAt}-$index"
+}
+
+@Composable
+internal fun rememberChatListState(messageCount: Int): LazyListState = key(messageCount > 0) {
+    rememberLazyListState(initialFirstVisibleItemIndex = messageCount)
 }
 
 internal fun nextFollowBottom(


### PR DESCRIPTION
## Summary

- initialize loaded chat history at the bottom anchor before its first non-empty layout
- keep the existing auto-follower for streaming growth and the manual scroll-to-bottom action
- add a device regression test that proves the list overflows and starts at its true bottom

## Root cause

The chat list state started at index 0. After the first layout, ChatBottomAutoScroller observed that more content was available and requested the bottom item, producing a visible top-to-bottom snap and unnecessary layout work for long histories.

## Testing

- RED: focused device test failed with the old initial index because the loaded list could scroll forward
- GREEN: focused device test passed after initializing at the bottom anchor
- full ChatBottomAutoScrollerInstrumentedTest: 3 tests passed on Pixel 7 API 37
- ./gradlew test
- ./gradlew :app:testDebugUnitTest :app:lintDebug :app:compileDebugAndroidTestKotlin
- ktlint on both changed Kotlin files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat history now opens at the latest message when loaded after the chat screen appears.
  * Improved scrolling behavior so users can scroll backward through history without unintended forward scrolling.
* **Tests**
  * Added coverage to verify the initial chat position and scrolling behavior when history becomes available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->