### PR TITLE
fix: restore chat loading and message actions

### DIFF
--- a/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatMessagePresentationInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatMessagePresentationInstrumentedTest.kt
@@ -87,7 +87,7 @@ class ChatMessagePresentationInstrumentedTest {
     }
 
     @Test
-    fun activeToolHidesStreamingDotAndDetailsSpinner() {
+    fun activeToolKeepsOneStreamingIndicatorVisible() {
         composeRule.setContent {
             GPTMobileTheme {
                 OpponentChatBubble(
@@ -103,7 +103,7 @@ class ChatMessagePresentationInstrumentedTest {
             }
         }
 
-        composeRule.onNodeWithText("Answer●").assertDoesNotExist()
+        composeRule.onAllNodesWithText("●").assertCountEquals(1)
         composeRule.onNodeWithText("Details").assertExists()
         composeRule.onNodeWithContentDescription("Tool in progress").assertDoesNotExist()
     }

--- a/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatMessagePresentationInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatMessagePresentationInstrumentedTest.kt
@@ -1,10 +1,11 @@
 package dev.chungjungsoo.gptmobile.presentation.ui.chat
 
 import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasProgressBarRangeInfo
 import androidx.compose.ui.test.junit4.v2.createComposeRule
-import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -24,7 +25,7 @@ class ChatMessagePresentationInstrumentedTest {
     val composeRule = createComposeRule()
 
     @Test
-    fun completedMessageKeepsActionsHiddenUntilRequested() {
+    fun completedMessageShowsInlineToolbar() {
         composeRule.setContent {
             GPTMobileTheme {
                 OpponentChatBubble(
@@ -35,13 +36,9 @@ class ChatMessagePresentationInstrumentedTest {
             }
         }
 
-        composeRule.onAllNodesWithContentDescription("Message actions").assertCountEquals(1)
-        composeRule.onNodeWithText("Copy Text").assertDoesNotExist()
-
-        composeRule.onNodeWithContentDescription("Message actions").performClick()
-
-        composeRule.onNodeWithText("Copy Text").assertExists()
-        composeRule.onNodeWithText("Select Text").assertExists()
+        composeRule.onNodeWithContentDescription("Message actions").assertDoesNotExist()
+        composeRule.onNodeWithContentDescription("Copy Text").assertExists()
+        composeRule.onNodeWithContentDescription("Select Text").assertExists()
     }
 
     @Test
@@ -56,6 +53,7 @@ class ChatMessagePresentationInstrumentedTest {
             }
         }
 
+        composeRule.onNodeWithContentDescription("Copy Text").assertDoesNotExist()
         composeRule.onNodeWithContentDescription("Message actions").assertDoesNotExist()
         composeRule.onNodeWithText("Answer").assertExists()
         composeRule.onNodeWithText("●").assertExists()
@@ -63,7 +61,7 @@ class ChatMessagePresentationInstrumentedTest {
     }
 
     @Test
-    fun activeToolReplacesStreamingDotWithOneProgressSignal() {
+    fun activeToolHidesStreamingDotAndDetailsSpinner() {
         composeRule.setContent {
             GPTMobileTheme {
                 OpponentChatBubble(
@@ -80,7 +78,19 @@ class ChatMessagePresentationInstrumentedTest {
         }
 
         composeRule.onNodeWithText("Answer●").assertDoesNotExist()
-        composeRule.onAllNodesWithContentDescription("Tool in progress").assertCountEquals(1)
+        composeRule.onNodeWithText("Details").assertExists()
+        composeRule.onNodeWithContentDescription("Tool in progress").assertDoesNotExist()
+    }
+
+    @Test
+    fun loadingLogoShowsProgressRing() {
+        composeRule.setContent {
+            GPTMobileTheme {
+                GPTMobileIcon(loading = true)
+            }
+        }
+
+        composeRule.onNode(hasProgressBarRangeInfo(ProgressBarRangeInfo.Indeterminate)).assertExists()
     }
 
     @Test
@@ -131,7 +141,7 @@ class ChatMessagePresentationInstrumentedTest {
     }
 
     @Test
-    fun failedRetryStaysInlineAndIsAbsentFromActionsSheet() {
+    fun failedRetryStaysOnToolbarWithoutCopy() {
         composeRule.setContent {
             GPTMobileTheme {
                 OpponentChatBubble(
@@ -139,32 +149,31 @@ class ChatMessagePresentationInstrumentedTest {
                     canRetry = true,
                     isLoading = false,
                     isError = true,
-                    canEdit = true,
-                    showInlineRetry = true
+                    canEdit = true
                 )
             }
         }
 
-        composeRule.onAllNodesWithText("Retry").assertCountEquals(1)
-        composeRule.onNodeWithContentDescription("Message actions").performClick()
-        composeRule.onAllNodesWithText("Retry").assertCountEquals(1)
+        composeRule.onNodeWithContentDescription("Message actions").assertDoesNotExist()
+        composeRule.onNodeWithContentDescription("Copy Text").assertDoesNotExist()
+        composeRule.onNodeWithContentDescription("Retry").assertExists()
+        composeRule.onNodeWithText("Retry may run assigned tools again.").assertExists()
     }
 
     @Test
-    fun successfulRetryInActionsSheetShowsToolsWarningOnce() {
+    fun successfulRetryOnToolbarShowsToolsWarningOnce() {
         composeRule.setContent {
             GPTMobileTheme {
                 OpponentChatBubble(
                     text = "Answer",
                     canRetry = true,
-                    isLoading = false,
-                    showInlineRetry = false
+                    isLoading = false
                 )
             }
         }
 
-        composeRule.onNodeWithContentDescription("Message actions").performClick()
-        composeRule.onAllNodesWithText("Retry").assertCountEquals(1)
+        composeRule.onNodeWithContentDescription("Copy Text").assertExists()
+        composeRule.onNodeWithContentDescription("Retry").assertExists()
         composeRule.onAllNodesWithText("Retry may run assigned tools again.").assertCountEquals(1)
     }
 
@@ -188,6 +197,9 @@ class ChatMessagePresentationInstrumentedTest {
             }
         }
 
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithText("Answer").fetchSemanticsNodes().size == 1
+        }
         composeRule.onAllNodesWithText("Answer").assertCountEquals(1)
         composeRule.onNodeWithText("Details").performClick()
         composeRule.onAllNodesWithText("Answer").assertCountEquals(1)

--- a/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatMessagePresentationInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatMessagePresentationInstrumentedTest.kt
@@ -2,6 +2,9 @@ package dev.chungjungsoo.gptmobile.presentation.ui.chat
 
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasProgressBarRangeInfo
@@ -10,6 +13,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
 import dev.chungjungsoo.gptmobile.data.database.entity.AssistantTimelineItem
 import dev.chungjungsoo.gptmobile.data.database.entity.AssistantTimelineItemType
 import dev.chungjungsoo.gptmobile.data.database.entity.ToolEvent
@@ -39,6 +43,28 @@ class ChatMessagePresentationInstrumentedTest {
         composeRule.onNodeWithContentDescription("Message actions").assertDoesNotExist()
         composeRule.onNodeWithContentDescription("Copy Text").assertExists()
         composeRule.onNodeWithContentDescription("Select Text").assertExists()
+    }
+
+    @Test
+    fun userMessageExposesLongPressActionsToAccessibility() {
+        composeRule.setContent {
+            GPTMobileTheme {
+                UserChatBubble(
+                    text = "Question",
+                    canEdit = true
+                )
+            }
+        }
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithText("Question").fetchSemanticsNodes().size == 1
+        }
+        composeRule
+            .onNodeWithText("Question")
+            .assert(SemanticsMatcher.keyIsDefined(SemanticsActions.OnLongClick))
+            .performSemanticsAction(SemanticsActions.OnLongClick)
+        composeRule.onNodeWithText("Copy Text").assertExists()
+        composeRule.onNodeWithText("Edit").assertExists()
     }
 
     @Test

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
@@ -69,7 +69,6 @@ import dev.chungjungsoo.gptmobile.data.database.entity.AgentRun
 import dev.chungjungsoo.gptmobile.data.database.entity.AssistantTimelineItem
 import dev.chungjungsoo.gptmobile.data.database.entity.AssistantTimelineItemType
 import dev.chungjungsoo.gptmobile.data.database.entity.ToolEvent
-import dev.chungjungsoo.gptmobile.data.database.entity.ToolEventStatus
 import dev.chungjungsoo.gptmobile.data.database.entity.hasUnavailableAssistantOrder
 import dev.chungjungsoo.gptmobile.presentation.theme.GPTMobileTheme
 import dev.chungjungsoo.gptmobile.presentation.theme.defaultSpatialSpec
@@ -171,9 +170,6 @@ fun OpponentChatBubble(
         isRunActive = isLoading
     )
     val contentTimeline = timeline.filter { it.type != AssistantTimelineItemType.NOTICE }
-    val activeToolEvents = toolEvents.filter {
-        it.status == ToolEventStatus.PENDING || it.status == ToolEventStatus.RUNNING
-    }
     val hasUnresolvedToolDetails = hasUnresolvedToolReferences(contentTimeline, toolEvents)
     val hasDetails = thoughts.isNotBlank() ||
         toolEvents.isNotEmpty() ||
@@ -189,7 +185,7 @@ fun OpponentChatBubble(
         hasToolEvents = toolEvents.isNotEmpty()
     )
     var isDetailsExpanded by rememberSaveable(contentIdentity) { mutableStateOf(false) }
-    val showAnswerStreamingIndicator = isLoading && activeToolEvents.isEmpty()
+    val showAnswerStreamingIndicator = isLoading
     val showProcessStreamingIndicator = showAnswerStreamingIndicator && text.isBlank()
 
     Column(modifier = modifier) {

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
@@ -206,7 +206,7 @@ fun OpponentChatBubble(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 8.dp),
+                    .padding(start = 8.dp, top = 8.dp, end = 8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 DetailsButton(

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.onLongClick
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
@@ -93,10 +94,17 @@ fun UserChatBubble(
     )
 
     var isActionsSheetOpen by rememberSaveable(contentIdentity) { mutableStateOf(false) }
+    val messageActionsLabel = stringResource(R.string.message_actions)
 
     Column(horizontalAlignment = Alignment.End) {
         Card(
             modifier = modifier
+                .semantics(mergeDescendants = true) {
+                    onLongClick(label = messageActionsLabel) {
+                        isActionsSheetOpen = true
+                        true
+                    }
+                }
                 .pointerInput(contentIdentity) {
                     detectTapGestures(onLongPress = { isActionsSheetOpen = true })
                 },

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
@@ -25,8 +26,10 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.rounded.KeyboardArrowDown
-import androidx.compose.material.icons.rounded.MoreHoriz
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -35,7 +38,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -55,7 +57,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
@@ -111,25 +112,13 @@ fun UserChatBubble(
             files = files,
             modifier = Modifier.padding(top = 8.dp)
         )
-        MessageActionsButton(onClick = { isActionsSheetOpen = true })
     }
 
     if (isActionsSheetOpen) {
         MessageActionsSheet(
-            role = MessageActionRole.USER,
-            canCopy = true,
             canEdit = canEdit,
-            canSelectText = false,
-            canRetry = false,
-            revisionIndexLabel = null,
-            canShowPreviousRevision = false,
-            canShowNextRevision = false,
             onCopy = onCopyClick,
-            onSelectText = {},
             onEdit = onEditClick,
-            onRetry = {},
-            onPreviousRevision = {},
-            onNextRevision = {},
             onDismissRequest = { isActionsSheetOpen = false }
         )
     }
@@ -153,7 +142,6 @@ fun OpponentChatBubble(
     revisionIndexLabel: String? = null,
     canShowPreviousRevision: Boolean = false,
     canShowNextRevision: Boolean = false,
-    showInlineRetry: Boolean = false,
     onCopyClick: () -> Unit = {},
     onSelectClick: () -> Unit = {},
     onViewFull: (String) -> Unit = {},
@@ -192,12 +180,7 @@ fun OpponentChatBubble(
         thoughts = thoughts,
         hasToolEvents = toolEvents.isNotEmpty()
     )
-    val canCopy = !isError
-    val canSelectText = !isError
-    val retryInSheet = canRetry && !showInlineRetry
-    val hasMessageActions = canCopy || canSelectText || canEdit || retryInSheet || revisionIndexLabel != null
     var isDetailsExpanded by rememberSaveable(contentIdentity) { mutableStateOf(false) }
-    var isActionsSheetOpen by rememberSaveable(contentIdentity) { mutableStateOf(false) }
     val showAnswerStreamingIndicator = isLoading && activeToolEvents.isEmpty()
     val showProcessStreamingIndicator = showAnswerStreamingIndicator && text.isBlank()
 
@@ -220,7 +203,6 @@ fun OpponentChatBubble(
             ) {
                 DetailsButton(
                     isExpanded = isDetailsExpanded,
-                    activeToolEvents = activeToolEvents,
                     onClick = { isDetailsExpanded = !isDetailsExpanded }
                 )
             }
@@ -276,57 +258,64 @@ fun OpponentChatBubble(
             }
         }
 
-        if (!isLoading && hasMessageActions) {
+        if (!isLoading) {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
+                modifier = Modifier.padding(start = 16.dp)
             ) {
-                Spacer(modifier = Modifier.weight(1f))
-                MessageActionsButton(onClick = { isActionsSheetOpen = true })
+                if (!isError) {
+                    CopyTextIcon(onCopyClick)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    SelectTextIcon(onSelectClick)
+                    if (canEdit) {
+                        Spacer(modifier = Modifier.width(8.dp))
+                        EditTextIcon(onEditClick)
+                    }
+                }
+                if (canRetry) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    RetryIcon(onRetryClick)
+                }
             }
-        }
-
-        if (showInlineRetry) {
-            TextButton(
-                onClick = onRetryClick,
-                modifier = Modifier.padding(start = 8.dp)
-            ) {
-                Icon(
-                    imageVector = Icons.Rounded.Refresh,
-                    contentDescription = null
+            if (canRetry) {
+                Text(
+                    text = stringResource(R.string.retry_tools_warning),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(start = 16.dp, top = 4.dp)
                 )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(stringResource(R.string.retry))
             }
-            Text(
-                text = stringResource(R.string.retry_tools_warning),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(start = 16.dp, top = 4.dp)
-            )
-        }
-    }
 
-    if (isActionsSheetOpen) {
-        MessageActionsSheet(
-            role = MessageActionRole.ASSISTANT,
-            canCopy = canCopy,
-            canEdit = canEdit,
-            canSelectText = canSelectText,
-            canRetry = retryInSheet,
-            revisionIndexLabel = revisionIndexLabel,
-            canShowPreviousRevision = canShowPreviousRevision,
-            canShowNextRevision = canShowNextRevision,
-            onCopy = onCopyClick,
-            onSelectText = onSelectClick,
-            onEdit = onEditClick,
-            onRetry = onRetryClick,
-            onPreviousRevision = onShowPreviousRevision,
-            onNextRevision = onShowNextRevision,
-            onDismissRequest = { isActionsSheetOpen = false }
-        )
+            revisionIndexLabel?.let { label ->
+                Row(
+                    modifier = Modifier.padding(start = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(
+                        enabled = canShowPreviousRevision,
+                        onClick = onShowPreviousRevision
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                            contentDescription = stringResource(R.string.previous_revision)
+                        )
+                    }
+                    Text(
+                        text = label,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    IconButton(
+                        enabled = canShowNextRevision,
+                        onClick = onShowNextRevision
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = stringResource(R.string.next_revision)
+                        )
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -369,7 +358,6 @@ private fun QuietAssistantContent(
 @Composable
 private fun DetailsButton(
     isExpanded: Boolean,
-    activeToolEvents: List<ToolEvent>,
     onClick: () -> Unit
 ) {
     val rotationAngle by animateFloatAsState(
@@ -377,14 +365,12 @@ private fun DetailsButton(
         animationSpec = fastEffectsSpec(),
         label = "details rotation"
     )
-    val progressDescription = stringResource(R.string.tool_in_progress)
     val expandStateDescription = stringResource(R.string.expand)
     val collapseStateDescription = stringResource(R.string.collapse)
-    Surface(
-        onClick = onClick,
+    Row(
         modifier = Modifier
-            .widthIn(max = 320.dp)
             .heightIn(min = 48.dp)
+            .clickable(onClick = onClick)
             .semantics(mergeDescendants = true) {
                 role = Role.Button
                 stateDescription = if (isExpanded) {
@@ -392,53 +378,61 @@ private fun DetailsButton(
                 } else {
                     expandStateDescription
                 }
-            },
-        shape = MaterialTheme.shapes.extraLarge,
-        color = MaterialTheme.colorScheme.surfaceContainerLow
-    ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            if (activeToolEvents.isNotEmpty()) {
-                CircularProgressIndicator(
-                    modifier = Modifier
-                        .size(20.dp)
-                        .semantics { contentDescription = progressDescription },
-                    strokeWidth = 2.dp
-                )
-                Spacer(modifier = Modifier.width(8.dp))
             }
-            Text(
-                text = if (activeToolEvents.isEmpty()) {
-                    stringResource(R.string.details)
-                } else {
-                    "${stringResource(R.string.details)} · ${toolTraceStatusSummary(activeToolEvents)}"
-                },
-                style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Icon(
-                imageVector = Icons.Rounded.KeyboardArrowDown,
-                contentDescription = null,
-                modifier = Modifier.rotate(rotationAngle)
-            )
-        }
+            .padding(horizontal = 4.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = stringResource(R.string.details),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Icon(
+            imageVector = Icons.Rounded.KeyboardArrowDown,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.rotate(rotationAngle)
+        )
     }
 }
 
 @Composable
-private fun MessageActionsButton(onClick: () -> Unit) {
-    IconButton(
-        onClick = onClick,
-        modifier = Modifier.size(48.dp)
-    ) {
+private fun CopyTextIcon(onCopyClick: () -> Unit) {
+    IconButton(onClick = onCopyClick) {
         Icon(
-            imageVector = Icons.Rounded.MoreHoriz,
-            contentDescription = stringResource(R.string.message_actions)
+            imageVector = ImageVector.vectorResource(id = R.drawable.ic_copy),
+            contentDescription = stringResource(R.string.copy_text)
+        )
+    }
+}
+
+@Composable
+private fun SelectTextIcon(onSelectClick: () -> Unit) {
+    IconButton(onClick = onSelectClick) {
+        Icon(
+            imageVector = ImageVector.vectorResource(id = R.drawable.ic_select),
+            contentDescription = stringResource(R.string.select_text)
+        )
+    }
+}
+
+@Composable
+private fun RetryIcon(onRetryClick: () -> Unit) {
+    IconButton(onClick = onRetryClick) {
+        Icon(
+            Icons.Rounded.Refresh,
+            contentDescription = stringResource(R.string.retry)
+        )
+    }
+}
+
+@Composable
+private fun EditTextIcon(onEditClick: () -> Unit) {
+    IconButton(onClick = onEditClick) {
+        Icon(
+            imageVector = Icons.Outlined.Edit,
+            contentDescription = stringResource(R.string.edit)
         )
     }
 }
@@ -557,7 +551,7 @@ private fun LegacyAssistantProcessContent(
 }
 
 @Composable
-fun GPTMobileIcon() {
+fun GPTMobileIcon(loading: Boolean) {
     Box(
         modifier = Modifier
             .padding(start = 8.dp)
@@ -566,6 +560,11 @@ fun GPTMobileIcon() {
             .background(color = Color(0xFF00A67D)),
         contentAlignment = Alignment.Center
     ) {
+        if (loading) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(40.dp)
+            )
+        }
         Image(
             painter = painterResource(R.drawable.ic_gpt_mobile_no_padding),
             contentDescription = null,

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatBubble.kt
@@ -378,6 +378,7 @@ private fun DetailsButton(
     Row(
         modifier = Modifier
             .heightIn(min = 48.dp)
+            .clip(MaterialTheme.shapes.extraLarge)
             .clickable(onClick = onClick)
             .semantics(mergeDescendants = true) {
                 role = Role.Button

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatDialogs.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatDialogs.kt
@@ -3,7 +3,6 @@ package dev.chungjungsoo.gptmobile.presentation.ui.chat
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -12,13 +11,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
@@ -31,7 +25,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -53,28 +46,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-internal enum class MessageActionRole {
-    USER,
-    ASSISTANT
-}
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun MessageActionsSheet(
-    role: MessageActionRole,
-    canCopy: Boolean,
     canEdit: Boolean,
-    canSelectText: Boolean,
-    canRetry: Boolean,
-    revisionIndexLabel: String?,
-    canShowPreviousRevision: Boolean,
-    canShowNextRevision: Boolean,
     onCopy: () -> Unit,
-    onSelectText: () -> Unit,
     onEdit: () -> Unit,
-    onRetry: () -> Unit,
-    onPreviousRevision: () -> Unit,
-    onNextRevision: () -> Unit,
     onDismissRequest: () -> Unit
 ) {
     fun runAction(action: () -> Unit) {
@@ -95,87 +72,19 @@ internal fun MessageActionsSheet(
                     .semantics { heading() }
                     .padding(horizontal = 8.dp, vertical = 12.dp)
             )
-            when (role) {
-                MessageActionRole.USER -> {
-                    SettingItem(
-                        title = stringResource(R.string.copy_text),
-                        enabled = canCopy,
-                        onItemClick = { runAction(onCopy) },
-                        showTrailingIcon = false,
-                        showLeadingIcon = false
-                    )
-                    SettingItem(
-                        title = stringResource(R.string.edit),
-                        enabled = canEdit,
-                        onItemClick = { runAction(onEdit) },
-                        showTrailingIcon = false,
-                        showLeadingIcon = false
-                    )
-                }
-
-                MessageActionRole.ASSISTANT -> {
-                    if (canCopy) {
-                        SettingItem(
-                            title = stringResource(R.string.copy_text),
-                            onItemClick = { runAction(onCopy) },
-                            showTrailingIcon = false,
-                            showLeadingIcon = false
-                        )
-                    }
-                    if (canSelectText) {
-                        SettingItem(
-                            title = stringResource(R.string.select_text),
-                            onItemClick = { runAction(onSelectText) },
-                            showTrailingIcon = false,
-                            showLeadingIcon = false
-                        )
-                    }
-                    if (canEdit) {
-                        SettingItem(
-                            title = stringResource(R.string.edit),
-                            onItemClick = { runAction(onEdit) },
-                            showTrailingIcon = false,
-                            showLeadingIcon = false
-                        )
-                    }
-                    if (canRetry) {
-                        SettingItem(
-                            title = stringResource(R.string.retry),
-                            description = stringResource(R.string.retry_tools_warning),
-                            onItemClick = { runAction(onRetry) },
-                            showTrailingIcon = false,
-                            showLeadingIcon = false
-                        )
-                    }
-                    revisionIndexLabel?.let { label ->
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            IconButton(
-                                enabled = canShowPreviousRevision,
-                                onClick = { runAction(onPreviousRevision) }
-                            ) {
-                                Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
-                                    contentDescription = stringResource(R.string.previous_revision)
-                                )
-                            }
-                            Text(
-                                text = label,
-                                style = MaterialTheme.typography.labelLarge,
-                                modifier = Modifier.weight(1f)
-                            )
-                            IconButton(
-                                enabled = canShowNextRevision,
-                                onClick = { runAction(onNextRevision) }
-                            ) {
-                                Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                                    contentDescription = stringResource(R.string.next_revision)
-                                )
-                            }
-                        }
-                    }
-                }
-            }
+            SettingItem(
+                title = stringResource(R.string.copy_text),
+                onItemClick = { runAction(onCopy) },
+                showTrailingIcon = false,
+                showLeadingIcon = false
+            )
+            SettingItem(
+                title = stringResource(R.string.edit),
+                enabled = canEdit,
+                onItemClick = { runAction(onEdit) },
+                showTrailingIcon = false,
+                showLeadingIcon = false
+            )
             Spacer(modifier = Modifier.height(24.dp))
         }
     }

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
@@ -516,8 +516,6 @@ private fun ChatMessagePair(
     val canEdit = canUseChat && isIdle
     val canRetry = canUseChat && isActiveMessage && !isCurrentPlatformLoading
     val isError = agentRun?.status == AgentRunStatus.FAILED && isAssistantErrorMessage(assistantContent)
-    val isFailedResponse = agentRun?.status == AgentRunStatus.FAILED || isAssistantErrorMessage(assistantContent)
-    val showInlineRetry = canRetry && isFailedResponse
 
     Column(modifier = Modifier.fillMaxWidth()) {
         Column(
@@ -548,7 +546,7 @@ private fun ChatMessagePair(
                     .padding(top = 12.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                GPTMobileIcon()
+                GPTMobileIcon(loading = isActiveMessage && !isIdle)
                 if (enabledPlatformsInChat.size > 1) {
                     Row(
                         modifier = Modifier
@@ -602,7 +600,6 @@ private fun ChatMessagePair(
                 },
                 canShowPreviousRevision = canShowPreviousRevision,
                 canShowNextRevision = canShowNextRevision,
-                showInlineRetry = showInlineRetry,
                 onCopyClick = { onCopyText(assistantContent) },
                 onSelectClick = { onSelectText(assistantContent) },
                 onViewFull = onSelectText,

--- a/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
+++ b/app/src/main/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatScreen.kt
@@ -546,7 +546,12 @@ private fun ChatMessagePair(
                     .padding(top = 12.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                GPTMobileIcon(loading = isActiveMessage && !isIdle)
+                GPTMobileIcon(
+                    loading = shouldShowReplyLoadingIndicator(
+                        isActiveMessage = isActiveMessage,
+                        loadingStates = loadingStates
+                    )
+                )
                 if (enabledPlatformsInChat.size > 1) {
                     Row(
                         modifier = Modifier
@@ -617,6 +622,11 @@ private fun chatMessagePairKey(message: MessageV2, index: Int): String = if (mes
 } else {
     "message-${message.createdAt}-$index"
 }
+
+internal fun shouldShowReplyLoadingIndicator(
+    isActiveMessage: Boolean,
+    loadingStates: List<ChatViewModel.LoadingState>
+): Boolean = isActiveMessage && loadingStates.any { it == ChatViewModel.LoadingState.Loading }
 
 @Composable
 internal fun rememberChatListState(messageCount: Int): LazyListState = key(messageCount > 0) {

--- a/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModelRetryTest.kt
+++ b/app/src/test/kotlin/dev/chungjungsoo/gptmobile/presentation/ui/chat/ChatViewModelRetryTest.kt
@@ -85,6 +85,22 @@ class ChatViewModelRetryTest {
     }
 
     @Test
+    fun `reply loading indicator follows platform loading state`() {
+        assertFalse(
+            shouldShowReplyLoadingIndicator(
+                isActiveMessage = true,
+                loadingStates = listOf(ChatViewModel.LoadingState.Idle)
+            )
+        )
+        assertTrue(
+            shouldShowReplyLoadingIndicator(
+                isActiveMessage = true,
+                loadingStates = listOf(ChatViewModel.LoadingState.Loading)
+            )
+        )
+    }
+
+    @Test
     fun `persisted message observer rebuilds normalized comparison rows`() {
         val grouped = groupPersistedMessages(
             messages = listOf(


### PR DESCRIPTION
## Summary
- restore the circular loading indicator around the app icon while an agent reply is active
- replace the filled Details chip with a quiet text-and-caret disclosure while preserving nested thinking and tool expansion
- remove per-message overflow buttons, keep the user long-press bottom sheet, and restore assistant inline actions
- expose user-message long press to assistive technologies and restrict the reply ring to platform loading states

## Validation
- Gradle unit tests, debug/app-test Kotlin compilation, and lintDebug passed
- ktlint passed on all changed Kotlin files
- focused ChatMessagePresentationInstrumentedTest passed 14/14 on emulator-5554 (Pixel 7 API 37)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat messages provide inline toolbar controls after loading.
  * Long-press accessibility actions support Copy, Select, and optional Edit for user messages.
  * Assistant messages provide Copy, Edit, Retry, and revision navigation controls.
  * Loading states display progress indicators, including during tool activity.
  * Details are presented as a clickable, labeled row.

* **Bug Fixes**
  * Retry and loading indicators now reflect the actual platform loading state.
  * Message action sheets now focus on Copy and Edit actions.
  * Error actions and progress indicators are displayed more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->